### PR TITLE
Add GUI scale slider to Settings Display tab

### DIFF
--- a/StereoVista/headers/Gui/GuiTypes.h
+++ b/StereoVista/headers/Gui/GuiTypes.h
@@ -100,6 +100,7 @@ struct PlaneCursor {
 
 struct ApplicationPreferences {
   bool isDarkTheme = true;
+  float guiScaleFactor = 1.0f;  // User-controlled GUI scale multiplier (0.5x - 2.0x)
   float separation = 0.5f;
   float convergence = 2.6f;
   float nearPlane = 0.1f;

--- a/StereoVista/headers/libs/imgui/imgui_style.cpp
+++ b/StereoVista/headers/libs/imgui/imgui_style.cpp
@@ -275,7 +275,8 @@ void UpdateGuiScale(int windowWidth, int windowHeight) {
   if (windowWidth <= 0 || windowHeight <= 0)
     return;
 
-  float newScale = CalculateGuiScale(windowWidth, windowHeight);
+  float baseScale = CalculateGuiScale(windowWidth, windowHeight);
+  float newScale = std::max(0.5f, std::min(2.0f, baseScale * g_GuiScale.userScaleFactor));
   bool isFirstCall =
       (g_GuiScale.lastWindowWidth == 0 && g_GuiScale.lastWindowHeight == 0);
 

--- a/StereoVista/headers/libs/imgui/imgui_sytle.h
+++ b/StereoVista/headers/libs/imgui/imgui_sytle.h
@@ -30,6 +30,7 @@ struct ImGuiFonts {
 // GUI Scale Settings
 struct GuiScaleSettings {
   float currentScale = 1.0f;
+  float userScaleFactor = 1.0f;  // User-controlled multiplier on top of window-based scale
   int lastWindowWidth = 0;
   int lastWindowHeight = 0;
   bool needsRescale = false;
@@ -38,6 +39,8 @@ struct GuiScaleSettings {
 
   static constexpr float MIN_SCALE = 0.5f;
   static constexpr float MAX_SCALE = 2.0f;
+  static constexpr float MIN_USER_FACTOR = 0.5f;
+  static constexpr float MAX_USER_FACTOR = 2.0f;
   static constexpr int MIN_WINDOW_WIDTH = 800;
   static constexpr int MIN_WINDOW_HEIGHT = 600;
   static constexpr int REFERENCE_WIDTH = 1920;

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -2691,6 +2691,44 @@ void renderSettingsWindow() {
       ImGui::SameLine();
       DrawHelpMarker("Toggle the entire GUI interface on/off (also 'G' key)");
 
+      ImGui::Spacing();
+      DrawSectionHeader("GUI Scale");
+
+      float userFactor = g_GuiScale.userScaleFactor;
+      if (ImGui::SliderFloat("Scale Factor", &userFactor,
+                             GuiScaleSettings::MIN_USER_FACTOR,
+                             GuiScaleSettings::MAX_USER_FACTOR, "%.2fx")) {
+        g_GuiScale.userScaleFactor = userFactor;
+        if (g_GuiScale.lastWindowWidth > 0 && g_GuiScale.lastWindowHeight > 0) {
+          float baseScale = CalculateGuiScale(g_GuiScale.lastWindowWidth,
+                                             g_GuiScale.lastWindowHeight);
+          float newScale = std::max(0.5f, std::min(2.0f, baseScale * userFactor));
+          g_GuiScale.currentScale = newScale;
+        }
+        g_GuiScale.needsRescale = true;
+        g_GuiScale.needsFontRebuild = true;
+        preferences.guiScaleFactor = userFactor;
+        settingsChanged = true;
+      }
+      ImGui::SameLine();
+      DrawHelpMarker("Multiplier applied on top of the automatic window-size "
+                     "scaling. 1.0x = default, 0.5x = smaller, 2.0x = larger");
+
+      if (ImGui::Button("Reset Scale")) {
+        g_GuiScale.userScaleFactor = 1.0f;
+        if (g_GuiScale.lastWindowWidth > 0 && g_GuiScale.lastWindowHeight > 0) {
+          float baseScale = CalculateGuiScale(g_GuiScale.lastWindowWidth,
+                                             g_GuiScale.lastWindowHeight);
+          g_GuiScale.currentScale = std::max(0.5f, std::min(2.0f, baseScale));
+        }
+        g_GuiScale.needsRescale = true;
+        g_GuiScale.needsFontRebuild = true;
+        preferences.guiScaleFactor = 1.0f;
+        settingsChanged = true;
+      }
+      ImGui::SameLine();
+      DrawHelpMarker("Reset GUI scale factor to default (1.0x)");
+
       DrawSectionHeader("Radar Overlay");
 
       if (ImGui::Checkbox("Show Radar", &preferences.radarEnabled)) {

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -1461,6 +1461,7 @@ void savePreferences() {
   j["ui"]["showFPS"] = preferences.showFPS;
   j["ui"]["show3DCursor"] = preferences.show3DCursor;
   j["ui"]["enableSpawnAnimation"] = preferences.enableSpawnAnimation;
+  j["ui"]["guiScaleFactor"] = preferences.guiScaleFactor;
 
   // Radar settings
   j["radar"]["enabled"] = preferences.radarEnabled;
@@ -1669,6 +1670,7 @@ void applyPreferencesToProgram() {
   SetupImGuiStyle(isDarkTheme, 1.0f);
   showFPS = preferences.showFPS;
   show3DCursor = preferences.show3DCursor;
+  g_GuiScale.userScaleFactor = preferences.guiScaleFactor;
 
   // Apply camera preferences
   convergenceSmoothingSpeed = preferences.convergenceSmoothingSpeed;
@@ -1825,6 +1827,7 @@ void loadPreferences() {
       preferences.show3DCursor = j["ui"].value("show3DCursor", true);
       preferences.enableSpawnAnimation =
           j["ui"].value("enableSpawnAnimation", true);
+      preferences.guiScaleFactor = j["ui"].value("guiScaleFactor", 1.0f);
     }
 
     // Radar settings


### PR DESCRIPTION
Adds a user-controllable scale factor (0.5x - 2.0x) that multiplies on
top of the existing automatic window-size-based GUI scaling. The slider
lives in Settings > Display > GUI Scale and includes a Reset button to
restore the default 1.0x factor. The preference persists across sessions
via preferences.json.

https://claude.ai/code/session_01WufZ5datXseS2HHQsCeouw