### PR TITLE
Fix voxelization dirty flag not being triggered on scene changes

### DIFF
--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -365,6 +365,11 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
       }
       currentSelectedIndex = currentScene.models.empty() ? -1 : 0;
       updateSpaceMouseBounds();
+
+      // Mark voxelizer dirty for re-voxelization with new scene
+      if (voxelizer) {
+        voxelizer->markDirty();
+      }
     } catch (const std::exception &e) {
       std::cerr << "Failed to load scene: " << e.what() << std::endl;
     }
@@ -402,6 +407,11 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
       }
 
       updateSpaceMouseBounds();
+
+      // Mark voxelizer dirty for re-voxelization with merged geometry
+      if (voxelizer) {
+        voxelizer->markDirty();
+      }
     } catch (const std::exception &e) {
       std::cerr << "Failed to load scene: " << e.what() << std::endl;
     }
@@ -424,6 +434,11 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
     }
     currentSelectedIndex = currentScene.models.empty() ? -1 : 0;
     updateSpaceMouseBounds();
+
+    // Mark voxelizer dirty for re-voxelization with new scene
+    if (voxelizer) {
+      voxelizer->markDirty();
+    }
   };
 
   if (ImGui::BeginMainMenuBar()) {
@@ -457,6 +472,11 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
               currentSelectedIndex = currentScene.models.size() - 1;
               currentSelectedType = SelectedType::Model;
               updateSpaceMouseBounds();
+
+              // Mark voxelizer dirty for re-voxelization
+              if (voxelizer) {
+                voxelizer->markDirty();
+              }
             } catch (const std::exception &e) {
               std::cerr << "Failed to load model: " << e.what() << std::endl;
             }
@@ -665,6 +685,7 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
         currentSelectedIndex = currentScene.models.size() - 1;
         currentSelectedType = SelectedType::Model;
         updateSpaceMouseBounds();
+        if (voxelizer) voxelizer->markDirty();
       }
 
       if (ImGui::MenuItem("Sphere")) {
@@ -681,6 +702,7 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
         currentSelectedIndex = currentScene.models.size() - 1;
         currentSelectedType = SelectedType::Model;
         updateSpaceMouseBounds();
+        if (voxelizer) voxelizer->markDirty();
       }
 
       if (ImGui::MenuItem("Cylinder")) {
@@ -697,6 +719,7 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
         currentSelectedIndex = currentScene.models.size() - 1;
         currentSelectedType = SelectedType::Model;
         updateSpaceMouseBounds();
+        if (voxelizer) voxelizer->markDirty();
       }
 
       if (ImGui::MenuItem("Plane")) {
@@ -713,6 +736,7 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
         currentSelectedIndex = currentScene.models.size() - 1;
         currentSelectedType = SelectedType::Model;
         updateSpaceMouseBounds();
+        if (voxelizer) voxelizer->markDirty();
       }
 
       if (ImGui::MenuItem("Torus")) {
@@ -729,6 +753,7 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
         currentSelectedIndex = currentScene.models.size() - 1;
         currentSelectedType = SelectedType::Model;
         updateSpaceMouseBounds();
+        if (voxelizer) voxelizer->markDirty();
       }
 
       ImGui::Separator();
@@ -1347,6 +1372,11 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
           }
           for (int idx : spotLightsToDelete) {
             spotLights.erase(spotLights.begin() + idx);
+          }
+
+          // Mark voxelizer dirty if models were deleted
+          if (!modelsToDelete.empty() && voxelizer) {
+            voxelizer->markDirty();
           }
 
           // Clear selection if needed
@@ -4809,6 +4839,11 @@ void deleteSelectedModel() {
     currentSelectedIndex = -1;
     currentSelectedType = SelectedType::None;
     updateSpaceMouseBounds();
+
+    // Mark voxelizer dirty for re-voxelization
+    if (voxelizer) {
+      voxelizer->markDirty();
+    }
   }
 }
 

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -4017,6 +4017,11 @@ void renderEye(GLenum drawBuffer, const glm::mat4 &projection,
           std::cout << "Irradiance cache cleared due to scene change" << std::endl;
         }
 
+        // Mark voxelizer dirty so it re-voxelizes with new geometry
+        if (voxelizer) {
+          voxelizer->markDirty();
+        }
+
         // Update debug renderer if debug is enabled
         if (showBVHDebug) {
           // Get max depth from GUI settings
@@ -5876,6 +5881,11 @@ void mouse_button_callback(GLFWwindow *window, int button, int action,
             currentSelectedIndex = currentScene.models.size() - 1;
             std::cout << "Model duplicated: " << duplicatedModel.name
                       << std::endl;
+
+            // Mark voxelizer dirty for re-voxelization
+            if (voxelizer) {
+              voxelizer->markDirty();
+            }
           } else {
             // Normal Ctrl+drag - select existing model
             currentSelectedIndex = closestModelIndex;


### PR DESCRIPTION
Added voxelizer->markDirty() calls to all places where scene geometry changes:

main.cpp:
- After BVH rebuild when scene changes (existing scene change detection)
- After model duplication (Alt+drag)

GUI.cpp:
- loadAndReplaceScene lambda (File > Load Scene with replace)
- loadAndMergeScene lambda (File > Load Scene with merge)
- loadSceneWithPreference lambda
- After batch scene object deletion
- deleteSelectedModel function
- After 3D model import
- After creating primitives (Cube, Sphere, Cylinder, Plane, Torus)

This ensures the voxel grid is re-generated whenever models are added, removed, or the scene is replaced/merged.