### PR TITLE
Add option to always show orbit center point

### DIFF
--- a/StereoVista/headers/Cursors/Base/CursorManager.h
+++ b/StereoVista/headers/Cursors/Base/CursorManager.h
@@ -59,6 +59,8 @@ public:
   // Orbit center properties
   bool isShowOrbitCenter() const { return m_showOrbitCenter; }
   void setShowOrbitCenter(bool show) { m_showOrbitCenter = show; }
+  bool isAlwaysShowOrbitCenter() const { return m_alwaysShowOrbitCenter; }
+  void setAlwaysShowOrbitCenter(bool show) { m_alwaysShowOrbitCenter = show; }
   const glm::vec4 &getOrbitCenterColor() const { return m_orbitCenterColor; }
   void setOrbitCenterColor(const glm::vec4 &color) {
     m_orbitCenterColor = color;
@@ -121,6 +123,7 @@ private:
 
   // Orbit center properties
   bool m_showOrbitCenter;
+  bool m_alwaysShowOrbitCenter;
   glm::vec4 m_orbitCenterColor;
   float m_orbitCenterSphereRadius;
 

--- a/StereoVista/headers/Gui/GuiTypes.h
+++ b/StereoVista/headers/Gui/GuiTypes.h
@@ -201,6 +201,12 @@ struct ApplicationPreferences {
   float mouseSmoothingFactor = 1.0f;
   float mouseSensitivity = 0.17f;
 
+  // Orbit center visualization settings
+  bool showOrbitCenter = false;
+  bool alwaysShowOrbitCenter = false;
+  glm::vec4 orbitCenterColor = glm::vec4(0.0f, 1.0f, 0.0f, 0.7f);
+  float orbitCenterSphereRadius = 0.2f;
+
   bool showStereoVisualization = true;
 
   bool radarEnabled = false;

--- a/StereoVista/src/Cursors/Base/CursorManager.cpp
+++ b/StereoVista/src/Cursors/Base/CursorManager.cpp
@@ -13,7 +13,8 @@ CursorManager::CursorManager()
     : m_cursorPosition(0.0f), m_cursorPositionValid(false),
       m_cursorPositionCalculatedThisFrame(false),
       m_backgroundCursorPosition(0.0f), m_hasBackgroundCursorPosition(false),
-      m_showOrbitCenter(false), m_orbitCenterColor(0.0f, 1.0f, 0.0f, 0.7f),
+      m_showOrbitCenter(false), m_alwaysShowOrbitCenter(false),
+      m_orbitCenterColor(0.0f, 1.0f, 0.0f, 0.7f),
       m_orbitCenterSphereRadius(0.2f), m_windowWidth(1920),
       m_windowHeight(1080), m_lastX(0.0f), m_lastY(0.0f),
       m_cursorInsideWindow(true), m_positionLocked(false) {

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -4100,20 +4100,37 @@ void renderCursorSettingsWindow() {
       bool showOrbitCenter = cursorManager.isShowOrbitCenter();
       if (ImGui::Checkbox("Show Orbit Center", &showOrbitCenter)) {
         cursorManager.setShowOrbitCenter(showOrbitCenter);
+        preferences.showOrbitCenter = showOrbitCenter;
+        savePreferences();
       }
       ImGui::SameLine();
       DrawHelpMarker("Display a marker at the camera's orbit pivot point");
 
       if (showOrbitCenter) {
+        bool alwaysShowOrbitCenter = cursorManager.isAlwaysShowOrbitCenter();
+        if (ImGui::Checkbox("Always Show Orbit Center", &alwaysShowOrbitCenter)) {
+          cursorManager.setAlwaysShowOrbitCenter(alwaysShowOrbitCenter);
+          preferences.alwaysShowOrbitCenter = alwaysShowOrbitCenter;
+          savePreferences();
+        }
+        ImGui::SameLine();
+        DrawHelpMarker("Keep the orbit center visible even when not orbiting");
+      }
+
+      if (showOrbitCenter) {
         glm::vec4 orbitColor = cursorManager.getOrbitCenterColor();
         if (ImGui::ColorEdit3("Marker Color", glm::value_ptr(orbitColor))) {
           cursorManager.setOrbitCenterColor(orbitColor);
+          preferences.orbitCenterColor = orbitColor;
+          savePreferences();
         }
 
         float orbitSize = cursorManager.getOrbitCenterSphereRadius();
         if (ImGui::SliderFloat("Marker Size", &orbitSize, 0.01f, 1.0f,
                                "%.2f")) {
           cursorManager.setOrbitCenterSphereRadius(orbitSize);
+          preferences.orbitCenterSphereRadius = orbitSize;
+          savePreferences();
         }
       }
 

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -1486,6 +1486,17 @@ void savePreferences() {
   j["camera"]["orbitFollowsCursor"] = preferences.orbitFollowsCursor;
   j["camera"]["mouseSmoothingFactor"] = preferences.mouseSmoothingFactor;
   j["camera"]["mouseSensitivity"] = preferences.mouseSensitivity;
+
+  // Orbit center visualization settings
+  j["camera"]["showOrbitCenter"] = preferences.showOrbitCenter;
+  j["camera"]["alwaysShowOrbitCenter"] = preferences.alwaysShowOrbitCenter;
+  j["camera"]["orbitCenterColor"] = {
+      preferences.orbitCenterColor.r,
+      preferences.orbitCenterColor.g,
+      preferences.orbitCenterColor.b,
+      preferences.orbitCenterColor.a
+  };
+  j["camera"]["orbitCenterSphereRadius"] = preferences.orbitCenterSphereRadius;
   j["camera"]["autoConvergence"] = preferences.autoConvergence;
   j["camera"]["convergenceDistanceFactor"] =
       preferences.convergenceDistanceFactor;
@@ -1676,6 +1687,12 @@ void applyPreferencesToProgram() {
   mouseSmoothingFactor = preferences.mouseSmoothingFactor;
   camera.MouseSensitivity = preferences.mouseSensitivity;
 
+  // Apply orbit center visualization settings
+  cursorManager.setShowOrbitCenter(preferences.showOrbitCenter);
+  cursorManager.setAlwaysShowOrbitCenter(preferences.alwaysShowOrbitCenter);
+  cursorManager.setOrbitCenterColor(preferences.orbitCenterColor);
+  cursorManager.setOrbitCenterSphereRadius(preferences.orbitCenterSphereRadius);
+
   skyboxConfig.type = static_cast<GUI::SkyboxType>(preferences.skyboxType);
   skyboxConfig.solidColor = preferences.skyboxSolidColor;
   skyboxConfig.gradientTopColor = preferences.skyboxGradientTop;
@@ -1845,6 +1862,21 @@ void loadPreferences() {
           j["camera"].value("mouseSmoothingFactor", 1.0f);
       preferences.mouseSensitivity =
           j["camera"].value("mouseSensitivity", 0.17f);
+
+      // Load orbit center visualization settings
+      preferences.showOrbitCenter = j["camera"].value("showOrbitCenter", false);
+      preferences.alwaysShowOrbitCenter = j["camera"].value("alwaysShowOrbitCenter", false);
+      if (j["camera"].contains("orbitCenterColor") && j["camera"]["orbitCenterColor"].is_array() &&
+          j["camera"]["orbitCenterColor"].size() >= 4) {
+        preferences.orbitCenterColor = glm::vec4(
+            j["camera"]["orbitCenterColor"][0].get<float>(),
+            j["camera"]["orbitCenterColor"][1].get<float>(),
+            j["camera"]["orbitCenterColor"][2].get<float>(),
+            j["camera"]["orbitCenterColor"][3].get<float>()
+        );
+      }
+      preferences.orbitCenterSphereRadius = j["camera"].value("orbitCenterSphereRadius", 0.2f);
+
       preferences.autoConvergence = j["camera"].value("autoConvergence", false);
       preferences.convergenceDistanceFactor =
           j["camera"].value("convergenceDistanceFactor", 1.0f);
@@ -4614,7 +4646,7 @@ void renderEye(GLenum drawBuffer, const glm::mat4 &projection,
 
   // Render orbit center if needed
   if (!orbitFollowsCursor && cursorManager.isShowOrbitCenter() &&
-      camera.IsOrbiting) {
+      (camera.IsOrbiting || cursorManager.isAlwaysShowOrbitCenter())) {
     cursorManager.renderOrbitCenter(projection, view, camera.OrbitPoint);
   }
 


### PR DESCRIPTION
This commit adds a new "Always Show Orbit Center" option in the Cursor Settings window that allows users to keep the rotation/orbit point visible at all times, not just when actively orbiting.

Changes:
- Added m_alwaysShowOrbitCenter property to CursorManager with getter/setter methods
- Updated rendering logic in main.cpp to show orbit center when either orbiting OR always-show is enabled
- Added "Always Show Orbit Center" checkbox in the Orbit Center tab of Cursor Settings
- Added preference persistence (save/load) for all orbit center visualization settings
- Settings are now saved to preferences.json and restored on application startup

https://claude.ai/code/session_zYKom