### PR TITLE
Fix orbit center visualization going out of sync with SpaceMouse pivot

### DIFF
--- a/StereoVista/headers/Engine/SpaceMouseInput.h
+++ b/StereoVista/headers/Engine/SpaceMouseInput.h
@@ -71,6 +71,9 @@ public:
     
     // Force refresh of pivot position in NavLib
     void RefreshPivotPosition();
+
+    // Get the current pivot point used by the SpaceMouse for navigation
+    glm::vec3 GetCurrentPivotPoint() const;
     
     // Set anchor mode and cursor centering options
     void SetAnchorMode(GUI::SpaceMouseAnchorMode mode);

--- a/StereoVista/src/Engine/SpaceMouseInput.cpp
+++ b/StereoVista/src/Engine/SpaceMouseInput.cpp
@@ -408,6 +408,13 @@ private:
 
       m_parent->m_camera->Pitch = glm::degrees(asin(newForward.y));
       m_parent->m_camera->Yaw = glm::degrees(atan2(newForward.z, newForward.x));
+
+      // Sync camera OrbitPoint with SpaceMouse pivot so the orbit center
+      // visualization stays correct during and after SpaceMouse navigation
+      glm::vec3 pivotPoint = GetCurrentPivotPoint();
+      m_parent->m_camera->OrbitPoint = pivotPoint;
+      m_parent->m_camera->OrbitDistance =
+          glm::length(m_parent->m_camera->Position - pivotPoint);
     }
 
     return 0;
@@ -499,7 +506,26 @@ private:
       if (m_parent->OnNavigationStarted) {
         m_parent->OnNavigationStarted();
       }
+
+      // Sync OrbitPoint with SpaceMouse pivot AFTER the callback, because
+      // OnNavigationStarted copies the main camera to the SpaceMouse camera
+      // and would overwrite a pre-callback sync
+      if (m_parent->m_camera) {
+        glm::vec3 pivotPoint = GetCurrentPivotPoint();
+        m_parent->m_camera->OrbitPoint = pivotPoint;
+        m_parent->m_camera->OrbitDistance =
+            glm::length(m_parent->m_camera->Position - pivotPoint);
+      }
     } else if (!motion && wasNavigating) {
+      // Sync OrbitPoint with final SpaceMouse pivot BEFORE the callback,
+      // so the copy in OnNavigationEnded picks up the correct orbit center
+      if (m_parent->m_camera) {
+        glm::vec3 pivotPoint = GetCurrentPivotPoint();
+        m_parent->m_camera->OrbitPoint = pivotPoint;
+        m_parent->m_camera->OrbitDistance =
+            glm::length(m_parent->m_camera->Position - pivotPoint);
+      }
+
       if (m_parent->OnNavigationEnded) {
         m_parent->OnNavigationEnded();
       }
@@ -701,6 +727,13 @@ void SpaceMouseInput::RefreshPivotPosition() {
   if (m_navigationModel) {
     m_navigationModel->RefreshPivotPosition();
   }
+}
+
+glm::vec3 SpaceMouseInput::GetCurrentPivotPoint() const {
+  if (m_navigationModel) {
+    return m_navigationModel->GetCurrentPivotPoint();
+  }
+  return (m_modelMin + m_modelMax) * 0.5f;
 }
 
 // Helper functions for coordinate system conversion

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -4676,9 +4676,10 @@ void renderEye(GLenum drawBuffer, const glm::mat4 &projection,
   // shader)
   cursorManager.updateShaderUniforms(shader);
 
-  // Render orbit center if needed
+  // Render orbit center if needed (during mouse orbit or SpaceMouse navigation)
   if (!orbitFollowsCursor && cursorManager.isShowOrbitCenter() &&
-      (camera.IsOrbiting || cursorManager.isAlwaysShowOrbitCenter())) {
+      (camera.IsOrbiting || spaceMouseInput.IsNavigating() ||
+       cursorManager.isAlwaysShowOrbitCenter())) {
     cursorManager.renderOrbitCenter(projection, view, camera.OrbitPoint);
   }
 


### PR DESCRIPTION
The SpaceMouse navigation system maintained its own pivot point
(GetCurrentPivotPoint) independently from camera.OrbitPoint, which is
used for the orbit center visualization. This caused the "Show Orbit
Center" indicator to display at the wrong location after SpaceMouse
use, especially in mixed-use scenarios.

Changes:
- Sync camera.OrbitPoint with SpaceMouse pivot in SetCameraMatrixImpl
  on every frame during SpaceMouse navigation
- Sync OrbitPoint at navigation start (after callback) and end (before
  callback) to ensure correct handoff between control modes
- Add public GetCurrentPivotPoint() to SpaceMouseInput for external
  access to the active pivot
- Show orbit center visualization during SpaceMouse navigation, not
  just during mouse orbit

https://claude.ai/code/session_01Xzu5FAQ5NBr4BH6Y81Cc7w