### PR TITLE
Add Screen Space Ambient Occlusion (SSAO) to HDR rendering pipeline

### DIFF
--- a/StereoVista/assets/shaders/bloom/final.frag
+++ b/StereoVista/assets/shaders/bloom/final.frag
@@ -5,7 +5,9 @@ in vec2 TexCoords;
 
 uniform sampler2D hdrBuffer;
 uniform sampler2D bloomBlur;
+uniform sampler2D ssaoTexture;
 uniform bool enableBloom;
+uniform bool enableSSAO;
 uniform float bloomIntensity;
 uniform float exposure;
 uniform int toneMapOperator; // 0=Reinhard, 1=ACES, 2=Uncharted2, 3=AgX, 4=Khronos PBR Neutral, 5=Tony McMapface
@@ -152,7 +154,13 @@ vec3 tonyMcMapfaceToneMapping(vec3 hdrColor, float exposure) {
 void main()
 {             
     vec3 hdrColor = texture(hdrBuffer, TexCoords).rgb;
-    
+
+    // Apply SSAO - darken occluded areas before tone mapping
+    if(enableSSAO) {
+        float ao = texture(ssaoTexture, TexCoords).r;
+        hdrColor *= ao;
+    }
+
     // Add bloom if enabled
     if(enableBloom) {
         vec3 bloomColor = texture(bloomBlur, TexCoords).rgb;

--- a/StereoVista/assets/shaders/ssao/geometry.frag
+++ b/StereoVista/assets/shaders/ssao/geometry.frag
@@ -1,0 +1,15 @@
+#version 460
+layout (location = 0) out vec4 gPosition;
+layout (location = 1) out vec3 gNormal;
+
+in vec3 FragPos;   // View-space position
+in vec3 Normal;    // View-space normal
+
+void main()
+{
+    // Store view-space position (use w=1 to mark valid fragments)
+    gPosition = vec4(FragPos, 1.0);
+
+    // Store normalized view-space normal
+    gNormal = normalize(Normal);
+}

--- a/StereoVista/assets/shaders/ssao/geometry.vert
+++ b/StereoVista/assets/shaders/ssao/geometry.vert
@@ -1,0 +1,27 @@
+#version 460
+layout (location = 0) in vec3 aPos;
+layout (location = 1) in vec3 aNormal;
+layout (location = 2) in vec2 aTexCoords;
+layout (location = 3) in vec3 aTangent;
+layout (location = 4) in vec3 aBitangent;
+
+out vec3 FragPos;   // View-space position
+out vec3 Normal;    // View-space normal
+
+uniform mat4 model;
+uniform mat4 view;
+uniform mat4 projection;
+uniform mat3 normalMatrix; // World-space normal matrix
+
+void main()
+{
+    // View-space position
+    vec4 viewPos = view * model * vec4(aPos, 1.0);
+    FragPos = viewPos.xyz;
+
+    // View-space normal: transform world normal into view space
+    vec3 worldNormal = normalize(normalMatrix * aNormal);
+    Normal = normalize(mat3(view) * worldNormal);
+
+    gl_Position = projection * viewPos;
+}

--- a/StereoVista/assets/shaders/ssao/ssao.frag
+++ b/StereoVista/assets/shaders/ssao/ssao.frag
@@ -1,0 +1,66 @@
+#version 460
+out float FragColor;
+
+in vec2 TexCoords;
+
+uniform sampler2D gPosition;
+uniform sampler2D gNormal;
+uniform sampler2D texNoise;
+
+uniform vec3 samples[64];
+uniform mat4 projection;
+uniform vec2 noiseScale; // screen dimensions / noise texture size
+uniform int kernelSize;
+uniform float radius;
+uniform float bias;
+uniform float power;
+
+void main()
+{
+    // Retrieve view-space position and normal for this fragment
+    vec4 fragData = texture(gPosition, TexCoords);
+
+    // Skip fragments with no geometry (w == 0 means background)
+    if (fragData.w < 0.5) {
+        FragColor = 1.0;
+        return;
+    }
+
+    vec3 fragPos = fragData.xyz;
+    vec3 normal = normalize(texture(gNormal, TexCoords).rgb);
+    vec3 randomVec = normalize(texture(texNoise, TexCoords * noiseScale).xyz);
+
+    // Create TBN change-of-basis matrix: from tangent-space to view-space
+    // Using the Gramm-Schmidt process to re-orthogonalize
+    vec3 tangent = normalize(randomVec - normal * dot(randomVec, normal));
+    vec3 bitangent = cross(normal, tangent);
+    mat3 TBN = mat3(tangent, bitangent, normal);
+
+    // Iterate over the sample kernel and calculate occlusion factor
+    float occlusion = 0.0;
+    for (int i = 0; i < kernelSize; ++i)
+    {
+        // Get sample position (transform from tangent to view-space)
+        vec3 samplePos = TBN * samples[i];
+        samplePos = fragPos + samplePos * radius;
+
+        // Project sample position to screen space to get texture coordinates
+        vec4 offset = vec4(samplePos, 1.0);
+        offset = projection * offset;       // from view to clip-space
+        offset.xyz /= offset.w;             // perspective divide
+        offset.xyz = offset.xyz * 0.5 + 0.5; // transform to range [0, 1]
+
+        // Get sample depth from the G-buffer position texture
+        float sampleDepth = texture(gPosition, offset.xy).z;
+
+        // Range check & accumulate:
+        // smoothstep prevents contributions from geometry that is too far away
+        float rangeCheck = smoothstep(0.0, 1.0, radius / abs(fragPos.z - sampleDepth));
+        occlusion += (sampleDepth >= samplePos.z + bias ? 1.0 : 0.0) * rangeCheck;
+    }
+
+    occlusion = 1.0 - (occlusion / float(kernelSize));
+
+    // Apply power curve for artistic control
+    FragColor = pow(occlusion, power);
+}

--- a/StereoVista/assets/shaders/ssao/ssao.vert
+++ b/StereoVista/assets/shaders/ssao/ssao.vert
@@ -1,0 +1,11 @@
+#version 460
+layout (location = 0) in vec3 aPos;
+layout (location = 1) in vec2 aTexCoords;
+
+out vec2 TexCoords;
+
+void main()
+{
+    TexCoords = aTexCoords;
+    gl_Position = vec4(aPos, 1.0);
+}

--- a/StereoVista/assets/shaders/ssao/ssao_blur.frag
+++ b/StereoVista/assets/shaders/ssao/ssao_blur.frag
@@ -1,0 +1,21 @@
+#version 460
+out float FragColor;
+
+in vec2 TexCoords;
+
+uniform sampler2D ssaoInput;
+
+void main()
+{
+    vec2 texelSize = 1.0 / vec2(textureSize(ssaoInput, 0));
+    float result = 0.0;
+    for (int x = -2; x < 2; ++x)
+    {
+        for (int y = -2; y < 2; ++y)
+        {
+            vec2 offset = vec2(float(x), float(y)) * texelSize;
+            result += texture(ssaoInput, TexCoords + offset).r;
+        }
+    }
+    FragColor = result / (4.0 * 4.0);
+}

--- a/StereoVista/assets/shaders/ssao/ssao_blur.vert
+++ b/StereoVista/assets/shaders/ssao/ssao_blur.vert
@@ -1,0 +1,11 @@
+#version 460
+layout (location = 0) in vec3 aPos;
+layout (location = 1) in vec2 aTexCoords;
+
+out vec2 TexCoords;
+
+void main()
+{
+    TexCoords = aTexCoords;
+    gl_Position = vec4(aPos, 1.0);
+}

--- a/StereoVista/headers/Engine/BloomRenderer.h
+++ b/StereoVista/headers/Engine/BloomRenderer.h
@@ -52,6 +52,10 @@ public:
   void applyBloom(GLuint sceneTexture, const BloomSettings &settings,
                   GLenum drawBuffer = GL_BACK);
 
+  // Set SSAO texture to be applied during final composition
+  void setSSAOTexture(GLuint ssaoTexture, bool ssaoEnabled);
+
+
   // Get bloom settings
   BloomSettings &getSettings() { return m_settings; }
 
@@ -65,6 +69,10 @@ private:
   BloomSettings m_settings;
   int m_width, m_height;
   bool m_initialized = false;
+
+  // SSAO integration
+  GLuint m_ssaoTexture = 0;
+  bool m_ssaoEnabled = false;
 
   // Setup framebuffers
   bool setupFramebuffers();

--- a/StereoVista/headers/Engine/SSAORenderer.h
+++ b/StereoVista/headers/Engine/SSAORenderer.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "Engine/Shader.h"
+#include <glad/glad.h>
+#include <glm/glm.hpp>
+#include <vector>
+
+namespace Engine {
+
+struct SSAOSettings {
+  bool enabled = false;
+  int kernelSize = 64;    // Number of SSAO samples (16-64)
+  float radius = 0.5f;    // Sample radius in view space
+  float bias = 0.025f;    // Depth comparison bias
+  float power = 1.0f;     // Occlusion intensity/power curve
+};
+
+class SSAORenderer {
+public:
+  SSAORenderer();
+  ~SSAORenderer();
+
+  // Initialize SSAO system
+  bool initialize(int width, int height);
+
+  // Cleanup all resources
+  void cleanup();
+
+  // Resize framebuffers when window changes
+  void resize(int width, int height);
+
+  // Geometry pass: render scene positions/normals to G-buffer
+  // Call this before rendering geometry, then render models, then call
+  // endGeometryPass()
+  void beginGeometryPass();
+  void endGeometryPass();
+
+  // SSAO pass: compute ambient occlusion from G-buffer
+  void computeSSAO(const glm::mat4 &projection);
+
+  // Blur pass: smooth the SSAO result
+  void blurSSAO();
+
+  // Get the final blurred SSAO texture (GL_RED, single channel)
+  GLuint getSSAOTexture() const { return m_ssaoColorBufferBlur; }
+
+  // Get the G-buffer textures (for debugging)
+  GLuint getPositionTexture() const { return m_gPosition; }
+  GLuint getNormalTexture() const { return m_gNormal; }
+
+  // Get the geometry pass shader (for rendering models)
+  Shader *getGeometryShader() const { return m_geometryShader; }
+
+  // Get settings
+  SSAOSettings &getSettings() { return m_settings; }
+  const SSAOSettings &getSettings() const { return m_settings; }
+
+  // Render a fullscreen quad
+  void renderQuad();
+
+  // Check if initialized
+  bool isInitialized() const { return m_initialized; }
+
+private:
+  SSAOSettings m_settings;
+  int m_width, m_height;
+  bool m_initialized = false;
+
+  // G-buffer
+  GLuint m_gBufferFBO = 0;
+  GLuint m_gPosition = 0;   // View-space position (RGBA16F)
+  GLuint m_gNormal = 0;     // View-space normal (RGB16F)
+  GLuint m_gDepthRBO = 0;   // Depth renderbuffer
+
+  // SSAO
+  GLuint m_ssaoFBO = 0;
+  GLuint m_ssaoColorBuffer = 0; // Single-channel occlusion (GL_RED)
+
+  // SSAO Blur
+  GLuint m_ssaoBlurFBO = 0;
+  GLuint m_ssaoColorBufferBlur = 0; // Blurred occlusion (GL_RED)
+
+  // Noise texture
+  GLuint m_noiseTexture = 0;
+
+  // Sample kernel
+  std::vector<glm::vec3> m_ssaoKernel;
+
+  // Shaders
+  Shader *m_geometryShader = nullptr;
+  Shader *m_ssaoShader = nullptr;
+  Shader *m_blurShader = nullptr;
+
+  // Screen quad
+  GLuint m_quadVAO = 0;
+  GLuint m_quadVBO = 0;
+
+  // Setup methods
+  bool setupGBuffer();
+  bool setupSSAOBuffers();
+  void generateSampleKernel();
+  void generateNoiseTexture();
+  bool loadShaders();
+  void setupQuad();
+};
+
+} // namespace Engine

--- a/StereoVista/headers/Gui/GuiTypes.h
+++ b/StereoVista/headers/Gui/GuiTypes.h
@@ -138,6 +138,15 @@ struct ApplicationPreferences {
     bool enableBloom = false;
   } hdrSettings;
 
+  // SSAO settings
+  struct SSAOSettings {
+    bool enabled = false;
+    int kernelSize = 64;  // Number of samples (16-64)
+    float radius = 0.5f;  // Sample radius in view space
+    float bias = 0.025f;  // Depth comparison bias
+    float power = 1.0f;   // Occlusion intensity curve
+  } ssaoSettings;
+
   // Shadow quality settings
   struct ShadowSettings {
     int pcfKernelSize = 3; // 3, 5, 7, or 9

--- a/StereoVista/src/Engine/BloomRenderer.cpp
+++ b/StereoVista/src/Engine/BloomRenderer.cpp
@@ -312,6 +312,10 @@ bool BloomRenderer::loadShaders() {
       m_settings.finalShader->setInt("bloomBlur", 1);
     }
 
+    // Initialize SSAO sampler to texture unit 2 (bound later if SSAO enabled)
+    m_settings.finalShader->setInt("ssaoTexture", 2);
+    m_settings.finalShader->setBool("enableSSAO", false);
+
     return true;
   } catch (const std::exception &e) {
     std::cerr << "Failed to load bloom shaders: " << e.what() << std::endl;

--- a/StereoVista/src/Engine/BloomRenderer.cpp
+++ b/StereoVista/src/Engine/BloomRenderer.cpp
@@ -457,6 +457,14 @@ void BloomRenderer::applyBloom(GLuint sceneTexture,
 
     m_settings.finalShader->setInt("bloomBlur", 1);
 
+    // Bind SSAO texture if available
+    m_settings.finalShader->setBool("enableSSAO", m_ssaoEnabled);
+    if (m_ssaoEnabled && m_ssaoTexture != 0) {
+      glActiveTexture(GL_TEXTURE2);
+      glBindTexture(GL_TEXTURE_2D, m_ssaoTexture);
+      m_settings.finalShader->setInt("ssaoTexture", 2);
+    }
+
     // Set all uniforms - always enable bloom but use effective intensity (0 if
     // disabled)
     m_settings.finalShader->setBool(
@@ -468,6 +476,8 @@ void BloomRenderer::applyBloom(GLuint sceneTexture,
     renderQuad();
 
     // Unbind textures to avoid state issues
+    glActiveTexture(GL_TEXTURE2);
+    glBindTexture(GL_TEXTURE_2D, 0);
     glActiveTexture(GL_TEXTURE1);
     glBindTexture(GL_TEXTURE_2D, 0);
     glActiveTexture(GL_TEXTURE0);
@@ -485,6 +495,11 @@ void BloomRenderer::renderQuad() {
   glBindVertexArray(m_settings.quadVAO);
   glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
   glBindVertexArray(0);
+}
+
+void BloomRenderer::setSSAOTexture(GLuint ssaoTexture, bool ssaoEnabled) {
+  m_ssaoTexture = ssaoTexture;
+  m_ssaoEnabled = ssaoEnabled;
 }
 
 bool BloomRenderer::validateBloomSystem() const {

--- a/StereoVista/src/Engine/SSAORenderer.cpp
+++ b/StereoVista/src/Engine/SSAORenderer.cpp
@@ -1,0 +1,418 @@
+#include "Engine/SSAORenderer.h"
+#include "Engine/Core.h"
+#include <iostream>
+#include <random>
+
+namespace Engine {
+
+static float lerp(float a, float b, float f) { return a + f * (b - a); }
+
+SSAORenderer::SSAORenderer() : m_width(0), m_height(0) {}
+
+SSAORenderer::~SSAORenderer() { cleanup(); }
+
+bool SSAORenderer::initialize(int width, int height) {
+  m_width = width;
+  m_height = height;
+
+  if (!loadShaders()) {
+    std::cerr << "Failed to load SSAO shaders" << std::endl;
+    return false;
+  }
+
+  if (!setupGBuffer()) {
+    std::cerr << "Failed to setup SSAO G-buffer" << std::endl;
+    return false;
+  }
+
+  if (!setupSSAOBuffers()) {
+    std::cerr << "Failed to setup SSAO framebuffers" << std::endl;
+    return false;
+  }
+
+  generateSampleKernel();
+  generateNoiseTexture();
+  setupQuad();
+
+  m_initialized = true;
+  return true;
+}
+
+void SSAORenderer::cleanup() {
+  if (m_gBufferFBO != 0) {
+    glDeleteFramebuffers(1, &m_gBufferFBO);
+    m_gBufferFBO = 0;
+  }
+  if (m_gPosition != 0) {
+    glDeleteTextures(1, &m_gPosition);
+    m_gPosition = 0;
+  }
+  if (m_gNormal != 0) {
+    glDeleteTextures(1, &m_gNormal);
+    m_gNormal = 0;
+  }
+  if (m_gDepthRBO != 0) {
+    glDeleteRenderbuffers(1, &m_gDepthRBO);
+    m_gDepthRBO = 0;
+  }
+  if (m_ssaoFBO != 0) {
+    glDeleteFramebuffers(1, &m_ssaoFBO);
+    m_ssaoFBO = 0;
+  }
+  if (m_ssaoColorBuffer != 0) {
+    glDeleteTextures(1, &m_ssaoColorBuffer);
+    m_ssaoColorBuffer = 0;
+  }
+  if (m_ssaoBlurFBO != 0) {
+    glDeleteFramebuffers(1, &m_ssaoBlurFBO);
+    m_ssaoBlurFBO = 0;
+  }
+  if (m_ssaoColorBufferBlur != 0) {
+    glDeleteTextures(1, &m_ssaoColorBufferBlur);
+    m_ssaoColorBufferBlur = 0;
+  }
+  if (m_noiseTexture != 0) {
+    glDeleteTextures(1, &m_noiseTexture);
+    m_noiseTexture = 0;
+  }
+  if (m_quadVAO != 0) {
+    glDeleteVertexArrays(1, &m_quadVAO);
+    glDeleteBuffers(1, &m_quadVBO);
+    m_quadVAO = m_quadVBO = 0;
+  }
+  if (m_geometryShader) {
+    delete m_geometryShader;
+    m_geometryShader = nullptr;
+  }
+  if (m_ssaoShader) {
+    delete m_ssaoShader;
+    m_ssaoShader = nullptr;
+  }
+  if (m_blurShader) {
+    delete m_blurShader;
+    m_blurShader = nullptr;
+  }
+  m_initialized = false;
+}
+
+void SSAORenderer::resize(int width, int height) {
+  if (width == m_width && height == m_height)
+    return;
+
+  m_width = width;
+  m_height = height;
+
+  if (m_initialized) {
+    // Delete existing framebuffers and textures
+    if (m_gBufferFBO != 0) {
+      glDeleteFramebuffers(1, &m_gBufferFBO);
+      glDeleteTextures(1, &m_gPosition);
+      glDeleteTextures(1, &m_gNormal);
+      glDeleteRenderbuffers(1, &m_gDepthRBO);
+    }
+    if (m_ssaoFBO != 0) {
+      glDeleteFramebuffers(1, &m_ssaoFBO);
+      glDeleteTextures(1, &m_ssaoColorBuffer);
+    }
+    if (m_ssaoBlurFBO != 0) {
+      glDeleteFramebuffers(1, &m_ssaoBlurFBO);
+      glDeleteTextures(1, &m_ssaoColorBufferBlur);
+    }
+
+    // Recreate
+    setupGBuffer();
+    setupSSAOBuffers();
+  }
+}
+
+bool SSAORenderer::setupGBuffer() {
+  glGenFramebuffers(1, &m_gBufferFBO);
+  glBindFramebuffer(GL_FRAMEBUFFER, m_gBufferFBO);
+
+  // Position color buffer (view-space, RGBA16F - w stores validity flag)
+  glGenTextures(1, &m_gPosition);
+  glBindTexture(GL_TEXTURE_2D, m_gPosition);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, m_width, m_height, 0, GL_RGBA,
+               GL_FLOAT, NULL);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                         m_gPosition, 0);
+
+  // Normal color buffer (view-space, RGB16F)
+  glGenTextures(1, &m_gNormal);
+  glBindTexture(GL_TEXTURE_2D, m_gNormal);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, m_width, m_height, 0, GL_RGBA,
+               GL_FLOAT, NULL);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D,
+                         m_gNormal, 0);
+
+  // Tell OpenGL which color attachments we'll use
+  GLuint attachments[2] = {GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1};
+  glDrawBuffers(2, attachments);
+
+  // Depth renderbuffer
+  glGenRenderbuffers(1, &m_gDepthRBO);
+  glBindRenderbuffer(GL_RENDERBUFFER, m_gDepthRBO);
+  glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, m_width,
+                        m_height);
+  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                            GL_RENDERBUFFER, m_gDepthRBO);
+
+  if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+    std::cerr << "SSAO G-buffer framebuffer not complete!" << std::endl;
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    return false;
+  }
+
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+  return true;
+}
+
+bool SSAORenderer::setupSSAOBuffers() {
+  // SSAO color buffer
+  glGenFramebuffers(1, &m_ssaoFBO);
+  glBindFramebuffer(GL_FRAMEBUFFER, m_ssaoFBO);
+
+  glGenTextures(1, &m_ssaoColorBuffer);
+  glBindTexture(GL_TEXTURE_2D, m_ssaoColorBuffer);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RED, m_width, m_height, 0, GL_RED,
+               GL_FLOAT, NULL);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                         m_ssaoColorBuffer, 0);
+
+  if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+    std::cerr << "SSAO framebuffer not complete!" << std::endl;
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    return false;
+  }
+
+  // SSAO blur buffer
+  glGenFramebuffers(1, &m_ssaoBlurFBO);
+  glBindFramebuffer(GL_FRAMEBUFFER, m_ssaoBlurFBO);
+
+  glGenTextures(1, &m_ssaoColorBufferBlur);
+  glBindTexture(GL_TEXTURE_2D, m_ssaoColorBufferBlur);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RED, m_width, m_height, 0, GL_RED,
+               GL_FLOAT, NULL);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                         m_ssaoColorBufferBlur, 0);
+
+  if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+    std::cerr << "SSAO blur framebuffer not complete!" << std::endl;
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    return false;
+  }
+
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+  return true;
+}
+
+void SSAORenderer::generateSampleKernel() {
+  std::uniform_real_distribution<float> randomFloats(0.0f, 1.0f);
+  std::default_random_engine generator;
+
+  m_ssaoKernel.clear();
+  for (unsigned int i = 0; i < 64; ++i) {
+    // Sample in tangent space hemisphere: x,y in [-1,1], z in [0,1]
+    glm::vec3 sample(randomFloats(generator) * 2.0f - 1.0f,
+                     randomFloats(generator) * 2.0f - 1.0f,
+                     randomFloats(generator));
+    sample = glm::normalize(sample);
+    sample *= randomFloats(generator);
+
+    // Scale samples so they're more aligned to center of hemisphere
+    // (accelerating interpolation to place more samples closer to the origin)
+    float scale = static_cast<float>(i) / 64.0f;
+    scale = lerp(0.1f, 1.0f, scale * scale);
+    sample *= scale;
+
+    m_ssaoKernel.push_back(sample);
+  }
+}
+
+void SSAORenderer::generateNoiseTexture() {
+  std::uniform_real_distribution<float> randomFloats(0.0f, 1.0f);
+  std::default_random_engine generator;
+
+  // Generate 4x4 noise texture of random rotation vectors around z-axis
+  std::vector<glm::vec3> ssaoNoise;
+  for (unsigned int i = 0; i < 16; i++) {
+    glm::vec3 noise(randomFloats(generator) * 2.0f - 1.0f,
+                    randomFloats(generator) * 2.0f - 1.0f,
+                    0.0f); // Rotate around z-axis (in tangent space)
+    ssaoNoise.push_back(noise);
+  }
+
+  glGenTextures(1, &m_noiseTexture);
+  glBindTexture(GL_TEXTURE_2D, m_noiseTexture);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, 4, 4, 0, GL_RGB, GL_FLOAT,
+               &ssaoNoise[0]);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+}
+
+bool SSAORenderer::loadShaders() {
+  try {
+    m_geometryShader =
+        Engine::loadShader("ssao/geometry.vert", "ssao/geometry.frag");
+    if (!m_geometryShader) {
+      std::cerr << "Failed to load SSAO geometry shader" << std::endl;
+      return false;
+    }
+
+    m_ssaoShader = Engine::loadShader("ssao/ssao.vert", "ssao/ssao.frag");
+    if (!m_ssaoShader) {
+      std::cerr << "Failed to load SSAO shader" << std::endl;
+      return false;
+    }
+
+    m_blurShader =
+        Engine::loadShader("ssao/ssao_blur.vert", "ssao/ssao_blur.frag");
+    if (!m_blurShader) {
+      std::cerr << "Failed to load SSAO blur shader" << std::endl;
+      return false;
+    }
+
+    // Set texture unit defaults
+    m_ssaoShader->use();
+    m_ssaoShader->setInt("gPosition", 0);
+    m_ssaoShader->setInt("gNormal", 1);
+    m_ssaoShader->setInt("texNoise", 2);
+
+    m_blurShader->use();
+    m_blurShader->setInt("ssaoInput", 0);
+
+    return true;
+  } catch (const std::exception &e) {
+    std::cerr << "Failed to load SSAO shaders: " << e.what() << std::endl;
+    if (m_geometryShader) {
+      delete m_geometryShader;
+      m_geometryShader = nullptr;
+    }
+    if (m_ssaoShader) {
+      delete m_ssaoShader;
+      m_ssaoShader = nullptr;
+    }
+    if (m_blurShader) {
+      delete m_blurShader;
+      m_blurShader = nullptr;
+    }
+    return false;
+  }
+}
+
+void SSAORenderer::setupQuad() {
+  float quadVertices[] = {
+      // positions        // texture Coords
+      -1.0f, 1.0f, 0.0f, 0.0f, 1.0f, -1.0f, -1.0f, 0.0f, 0.0f, 0.0f,
+      1.0f,  1.0f, 0.0f, 1.0f, 1.0f, 1.0f,  -1.0f, 0.0f, 1.0f, 0.0f,
+  };
+
+  glGenVertexArrays(1, &m_quadVAO);
+  glGenBuffers(1, &m_quadVBO);
+  glBindVertexArray(m_quadVAO);
+  glBindBuffer(GL_ARRAY_BUFFER, m_quadVBO);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(quadVertices), &quadVertices,
+               GL_STATIC_DRAW);
+  glEnableVertexAttribArray(0);
+  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float),
+                        (void *)0);
+  glEnableVertexAttribArray(1);
+  glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float),
+                        (void *)(3 * sizeof(float)));
+  glBindVertexArray(0);
+}
+
+void SSAORenderer::beginGeometryPass() {
+  if (!m_initialized)
+    return;
+
+  glBindFramebuffer(GL_FRAMEBUFFER, m_gBufferFBO);
+  glViewport(0, 0, m_width, m_height);
+
+  // Clear the G-buffer (position w=0 means no geometry)
+  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+}
+
+void SSAORenderer::endGeometryPass() {
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+void SSAORenderer::computeSSAO(const glm::mat4 &projection) {
+  if (!m_initialized || !m_ssaoShader)
+    return;
+
+  glBindFramebuffer(GL_FRAMEBUFFER, m_ssaoFBO);
+  glViewport(0, 0, m_width, m_height);
+  glClear(GL_COLOR_BUFFER_BIT);
+
+  m_ssaoShader->use();
+
+  // Send kernel samples
+  for (unsigned int i = 0; i < 64; ++i) {
+    m_ssaoShader->setVec3("samples[" + std::to_string(i) + "]",
+                          m_ssaoKernel[i]);
+  }
+  m_ssaoShader->setMat4("projection", projection);
+  m_ssaoShader->setInt("kernelSize", m_settings.kernelSize);
+  m_ssaoShader->setFloat("radius", m_settings.radius);
+  m_ssaoShader->setFloat("bias", m_settings.bias);
+  m_ssaoShader->setFloat("power", m_settings.power);
+
+  // Noise scale: screen dimensions / noise texture size (4x4)
+  m_ssaoShader->setVec2("noiseScale",
+                        glm::vec2(static_cast<float>(m_width) / 4.0f,
+                                  static_cast<float>(m_height) / 4.0f));
+
+  // Bind G-buffer textures
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_2D, m_gPosition);
+  glActiveTexture(GL_TEXTURE1);
+  glBindTexture(GL_TEXTURE_2D, m_gNormal);
+  glActiveTexture(GL_TEXTURE2);
+  glBindTexture(GL_TEXTURE_2D, m_noiseTexture);
+
+  renderQuad();
+
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+void SSAORenderer::blurSSAO() {
+  if (!m_initialized || !m_blurShader)
+    return;
+
+  glBindFramebuffer(GL_FRAMEBUFFER, m_ssaoBlurFBO);
+  glViewport(0, 0, m_width, m_height);
+  glClear(GL_COLOR_BUFFER_BIT);
+
+  m_blurShader->use();
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_2D, m_ssaoColorBuffer);
+
+  renderQuad();
+
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+void SSAORenderer::renderQuad() {
+  if (m_quadVAO == 0)
+    return;
+
+  glBindVertexArray(m_quadVAO);
+  glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+  glBindVertexArray(0);
+}
+
+} // namespace Engine

