### PR TITLE
Add triangle dilation for conservative voxelization

### DIFF
--- a/StereoVista/assets/shaders/voxelization/voxelization.frag
+++ b/StereoVista/assets/shaders/voxelization/voxelization.frag
@@ -38,6 +38,7 @@ uniform int numberOfLights;
 uniform vec3 cameraPosition;
 uniform int mipmapLevel;  // Current mipmap level
 uniform float gridSize;   // Actual voxel grid size
+uniform vec3 gridCenter;  // Grid center position in world space
 
 layout(rgba16f, binding = 0) uniform image3D texture3D;
 
@@ -53,12 +54,13 @@ vec3 calculatePointLight(const PointLight light) {
     return diff * POINT_LIGHT_INTENSITY * attenuation * light.color;
 }
 
-bool isInsideCube(const vec3 p, float e) { 
-    // Check if the world position is within the voxel grid bounds
+bool isInsideCube(const vec3 p, float e) {
+    // Check if the world position is within the voxel grid bounds (centered at gridCenter)
     float halfGrid = gridSize * 0.5;
-    return abs(p.x) < halfGrid + e && 
-           abs(p.y) < halfGrid + e && 
-           abs(p.z) < halfGrid + e; 
+    vec3 relativePos = p - gridCenter;
+    return abs(relativePos.x) < halfGrid + e &&
+           abs(relativePos.y) < halfGrid + e &&
+           abs(relativePos.z) < halfGrid + e;
 }
 
 void main() {
@@ -94,8 +96,9 @@ void main() {
     finalColor = clamp(finalColor, vec3(0.0), vec3(1.0));
 
     // Convert world position to normalized voxel coordinates [0,1]
+    // Grid is centered at gridCenter, so offset the position first
     float halfGrid = gridSize * 0.5;
-    vec3 normalizedPos = (worldPositionFrag + halfGrid) / gridSize;
+    vec3 normalizedPos = (worldPositionFrag - gridCenter + halfGrid) / gridSize;
     
     // Get texture dimensions
     ivec3 texDim = imageSize(texture3D);

--- a/StereoVista/assets/shaders/voxelization/voxelization.frag
+++ b/StereoVista/assets/shaders/voxelization/voxelization.frag
@@ -124,16 +124,18 @@ void main() {
         // Set alpha based on transparency
         float alpha = 1.0 - material.transparency;
         vec4 voxelColor = vec4(finalColor, alpha);
-        
-        // Atomic max blending for better overlapping fragment handling
-        // Read existing value and blend with new color
+
+        // Alpha compositing (Porter-Duff "over" operator)
+        // This properly blends overlapping fragments instead of just taking max
         vec4 existingColor = imageLoad(texture3D, storageCoord);
-        vec4 blendedColor = max(existingColor, voxelColor);
-        
+        float oneMinusExistingAlpha = 1.0 - existingColor.a;
+        vec4 blendedColor;
+        blendedColor.rgb = existingColor.rgb + voxelColor.rgb * voxelColor.a * oneMinusExistingAlpha;
+        blendedColor.a = existingColor.a + voxelColor.a * oneMinusExistingAlpha;
+
         // Write to the voxel grid
         imageStore(texture3D, storageCoord, blendedColor);
-        
-        
+
         // Fill in additional voxels at higher mipmap levels for proper LOD
         if (mipmapLevel > 0) {
             for (int x = 0; x < stride && storageCoord.x + x < texDim.x; x++) {
@@ -141,9 +143,12 @@ void main() {
                     for (int z = 0; z < stride && storageCoord.z + z < texDim.z; z++) {
                         if (x == 0 && y == 0 && z == 0) continue; // Skip the center voxel
                         ivec3 neighborCoord = storageCoord + ivec3(x, y, z);
-                        
+
                         vec4 existingMip = imageLoad(texture3D, neighborCoord);
-                        vec4 blendedMip = max(existingMip, voxelColor);
+                        float oneMinusMipAlpha = 1.0 - existingMip.a;
+                        vec4 blendedMip;
+                        blendedMip.rgb = existingMip.rgb + voxelColor.rgb * voxelColor.a * oneMinusMipAlpha;
+                        blendedMip.a = existingMip.a + voxelColor.a * oneMinusMipAlpha;
                         imageStore(texture3D, neighborCoord, blendedMip);
                     }
                 }

--- a/StereoVista/assets/shaders/voxelization/voxelization.frag
+++ b/StereoVista/assets/shaders/voxelization/voxelization.frag
@@ -39,7 +39,7 @@ uniform vec3 cameraPosition;
 uniform int mipmapLevel;  // Current mipmap level
 uniform float gridSize;   // Actual voxel grid size
 
-layout(rgba8, binding = 0) uniform image3D texture3D;
+layout(rgba16f, binding = 0) uniform image3D texture3D;
 
 in vec3 worldPositionFrag;
 in vec3 normalFrag;

--- a/StereoVista/assets/shaders/voxelization/voxelization.geom
+++ b/StereoVista/assets/shaders/voxelization/voxelization.geom
@@ -1,7 +1,7 @@
 #version 450 core
 
 layout(triangles) in;
-layout(triangle_strip, max_vertices = 9) out; // 3 vertices * 3 projections max
+layout(triangle_strip, max_vertices = 3) out;
 
 in vec3 worldPositionGeom[];
 in vec3 normalGeom[];
@@ -12,51 +12,129 @@ out vec3 normalFrag;
 out vec2 texCoordFrag;
 
 uniform float gridSize;
+uniform int voxelResolution;  // Voxel grid resolution for dilation calculation
+
+// Dilate a triangle in 2D to ensure conservative rasterization
+// This expands each edge outward by half a pixel to cover all voxels the triangle touches
+vec2 dilateVertex(vec2 v0, vec2 v1, vec2 v2, int vertexIndex, float pixelSize) {
+    // Get the current vertex and its two neighbors
+    vec2 current, prev, next;
+    if (vertexIndex == 0) {
+        current = v0; prev = v2; next = v1;
+    } else if (vertexIndex == 1) {
+        current = v1; prev = v0; next = v2;
+    } else {
+        current = v2; prev = v1; next = v0;
+    }
+
+    // Compute edge vectors
+    vec2 edge1 = current - prev;
+    vec2 edge2 = next - current;
+
+    // Compute outward-facing edge normals (perpendicular to edges)
+    // For CCW winding, rotating 90 degrees clockwise gives outward normal
+    vec2 normal1 = normalize(vec2(edge1.y, -edge1.x));
+    vec2 normal2 = normalize(vec2(edge2.y, -edge2.x));
+
+    // Average the two normals to get the vertex displacement direction
+    vec2 displacement = normal1 + normal2;
+    float len = length(displacement);
+
+    // Handle degenerate case where normals cancel out
+    if (len < 0.001) {
+        displacement = normal1;
+    } else {
+        displacement = displacement / len;
+    }
+
+    // Scale displacement by half a pixel
+    // We use a slightly larger factor (0.5 * sqrt(2)) to ensure corner coverage
+    float dilationAmount = pixelSize * 0.7071; // 0.5 * sqrt(2)
+
+    return current + displacement * dilationAmount;
+}
 
 void main() {
     // Determine the dominant axis based on face normal
-    vec3 v0 = worldPositionGeom[1] - worldPositionGeom[0];
-    vec3 v1 = worldPositionGeom[2] - worldPositionGeom[0];
-    vec3 faceNormal = normalize(cross(v0, v1));
+    vec3 e0 = worldPositionGeom[1] - worldPositionGeom[0];
+    vec3 e1 = worldPositionGeom[2] - worldPositionGeom[0];
+    vec3 faceNormal = cross(e0, e1);
     vec3 absFaceNormal = abs(faceNormal);
-    
+
     // Scale factor to map world coordinates to [-1, 1] range
     float scale = 2.0 / gridSize;
-    
-    // Choose the projection axis based on the largest component of the face normal
-    if(absFaceNormal.x >= absFaceNormal.y && absFaceNormal.x >= absFaceNormal.z) {
-        // Project onto X-axis (YZ plane)
-        for(int i = 0; i < 3; ++i) {
+
+    // Pixel size in NDC space (viewport is voxelResolution x voxelResolution)
+    float pixelSize = 2.0 / float(voxelResolution);
+
+    // Project vertices based on dominant axis and apply dilation
+    vec2 projected[3];
+
+    if (absFaceNormal.x >= absFaceNormal.y && absFaceNormal.x >= absFaceNormal.z) {
+        // Project onto YZ plane (X is dominant)
+        for (int i = 0; i < 3; ++i) {
+            vec3 p = worldPositionGeom[i] * scale;
+            projected[i] = vec2(p.y, p.z);
+        }
+
+        // Dilate the triangle
+        vec2 dilated[3];
+        for (int i = 0; i < 3; ++i) {
+            dilated[i] = dilateVertex(projected[0], projected[1], projected[2], i, pixelSize);
+        }
+
+        // Emit dilated vertices
+        for (int i = 0; i < 3; ++i) {
             worldPositionFrag = worldPositionGeom[i];
             normalFrag = normalGeom[i];
             texCoordFrag = texCoordGeom[i];
-            
-            vec3 projectedPos = worldPositionFrag * scale;
-            gl_Position = vec4(projectedPos.y, projectedPos.z, 0.0, 1.0);
+            gl_Position = vec4(dilated[i], 0.0, 1.0);
             EmitVertex();
         }
         EndPrimitive();
-    } else if(absFaceNormal.y >= absFaceNormal.z) {
-        // Project onto Y-axis (XZ plane)
-        for(int i = 0; i < 3; ++i) {
+
+    } else if (absFaceNormal.y >= absFaceNormal.z) {
+        // Project onto XZ plane (Y is dominant)
+        for (int i = 0; i < 3; ++i) {
+            vec3 p = worldPositionGeom[i] * scale;
+            projected[i] = vec2(p.x, p.z);
+        }
+
+        // Dilate the triangle
+        vec2 dilated[3];
+        for (int i = 0; i < 3; ++i) {
+            dilated[i] = dilateVertex(projected[0], projected[1], projected[2], i, pixelSize);
+        }
+
+        // Emit dilated vertices
+        for (int i = 0; i < 3; ++i) {
             worldPositionFrag = worldPositionGeom[i];
             normalFrag = normalGeom[i];
             texCoordFrag = texCoordGeom[i];
-            
-            vec3 projectedPos = worldPositionFrag * scale;
-            gl_Position = vec4(projectedPos.x, projectedPos.z, 0.0, 1.0);
+            gl_Position = vec4(dilated[i], 0.0, 1.0);
             EmitVertex();
         }
         EndPrimitive();
+
     } else {
-        // Project onto Z-axis (XY plane)
-        for(int i = 0; i < 3; ++i) {
+        // Project onto XY plane (Z is dominant)
+        for (int i = 0; i < 3; ++i) {
+            vec3 p = worldPositionGeom[i] * scale;
+            projected[i] = vec2(p.x, p.y);
+        }
+
+        // Dilate the triangle
+        vec2 dilated[3];
+        for (int i = 0; i < 3; ++i) {
+            dilated[i] = dilateVertex(projected[0], projected[1], projected[2], i, pixelSize);
+        }
+
+        // Emit dilated vertices
+        for (int i = 0; i < 3; ++i) {
             worldPositionFrag = worldPositionGeom[i];
             normalFrag = normalGeom[i];
             texCoordFrag = texCoordGeom[i];
-            
-            vec3 projectedPos = worldPositionFrag * scale;
-            gl_Position = vec4(projectedPos.x, projectedPos.y, 0.0, 1.0);
+            gl_Position = vec4(dilated[i], 0.0, 1.0);
             EmitVertex();
         }
         EndPrimitive();

--- a/StereoVista/assets/shaders/voxelization/voxelization.geom
+++ b/StereoVista/assets/shaders/voxelization/voxelization.geom
@@ -12,6 +12,7 @@ out vec3 normalFrag;
 out vec2 texCoordFrag;
 
 uniform float gridSize;
+uniform vec3 gridCenter;      // Grid center position in world space
 uniform int voxelResolution;  // Voxel grid resolution for dilation calculation
 
 // Dilate a triangle in 2D to ensure conservative rasterization
@@ -73,7 +74,7 @@ void main() {
     if (absFaceNormal.x >= absFaceNormal.y && absFaceNormal.x >= absFaceNormal.z) {
         // Project onto YZ plane (X is dominant)
         for (int i = 0; i < 3; ++i) {
-            vec3 p = worldPositionGeom[i] * scale;
+            vec3 p = (worldPositionGeom[i] - gridCenter) * scale;
             projected[i] = vec2(p.y, p.z);
         }
 
@@ -96,7 +97,7 @@ void main() {
     } else if (absFaceNormal.y >= absFaceNormal.z) {
         // Project onto XZ plane (Y is dominant)
         for (int i = 0; i < 3; ++i) {
-            vec3 p = worldPositionGeom[i] * scale;
+            vec3 p = (worldPositionGeom[i] - gridCenter) * scale;
             projected[i] = vec2(p.x, p.z);
         }
 
@@ -119,7 +120,7 @@ void main() {
     } else {
         // Project onto XY plane (Z is dominant)
         for (int i = 0; i < 3; ++i) {
-            vec3 p = worldPositionGeom[i] * scale;
+            vec3 p = (worldPositionGeom[i] - gridCenter) * scale;
             projected[i] = vec2(p.x, p.y);
         }
 

--- a/StereoVista/headers/Core/Voxalizer.h
+++ b/StereoVista/headers/Core/Voxalizer.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "Engine/Core.h"
 #include "Engine/Shader.h"
+#include "Engine/BVH.h"
 #include "Loaders/ModelLoader.h"
 
 namespace Engine {
@@ -29,6 +30,11 @@ namespace Engine {
         GLuint getVoxelTexture() const { return m_voxelTexture; }
         float getVoxelGridSize() const { return m_voxelGridSize; }
         void setVoxelGridSize(float size) { m_voxelGridSize = size; }
+        glm::vec3 getGridCenter() const { return m_gridCenter; }
+        void setGridCenter(const glm::vec3& center) { m_gridCenter = center; }
+
+        // Auto-fit grid to scene bounds with optional padding factor (1.1 = 10% padding)
+        void autoFitGridToScene(const std::vector<Model>& models, float paddingFactor = 1.1f);
 
         // Change visualization state (mipmap level)
         void increaseState();
@@ -82,6 +88,7 @@ namespace Engine {
     private:
         int m_resolution;
         float m_voxelGridSize;
+        glm::vec3 m_gridCenter = glm::vec3(0.0f);  // Grid center position in world space
         GLuint m_voxelTexture;
 
         Shader* m_voxelShader;

--- a/StereoVista/headers/Core/Voxalizer.h
+++ b/StereoVista/headers/Core/Voxalizer.h
@@ -29,9 +29,23 @@ namespace Engine {
 
         GLuint getVoxelTexture() const { return m_voxelTexture; }
         float getVoxelGridSize() const { return m_voxelGridSize; }
-        void setVoxelGridSize(float size) { m_voxelGridSize = size; }
+        void setVoxelGridSize(float size) {
+            if (m_voxelGridSize != size) {
+                m_voxelGridSize = size;
+                m_needsRevoxelization = true;
+            }
+        }
         glm::vec3 getGridCenter() const { return m_gridCenter; }
-        void setGridCenter(const glm::vec3& center) { m_gridCenter = center; }
+        void setGridCenter(const glm::vec3& center) {
+            if (m_gridCenter != center) {
+                m_gridCenter = center;
+                m_needsRevoxelization = true;
+            }
+        }
+
+        // Dirty flag for caching - skip re-voxelization if scene hasn't changed
+        void markDirty() { m_needsRevoxelization = true; }
+        bool isDirty() const { return m_needsRevoxelization; }
 
         // Auto-fit grid to scene bounds with optional padding factor (1.1 = 10% padding)
         void autoFitGridToScene(const std::vector<Model>& models, float paddingFactor = 1.1f);
@@ -90,6 +104,7 @@ namespace Engine {
         float m_voxelGridSize;
         glm::vec3 m_gridCenter = glm::vec3(0.0f);  // Grid center position in world space
         GLuint m_voxelTexture;
+        bool m_needsRevoxelization = true;  // Dirty flag - true on first run
 
         Shader* m_voxelShader;
 

--- a/StereoVista/src/Core/Voxalizer.cpp
+++ b/StereoVista/src/Core/Voxalizer.cpp
@@ -188,8 +188,9 @@ namespace Engine {
         // Pass the current mipmap level to the shader
         m_voxelShader->setInt("mipmapLevel", m_state);
 
-        // CRITICAL: Pass the actual grid size to the shader
+        // CRITICAL: Pass the actual grid size and center to the shader
         m_voxelShader->setFloat("gridSize", m_voxelGridSize);
+        m_voxelShader->setVec3("gridCenter", m_gridCenter);
 
         // Pass resolution for triangle dilation (conservative rasterization)
         m_voxelShader->setInt("voxelResolution", m_resolution);
@@ -338,12 +339,12 @@ namespace Engine {
                             float nz = ((float)z + 0.5f) / (float)effectiveSamples;
 
                             // Convert back to world space using the SAME mapping as voxelization shader
-                            // This must match the voxelization.frag: normalizedPos = (worldPos + halfGrid) / gridSize
+                            // This must match the voxelization.frag: normalizedPos = (worldPos - gridCenter + halfGrid) / gridSize
                             float halfGrid = m_voxelGridSize * 0.5f;
                             glm::vec3 position(
-                                (nx * m_voxelGridSize) - halfGrid,
-                                (ny * m_voxelGridSize) - halfGrid,
-                                (nz * m_voxelGridSize) - halfGrid
+                                (nx * m_voxelGridSize) - halfGrid + m_gridCenter.x,
+                                (ny * m_voxelGridSize) - halfGrid + m_gridCenter.y,
+                                (nz * m_voxelGridSize) - halfGrid + m_gridCenter.z
                             );
 
                             // Calculate distance from camera
@@ -494,6 +495,59 @@ namespace Engine {
     void Voxelizer::decreaseState() {
         m_state = std::max(m_state - 1, 0);
         m_voxelDataNeedsUpdate = true;  // Add this line
+    }
+
+    void Voxelizer::autoFitGridToScene(const std::vector<Model>& models, float paddingFactor) {
+        // Compute scene AABB using the existing AABB struct from BVH.h
+        AABB sceneBounds;
+
+        for (const auto& model : models) {
+            if (!model.visible) continue;
+
+            // Build model transformation matrix
+            glm::mat4 modelMatrix = glm::mat4(1.0f);
+            modelMatrix = glm::translate(modelMatrix, model.position);
+            modelMatrix = glm::rotate(modelMatrix, glm::radians(model.rotation.x), glm::vec3(1, 0, 0));
+            modelMatrix = glm::rotate(modelMatrix, glm::radians(model.rotation.y), glm::vec3(0, 1, 0));
+            modelMatrix = glm::rotate(modelMatrix, glm::radians(model.rotation.z), glm::vec3(0, 0, 1));
+            modelMatrix = glm::scale(modelMatrix, model.scale);
+
+            // Expand bounds with all mesh vertices (transformed to world space)
+            for (const auto& mesh : model.getMeshes()) {
+                if (!mesh.visible) continue;
+
+                for (const auto& vertex : mesh.vertices) {
+                    glm::vec4 worldPos = modelMatrix * glm::vec4(vertex.Position, 1.0f);
+                    sceneBounds.expand(glm::vec3(worldPos));
+                }
+            }
+        }
+
+        // Check if we found any valid geometry
+        if (!sceneBounds.isValid()) {
+            std::cerr << "Warning: No visible geometry found for auto-fit grid" << std::endl;
+            return;
+        }
+
+        // Compute grid center and size
+        glm::vec3 center = sceneBounds.getCenter();
+        glm::vec3 size = sceneBounds.getSize();
+
+        // Use the largest dimension to create a cubic grid (voxels are cubic)
+        float maxDimension = std::max({size.x, size.y, size.z});
+
+        // Apply padding factor to ensure geometry doesn't touch grid edges
+        float gridSize = maxDimension * paddingFactor;
+
+        // Ensure minimum grid size to avoid degenerate cases
+        gridSize = std::max(gridSize, 0.1f);
+
+        // Apply the computed values
+        m_gridCenter = center;
+        m_voxelGridSize = gridSize;
+
+        std::cout << "Auto-fit grid: center=(" << center.x << ", " << center.y << ", " << center.z
+                  << "), size=" << gridSize << std::endl;
     }
 
 } // namespace Engine

--- a/StereoVista/src/Core/Voxalizer.cpp
+++ b/StereoVista/src/Core/Voxalizer.cpp
@@ -191,6 +191,9 @@ namespace Engine {
         // CRITICAL: Pass the actual grid size to the shader
         m_voxelShader->setFloat("gridSize", m_voxelGridSize);
 
+        // Pass resolution for triangle dilation (conservative rasterization)
+        m_voxelShader->setInt("voxelResolution", m_resolution);
+
         // Voxelize each model
         for (const auto& model : models) {
             // Skip invisible models

--- a/StereoVista/src/Core/Voxalizer.cpp
+++ b/StereoVista/src/Core/Voxalizer.cpp
@@ -68,7 +68,7 @@ namespace Engine {
         glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
         glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
-        glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA8,
+        glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA16F,
             m_resolution, m_resolution, m_resolution,
             0, GL_RGBA, GL_FLOAT, nullptr);
 
@@ -154,7 +154,7 @@ namespace Engine {
         glClearTexImage(m_voxelTexture, 0, GL_RGBA, GL_FLOAT, nullptr);
 
         // Bind voxel texture for writing
-        glBindImageTexture(0, m_voxelTexture, 0, GL_TRUE, 0, GL_READ_WRITE, GL_RGBA8);
+        glBindImageTexture(0, m_voxelTexture, 0, GL_TRUE, 0, GL_READ_WRITE, GL_RGBA16F);
 
         // Use standard resolution viewport
         int voxelizationRes = m_resolution;

--- a/StereoVista/src/Core/Voxalizer.cpp
+++ b/StereoVista/src/Core/Voxalizer.cpp
@@ -150,6 +150,11 @@ namespace Engine {
     // This function was moved to the constructor
 
     void Voxelizer::update(const glm::vec3& cameraPos, const std::vector<Model>& models) {
+        // Skip re-voxelization if nothing changed (caching)
+        if (!m_needsRevoxelization) {
+            return;
+        }
+
         // Clear voxel texture
         glClearTexImage(m_voxelTexture, 0, GL_RGBA, GL_FLOAT, nullptr);
 
@@ -269,6 +274,9 @@ namespace Engine {
 
         // Mark voxel data as needing update for visualization
         m_voxelDataNeedsUpdate = true;
+
+        // Clear dirty flag - voxelization is now up to date
+        m_needsRevoxelization = false;
 
         // Reset state
         glEnable(GL_DEPTH_TEST);
@@ -542,9 +550,10 @@ namespace Engine {
         // Ensure minimum grid size to avoid degenerate cases
         gridSize = std::max(gridSize, 0.1f);
 
-        // Apply the computed values
+        // Apply the computed values and mark dirty for re-voxelization
         m_gridCenter = center;
         m_voxelGridSize = gridSize;
+        m_needsRevoxelization = true;
 
         std::cout << "Auto-fit grid: center=(" << center.x << ", " << center.y << ", " << center.z
                   << "), size=" << gridSize << std::endl;


### PR DESCRIPTION
Implements classic conservative rasterization by expanding triangles
in the geometry shader. Each vertex is displaced outward along the
bisector of its adjacent edge normals by half a pixel. This ensures
thin triangles that don't cover voxel centers still get rasterized,
fixing holes and cracks in the voxelized output.