--- a/StereoVista/src/Engine/SSAORenderer.cpp
+++ b/StereoVista/src/Engine/SSAORenderer.cpp
@@ -341,9 +341,14 @@ void SSAORenderer::beginGeometryPass() {
   glBindFramebuffer(GL_FRAMEBUFFER, m_gBufferFBO);
   glViewport(0, 0, m_width, m_height);
 
-  // Clear the G-buffer (position w=0 means no geometry)
+  // Save current clear color, then clear G-buffer with zeros
+  // (position w=0 marks empty/background pixels)
+  GLfloat prevClearColor[4];
+  glGetFloatv(GL_COLOR_CLEAR_VALUE, prevClearColor);
   glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+  glClearColor(prevClearColor[0], prevClearColor[1], prevClearColor[2],
+               prevClearColor[3]);
 }
 
 void SSAORenderer::endGeometryPass() {

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -1731,6 +1731,61 @@ void renderSettingsWindow() {
         }
 
         ImGui::Spacing();
+        DrawSectionHeader("Screen Space Ambient Occlusion");
+
+        if (ImGui::Checkbox("Enable SSAO", &preferences.ssaoSettings.enabled)) {
+          settingsChanged = true;
+        }
+        ImGui::SameLine();
+        DrawHelpMarker(
+            "Screen-Space Ambient Occlusion darkens creases and corners "
+            "for more realistic lighting. Requires HDR to be enabled.");
+
+        if (preferences.ssaoSettings.enabled) {
+          const char *ssaoSampleCounts[] = {"16 (Fast)", "32 (Balanced)",
+                                            "64 (Quality)"};
+          int ssaoKernelIndex = 2;
+          if (preferences.ssaoSettings.kernelSize <= 16)
+            ssaoKernelIndex = 0;
+          else if (preferences.ssaoSettings.kernelSize <= 32)
+            ssaoKernelIndex = 1;
+          if (ImGui::Combo("SSAO Samples", &ssaoKernelIndex, ssaoSampleCounts,
+                           IM_ARRAYSIZE(ssaoSampleCounts))) {
+            const int kernelSizes[] = {16, 32, 64};
+            preferences.ssaoSettings.kernelSize = kernelSizes[ssaoKernelIndex];
+            settingsChanged = true;
+          }
+          ImGui::SameLine();
+          DrawHelpMarker(
+              "Number of samples per pixel. More samples = better quality "
+              "but slower");
+
+          if (ImGui::SliderFloat("SSAO Radius",
+                                 &preferences.ssaoSettings.radius, 0.1f, 2.0f,
+                                 "%.2f")) {
+            settingsChanged = true;
+          }
+          ImGui::SameLine();
+          DrawHelpMarker(
+              "Radius of the hemisphere sample kernel in view space");
+
+          if (ImGui::SliderFloat("SSAO Bias", &preferences.ssaoSettings.bias,
+                                 0.001f, 0.1f, "%.3f")) {
+            settingsChanged = true;
+          }
+          ImGui::SameLine();
+          DrawHelpMarker("Depth bias to prevent self-occlusion artifacts");
+
+          if (ImGui::SliderFloat("SSAO Power", &preferences.ssaoSettings.power,
+                                 0.5f, 5.0f, "%.1f")) {
+            settingsChanged = true;
+          }
+          ImGui::SameLine();
+          DrawHelpMarker("Power curve to control occlusion intensity. Higher "
+                         "values = stronger darkening");
+        }
+
+        ImGui::Spacing();
         DrawSectionHeader("Shadow Quality");
 
         const char *pcfKernelSizes[] = {"3x3 (Fast)", "5x5 (Balanced)",

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -9,6 +9,7 @@
 #include "../headers/Engine/BVH.h"
 #include "../headers/Engine/BVHDebug.h"
 #include "../headers/Engine/BloomRenderer.h"
+#include "../headers/Engine/SSAORenderer.h"
 #include "../headers/Engine/IrradianceCache.h"
 #include "Core/Camera.h"
 #include "Core/CursorSyncState.h"
@@ -296,6 +297,9 @@ Engine::Shader *instancedShader = nullptr;
 
 // Bloom rendering system
 Engine::BloomRenderer *bloomRenderer = nullptr;
+
+// SSAO rendering system
+Engine::SSAORenderer *ssaoRenderer = nullptr;
 
 GUI::LightingMode currentLightingMode = GUI::LIGHTING_SHADOW_MAPPING;
 bool enableShadows = true;
@@ -1557,6 +1561,13 @@ void savePreferences() {
   j["hdr"]["toneMapOperator"] = preferences.hdrSettings.toneMapOperator;
   j["hdr"]["enableBloom"] = preferences.hdrSettings.enableBloom;
 
+  // Save SSAO settings
+  j["ssao"]["enabled"] = preferences.ssaoSettings.enabled;
+  j["ssao"]["kernelSize"] = preferences.ssaoSettings.kernelSize;
+  j["ssao"]["radius"] = preferences.ssaoSettings.radius;
+  j["ssao"]["bias"] = preferences.ssaoSettings.bias;
+  j["ssao"]["power"] = preferences.ssaoSettings.power;
+
   // Save shadow settings
   j["shadows"]["pcfKernelSize"] = preferences.shadowSettings.pcfKernelSize;
   j["shadows"]["enablePCSS"] = preferences.shadowSettings.enablePCSS;
@@ -1995,6 +2006,15 @@ void loadPreferences() {
           j["hdr"].value("toneMapOperator", 0);
       preferences.hdrSettings.enableBloom =
           j["hdr"].value("enableBloom", false);
+    }
+
+    // SSAO settings
+    if (j.contains("ssao")) {
+      preferences.ssaoSettings.enabled = j["ssao"].value("enabled", false);
+      preferences.ssaoSettings.kernelSize = j["ssao"].value("kernelSize", 64);
+      preferences.ssaoSettings.radius = j["ssao"].value("radius", 0.5f);
+      preferences.ssaoSettings.bias = j["ssao"].value("bias", 0.025f);
+      preferences.ssaoSettings.power = j["ssao"].value("power", 1.0f);
     }
 
     // Shadow settings
@@ -2473,6 +2493,16 @@ int main() {
       delete bloomRenderer;
       bloomRenderer = nullptr;
     }
+  }
+
+  // ---- Initialize SSAO Renderer ----
+  ssaoRenderer = new Engine::SSAORenderer();
+  if (!ssaoRenderer->initialize(windowWidth, windowHeight)) {
+    std::cerr << "Warning: Failed to initialize SSAO renderer - SSAO "
+                 "effects will be disabled"
+              << std::endl;
+    delete ssaoRenderer;
+    ssaoRenderer = nullptr;
   }
 
   // ---- Load Initial Scene ----
@@ -3192,6 +3222,14 @@ int main() {
       bloomSettings.exposure = preferences.hdrSettings.exposure;
       bloomSettings.toneMapOperator = preferences.hdrSettings.toneMapOperator;
 
+      // Set SSAO texture for final composition
+      if (ssaoRenderer && ssaoRenderer->isInitialized() &&
+          preferences.ssaoSettings.enabled) {
+        bloomRenderer->setSSAOTexture(ssaoRenderer->getSSAOTexture(), true);
+      } else {
+        bloomRenderer->setSSAOTexture(0, false);
+      }
+
       if (isStereoWindow) {
         // Render and apply HDR/bloom separately for each eye
         // Swap eyes if flipEyes is enabled
@@ -3344,6 +3382,12 @@ void cleanup() {
   if (bloomRenderer) {
     delete bloomRenderer;
     bloomRenderer = nullptr;
+  }
+
+  // Cleanup SSAO renderer
+  if (ssaoRenderer) {
+    delete ssaoRenderer;
+    ssaoRenderer = nullptr;
   }
 
   // Delete zero plane resources
@@ -3586,6 +3630,71 @@ void renderEye(GLenum drawBuffer, const glm::mat4 &projection,
 
       glDisable(GL_POLYGON_OFFSET_FILL);
     }
+
+    // Restore wireframe mode if it was enabled
+    glPolygonMode(GL_FRONT_AND_BACK, camera.wireframe ? GL_LINE : GL_FILL);
+  }
+
+  // 2.7. SSAO geometry pass - render view-space positions and normals
+  if (ssaoRenderer && ssaoRenderer->isInitialized() &&
+      preferences.ssaoSettings.enabled && preferences.hdrSettings.enabled &&
+      bloomRenderer != nullptr) {
+    // Temporarily disable wireframe mode for geometry pass
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
+    ssaoRenderer->beginGeometryPass();
+
+    Engine::Shader *geoShader = ssaoRenderer->getGeometryShader();
+    if (geoShader) {
+      geoShader->use();
+      geoShader->setMat4("projection", projection);
+      geoShader->setMat4("view", view);
+
+      // Render all models with the geometry shader
+      for (int i = 0; i < currentScene.models.size(); i++) {
+        auto &model = currentScene.models[i];
+        if (!model.visible)
+          continue;
+
+        glm::mat4 modelMatrix = glm::mat4(1.0f);
+        modelMatrix = glm::translate(modelMatrix, model.position);
+        modelMatrix = glm::rotate(modelMatrix, glm::radians(model.rotation.x),
+                                  glm::vec3(1, 0, 0));
+        modelMatrix = glm::rotate(modelMatrix, glm::radians(model.rotation.y),
+                                  glm::vec3(0, 1, 0));
+        modelMatrix = glm::rotate(modelMatrix, glm::radians(model.rotation.z),
+                                  glm::vec3(0, 0, 1));
+        modelMatrix = glm::scale(modelMatrix, model.scale);
+
+        geoShader->setMat4("model", modelMatrix);
+
+        glm::mat3 normalMatrix =
+            glm::transpose(glm::inverse(glm::mat3(modelMatrix)));
+        geoShader->setMat3("normalMatrix", normalMatrix);
+
+        for (int j = 0; j < model.getMeshes().size(); j++) {
+          model.getMeshes()[j].Draw(*geoShader);
+        }
+      }
+    }
+
+    ssaoRenderer->endGeometryPass();
+
+    // Update SSAO settings from preferences
+    Engine::SSAOSettings &ssaoSettings = ssaoRenderer->getSettings();
+    ssaoSettings.enabled = preferences.ssaoSettings.enabled;
+    ssaoSettings.kernelSize = preferences.ssaoSettings.kernelSize;
+    ssaoSettings.radius = preferences.ssaoSettings.radius;
+    ssaoSettings.bias = preferences.ssaoSettings.bias;
+    ssaoSettings.power = preferences.ssaoSettings.power;
+
+    // Compute SSAO
+    glDisable(GL_DEPTH_TEST);
+    ssaoRenderer->computeSSAO(projection);
+
+    // Blur SSAO result
+    ssaoRenderer->blurSSAO();
+    glEnable(GL_DEPTH_TEST);
 
     // Restore wireframe mode if it was enabled
     glPolygonMode(GL_FRONT_AND_BACK, camera.wireframe ? GL_LINE : GL_FILL);
@@ -5735,6 +5844,11 @@ void framebuffer_size_callback(GLFWwindow *window, int width, int height) {
   // Resize bloom renderer if it exists
   if (bloomRenderer) {
     bloomRenderer->resize(width, height);
+  }
+
+  // Resize SSAO renderer if it exists
+  if (ssaoRenderer) {
+    ssaoRenderer->resize(width, height);
   }
 }
 


### PR DESCRIPTION
Implements SSAO following the LearnOpenGL technique: a geometry pre-pass
renders view-space positions and normals to a G-buffer, then a
hemisphere sampling kernel computes per-pixel occlusion, followed by a
4x4 box blur. The blurred AO texture is multiplied into the HDR scene
color in the final composition shader before tone mapping.

New files:
- SSAORenderer class (header + source) managing G-buffer, SSAO, and blur
  framebuffers, 64-sample hemisphere kernel, and 4x4 noise texture
- GLSL shaders: geometry pass, SSAO computation, and SSAO blur

Integration:
- BloomRenderer passes SSAO texture to final.frag via texture unit 2
- GUI controls for enable/disable, sample count, radius, bias, and power
- Settings persisted in preferences.json under "ssao" key
- Resize and cleanup handled alongside existing bloom renderer

https://claude.ai/code/session_01YXqno8aodXxjmo8jSb7xjF