### PR TITLE
Implement Schütz per-batch frustum culling and packed 10/20/30-bit coordinates

### DIFF
--- a/StereoVista/assets/shaders/core/pointcloud_rasterize.comp
+++ b/StereoVista/assets/shaders/core/pointcloud_rasterize.comp
@@ -1,108 +1,281 @@
+// pointcloud_rasterize.comp
+// Schütz compute rasterizer – Phase 2 (m-schuetz/compute_rasterizer, standard method)
+//
+// Two improvements over the naive per-point dispatch:
+//
+//  1. PER-BATCH FRUSTUM CULLING
+//     Each workgroup processes one batch of kComputeBatchSize contiguous points.
+//     Thread 0's first act is to test the batch bounding box against the 6 clip
+//     planes extracted from the MVP matrix (Gribb/Hartmann method, adapted from
+//     Schütz who adapted it from three.js).  If the whole batch is outside any
+//     plane the workgroup returns immediately – no projection, no atomic writes.
+//
+//  2. PACKED 10/20/30-BIT COORDINATES
+//     Coordinates are quantised per-batch and stored as three uint arrays:
+//       ssXyz_4b  (binding 43) – high  10 bits per axis  [29:20]  (coarsest)
+//       ssXyz_8b  (binding 42) – mid   10 bits per axis  [19:10]
+//       ssXyz_12b (binding 41) – low   10 bits per axis  [ 9: 0]  (finest)
+//     The precision level selected per batch determines which buffers are read:
+//       level 0 → all three  (30-bit, ~1 mm over 1000 km)
+//       level 1 → _4b + _8b (20-bit, ~1 mm over 1 km)
+//       level 2+ → _4b only (10-bit, ~1/1024 of batch size per axis)
+//     This matches Schütz's getPrecisionLevel() thresholds exactly.
+//
+// Frustum culling code is adapted from Schütz / three.js (MIT licence).
+// Coordinate decoding follows Schütz compute_rasterizer/modules/compute_loop_las.
+
 #version 460 core
 #extension GL_ARB_gpu_shader_int64      : require
 #extension GL_EXT_shader_atomic_int64   : enable
 #extension GL_NV_shader_atomic_int64    : enable
+#extension GL_NV_gpu_shader5            : enable
+
+// ── Constants ────────────────────────────────────────────────────────────────
+#define STEPS_30BIT 1073741824  // 2^30
+#define STEPS_10BIT 1024        // 2^10
+#define MASK_10BIT  1023u       // 0x3FF
 
 layout(local_size_x = 128, local_size_y = 1, local_size_z = 1) in;
 
-// Schütz compute rasterizer – Phase 2 (faithful to m-schuetz/compute_rasterizer)
-//
-// Packs depth + point-index into a single uint64_t per pixel:
-//   high 32 bits = floatBitsToUint(clip.w)   <- view-space depth, sorts as uint
-//   low  32 bits = point index               <- used in resolve to fetch colour
-//
-// A single atomicMin on the 64-bit value handles both depth test and colour
-// selection atomically, eliminating the race between the two separate atomics
-// of the old two-buffer approach.
-//
-// PointCloudPoint layout (must match C++ struct, 7 floats = 28 bytes):
-//   float x, y, z   (position)
-//   float intensity
-//   float r, g, b   (colour, linear [0,1])
-
-// Input: flat SSBO of all points (entire cloud, not per-node)
-layout(std430, binding = 0) readonly buffer PointBuffer {
-    float pointData[];
+// ── Batch descriptor (must match C++ ComputeBatch, 32 bytes, std430) ─────────
+struct Batch {
+    float min_x, min_y, min_z;
+    float max_x, max_y, max_z;
+    int   numPoints;
+    int   firstPoint;
 };
 
-// Per-pixel framebuffer: packed (depth:32 | index:32).
-// Initialised to 0xFFFFFFFFFFFFFFFFUL by the host before each frame
-// (via glClearNamedBufferSubData).
-layout(std430, binding = 1) coherent buffer ssFramebuffer {
-    uint64_t framebuffer[];
-};
+// ── SSBOs ────────────────────────────────────────────────────────────────────
+layout(std430, binding =  1) coherent buffer ssFramebufferBlock { uint64_t framebuffer[]; };
+layout(std430, binding = 40) readonly buffer ssBatchesBlock     { Batch    ssBatches[];   };
+layout(std430, binding = 41) readonly buffer ssXyz12bBlock      { uint     ssXyz_12b[];   };
+layout(std430, binding = 42) readonly buffer ssXyz8bBlock       { uint     ssXyz_8b[];    };
+layout(std430, binding = 43) readonly buffer ssXyz4bBlock       { uint     ssXyz_4b[];    };
+layout(std430, binding = 44) readonly buffer ssRGBABlock        { uint     ssRGBA[];      };
 
-// Per-point packed RGBA colour (written at rasterise time, read at resolve time).
-// Binding 44 matches Schütz's ssColors binding.
-layout(std430, binding = 44) coherent buffer ssColors {
-    uint packedColor[];
-};
-
-uniform mat4  uMVP;
+// ── Uniforms ─────────────────────────────────────────────────────────────────
+uniform mat4  uMVP;             // proj * view * model – point projection + frustum planes
+uniform mat4  uModelView;       // view * model        – precision level (view-space radius)
+uniform mat4  uProj;            // projection matrix   – precision level
 uniform ivec2 uImageSize;
-uniform uint  uNumPoints;
+uniform int   uPointsPerThread; // ceil(kComputeBatchSize / 128)
 uniform float uPointBaseSize;   // world-space splat radius in metres
 uniform float uFieldOfView;     // vertical FOV in radians
 
+// ── Frustum culling ───────────────────────────────────────────────────────────
+// Adapted from Schütz compute_rasterizer / three.js (MIT).
+// Extracts 6 clip planes directly from the MVP matrix (Gribb/Hartmann method).
+// The bounding box coordinates are in the point cloud's local space, and the
+// MVP matrix transforms local → clip, so the extracted planes are also in
+// local space – no explicit world transform needed.
+
+struct Plane { vec3 normal; float constant; };
+
+float distanceToPoint(vec3 pt, Plane pl) {
+    return dot(pl.normal, pt) + pl.constant;
+}
+
+Plane createPlane(float x, float y, float z, float w) {
+    float len = length(vec3(x, y, z));
+    return Plane(vec3(x, y, z) / len, w / len);
+}
+
+bool intersectsFrustum(mat4 m, vec3 wgMin, vec3 wgMax) {
+    // GLSL mat4 is column-major: m[col][row]
+    // Row i of the matrix = vec4(m[0][i], m[1][i], m[2][i], m[3][i])
+    float r0x = m[0][0], r0y = m[1][0], r0z = m[2][0], r0w = m[3][0]; // row 0
+    float r1x = m[0][1], r1y = m[1][1], r1z = m[2][1], r1w = m[3][1]; // row 1
+    float r2x = m[0][2], r2y = m[1][2], r2z = m[2][2], r2w = m[3][2]; // row 2
+    float r3x = m[0][3], r3y = m[1][3], r3z = m[2][3], r3w = m[3][3]; // row 3
+
+    Plane planes[6];
+    planes[0] = createPlane(r3x - r0x, r3y - r0y, r3z - r0z, r3w - r0w); // right
+    planes[1] = createPlane(r3x + r0x, r3y + r0y, r3z + r0z, r3w + r0w); // left
+    planes[2] = createPlane(r3x + r1x, r3y + r1y, r3z + r1z, r3w + r1w); // bottom
+    planes[3] = createPlane(r3x - r1x, r3y - r1y, r3z - r1z, r3w - r1w); // top
+    planes[4] = createPlane(r3x - r2x, r3y - r2y, r3z - r2z, r3w - r2w); // near
+    planes[5] = createPlane(r3x + r2x, r3y + r2y, r3z + r2z, r3w + r2w); // far
+
+    for (int i = 0; i < 6; i++) {
+        // Test the "positive vertex" – the corner of the AABB closest to the
+        // plane normal.  If even that is behind the plane, the whole box is out.
+        vec3 pv;
+        pv.x = planes[i].normal.x > 0.0 ? wgMax.x : wgMin.x;
+        pv.y = planes[i].normal.y > 0.0 ? wgMax.y : wgMin.y;
+        pv.z = planes[i].normal.z > 0.0 ? wgMax.z : wgMin.z;
+        if (distanceToPoint(pv, planes[i]) < 0.0) return false;
+    }
+    return true;
+}
+
+// ── Precision level selection ─────────────────────────────────────────────────
+// Projects the batch bounding sphere into screen space and returns a LOD level
+// that determines how many packed-coordinate buffers are read per point.
+// Matches Schütz's getPrecisionLevel() thresholds exactly.
+int getPrecisionLevel(vec3 wgMin, vec3 wgMax) {
+    vec3  wgCenter = (wgMin + wgMax) * 0.5;
+    float wgRadius = distance(wgMin, wgMax);          // bounding sphere radius
+
+    // Project center and a tangent point into view space, then to clip
+    vec4 viewCenter = uModelView * vec4(wgCenter, 1.0);
+    vec4 viewEdge   = viewCenter + vec4(wgRadius, 0.0, 0.0, 0.0);
+
+    vec4 projCenter = uProj * viewCenter;
+    vec4 projEdge   = uProj * viewEdge;
+
+    // Guard against behind-camera
+    if (projCenter.w <= 0.0) return 0;
+
+    projCenter.xy /= projCenter.w;
+    projEdge.xy   /= projEdge.w;
+
+    vec2 screenCenter = vec2(uImageSize) * (projCenter.xy * 0.5 + 0.5);
+    vec2 screenEdge   = vec2(uImageSize) * (projEdge.xy   * 0.5 + 0.5);
+    float pixelSize   = distance(screenEdge, screenCenter);
+
+    // Schütz thresholds (verbatim)
+    if      (pixelSize <    100.0) return 4;
+    else if (pixelSize <    200.0) return 3;
+    else if (pixelSize <    500.0) return 2;
+    else if (pixelSize < 10000.0)  return 1;
+    else                           return 0;
+}
+
+// ── Pixel write (circle splat, depth-test via atomicMin) ──────────────────────
 void writePixel(ivec2 px, uint64_t newEntry) {
     px = clamp(px, ivec2(0), uImageSize - ivec2(1));
     int pixelID = px.y * uImageSize.x + px.x;
 
-    // Fast non-atomic pre-check: skip if clearly behind existing depth
+    // Non-atomic fast-reject; real race resolved by atomicMin below
     uint64_t old = framebuffer[pixelID];
     if (newEntry >= old) return;
 
     atomicMin(framebuffer[pixelID], newEntry);
 }
 
+// ── Main ──────────────────────────────────────────────────────────────────────
 void main() {
-    uint idx = gl_GlobalInvocationID.x;
-    if (idx >= uNumPoints) return;
+    // One workgroup = one batch
+    uint  batchIndex = gl_WorkGroupID.x;
+    Batch batch      = ssBatches[batchIndex];
 
-    // ---- fetch point -------------------------------------------------------
-    uint base  = idx * 7u;
-    vec3 pos   = vec3(pointData[base + 0u],
-                      pointData[base + 1u],
-                      pointData[base + 2u]);
-    vec3 color = vec3(pointData[base + 4u],
-                      pointData[base + 5u],
-                      pointData[base + 6u]);
+    vec3 wgMin  = vec3(batch.min_x, batch.min_y, batch.min_z);
+    vec3 wgMax  = vec3(batch.max_x, batch.max_y, batch.max_z);
+    vec3 boxSize = wgMax - wgMin;
 
-    // ---- project -----------------------------------------------------------
-    vec4 clip = uMVP * vec4(pos, 1.0);
-    if (clip.w <= 0.0) return;     // behind camera
+    // ── Per-batch frustum cull ────────────────────────────────────────────────
+    // All 128 threads share this early-out: one AABB test replaces up to
+    // kComputeBatchSize individual per-point clip-space tests.
+    if (!intersectsFrustum(uMVP, wgMin, wgMax)) return;
 
-    vec3 ndc = clip.xyz / clip.w;
-    if (ndc.x < -1.0 || ndc.x > 1.0 ||
-        ndc.y < -1.0 || ndc.y > 1.0 ||
-        ndc.z < -1.0 || ndc.z > 1.0) return;   // outside frustum
+    // ── Precision level ───────────────────────────────────────────────────────
+    int level = getPrecisionLevel(wgMin, wgMax);
 
-    // ---- centre pixel ------------------------------------------------------
-    ivec2 px = ivec2((ndc.xy * 0.5 + 0.5) * vec2(uImageSize));
+    // ── Splat-radius factor (per-batch constant, amortised) ───────────────────
+    float fovFactor = float(uImageSize.y) / (2.0 * tan(uFieldOfView * 0.5));
 
-    // ---- depth in high 32 bits (floatBitsToUint sorts IEEE-754 correctly) --
-    uint depth = floatBitsToUint(clip.w);
+    // ── Point loop ────────────────────────────────────────────────────────────
+    // Strided access: thread T processes points T, T+128, T+256, …
+    // This gives coalesced memory reads across the warp.
+    for (int i = 0; i < uPointsPerThread; i++) {
+        uint localIndex = uint(i) * gl_WorkGroupSize.x + gl_LocalInvocationID.x;
+        if (int(localIndex) >= batch.numPoints) return;
 
-    // ---- store packed colour for this point (resolve reads it by index) ----
-    uint r = uint(clamp(color.r, 0.0, 1.0) * 255.0 + 0.5);
-    uint g = uint(clamp(color.g, 0.0, 1.0) * 255.0 + 0.5);
-    uint b = uint(clamp(color.b, 0.0, 1.0) * 255.0 + 0.5);
-    packedColor[idx] = (0xFFu << 24u) | (b << 16u) | (g << 8u) | r;
+        uint index = uint(batch.firstPoint) + localIndex;
 
-    // ---- pack 64-bit entry (depth:32 | index:32) ---------------------------
-    uint64_t entry = (uint64_t(depth) << 32UL) | uint64_t(idx);
+        // ── Decode position from packed coordinates ───────────────────────────
+        // Schütz's 10/20/30-bit quantisation scheme:
+        //   _4b  holds the highest 10 bits of each 30-bit axis value
+        //   _8b  holds the middle 10 bits
+        //   _12b holds the lowest  10 bits
+        // Recombine them, then scale back to [wgMin, wgMax].
+        vec3 point;
 
-    // ---- screen-space splat radius (same formula as GL_POINTS path) --------
-    float fovFactor    = float(uImageSize.y) / (2.0 * tan(uFieldOfView * 0.5));
-    float screenRadius = max(0.5, (uPointBaseSize / max(clip.w, 0.001)) * fovFactor);
-    int   splatR       = clamp(int(screenRadius), 0, 4);
+        if (level == 0) {
+            // 30-bit precision – read all three buffers
+            uint b4  = ssXyz_4b [index];
+            uint b8  = ssXyz_8b [index];
+            uint b12 = ssXyz_12b[index];
 
-    // ---- circle splat ------------------------------------------------------
-    float r2 = screenRadius * screenRadius;
-    for (int dy = -splatR; dy <= splatR; dy++) {
-        for (int dx = -splatR; dx <= splatR; dx++) {
-            if (float(dx * dx + dy * dy) <= r2) {
-                writePixel(px + ivec2(dx, dy), entry);
+            uint X4  = (b4  >>  0) & MASK_10BIT;
+            uint Y4  = (b4  >> 10) & MASK_10BIT;
+            uint Z4  = (b4  >> 20) & MASK_10BIT;
+
+            uint X8  = (b8  >>  0) & MASK_10BIT;
+            uint Y8  = (b8  >> 10) & MASK_10BIT;
+            uint Z8  = (b8  >> 20) & MASK_10BIT;
+
+            uint X12 = (b12 >>  0) & MASK_10BIT;
+            uint Y12 = (b12 >> 10) & MASK_10BIT;
+            uint Z12 = (b12 >> 20) & MASK_10BIT;
+
+            uint X = (X4 << 20) | (X8 << 10) | X12;
+            uint Y = (Y4 << 20) | (Y8 << 10) | Y12;
+            uint Z = (Z4 << 20) | (Z8 << 10) | Z12;
+
+            point = vec3(float(X), float(Y), float(Z))
+                  * (boxSize / float(STEPS_30BIT)) + wgMin;
+
+        } else if (level == 1) {
+            // 20-bit precision – skip ssXyz_12b
+            uint b4 = ssXyz_4b[index];
+            uint b8 = ssXyz_8b[index];
+
+            uint X4 = (b4 >>  0) & MASK_10BIT;
+            uint Y4 = (b4 >> 10) & MASK_10BIT;
+            uint Z4 = (b4 >> 20) & MASK_10BIT;
+
+            uint X8 = (b8 >>  0) & MASK_10BIT;
+            uint Y8 = (b8 >> 10) & MASK_10BIT;
+            uint Z8 = (b8 >> 20) & MASK_10BIT;
+
+            // High 20 bits of the 30-bit value; low 10 bits stay zero
+            uint X = (X4 << 20) | (X8 << 10);
+            uint Y = (Y4 << 20) | (Y8 << 10);
+            uint Z = (Z4 << 20) | (Z8 << 10);
+
+            point = vec3(float(X), float(Y), float(Z))
+                  * (boxSize / float(STEPS_30BIT)) + wgMin;
+
+        } else {
+            // 10-bit precision – only ssXyz_4b (levels 2, 3, 4)
+            uint b4 = ssXyz_4b[index];
+
+            uint X = (b4 >>  0) & MASK_10BIT;
+            uint Y = (b4 >> 10) & MASK_10BIT;
+            uint Z = (b4 >> 20) & MASK_10BIT;
+
+            point = vec3(float(X), float(Y), float(Z))
+                  * (boxSize / float(STEPS_10BIT)) + wgMin;
+        }
+
+        // ── Project to clip space ─────────────────────────────────────────────
+        vec4 clip = uMVP * vec4(point, 1.0);
+        if (clip.w <= 0.0) continue;
+
+        vec3 ndc = clip.xyz / clip.w;
+        if (ndc.x < -1.0 || ndc.x > 1.0 ||
+            ndc.y < -1.0 || ndc.y > 1.0 ||
+            ndc.z < -1.0 || ndc.z > 1.0) continue;
+
+        // ── Screen-space splat radius (perspective-correct) ───────────────────
+        ivec2 px = ivec2((ndc.xy * 0.5 + 0.5) * vec2(uImageSize));
+
+        float screenRadius = max(0.5, (uPointBaseSize / max(clip.w, 0.001)) * fovFactor);
+        int   splatR       = clamp(int(screenRadius), 0, 4);
+
+        // ── Depth + index packed into 64 bits ─────────────────────────────────
+        // floatBitsToUint preserves IEEE-754 sort order → atomicMin works as depth test
+        uint     depth = floatBitsToUint(clip.w);
+        uint64_t entry = (uint64_t(depth) << 32UL) | uint64_t(index);
+
+        // ── Filled-circle splat ───────────────────────────────────────────────
+        float r2 = screenRadius * screenRadius;
+        for (int dy = -splatR; dy <= splatR; dy++) {
+            for (int dx = -splatR; dx <= splatR; dx++) {
+                if (float(dx * dx + dy * dy) <= r2) {
+                    writePixel(px + ivec2(dx, dy), entry);
+                }
             }
         }
     }

--- a/StereoVista/headers/Engine/ComputePointCloudRenderer.h
+++ b/StereoVista/headers/Engine/ComputePointCloudRenderer.h
@@ -6,11 +6,13 @@
 // Per-frame pipeline:
 //   1. beginFrame() – clear the uint64_t framebuffer SSBO via
 //      glClearNamedBufferSubData (one driver call, no shader dispatch).
-//   2. renderNode() – for each point cloud, one glDispatchCompute covers ALL
-//      points.  The rasterize shader packs (depth:32 | point_index:32) into
-//      each pixel via atomicMin, and writes per-point packed RGBA into ssColors.
+//   2. renderNode() – for each point cloud, dispatch one workgroup per batch.
+//      Each workgroup tests its batch bounding box against the 6 frustum planes
+//      (Schütz / Gribb-Hartmann) and returns early if fully outside.
+//      Inside batches are decoded from packed 10/20/30-bit coordinates and
+//      rasterised into the uint64_t framebuffer via atomicMin.
 //   3. endFrame() – single glMemoryBarrier, then a fullscreen-quad resolve pass
-//      reads the framebuffer SSBO + ssColors to composite the result into the
+//      reads the framebuffer SSBO + ssRGBA to composite the result into the
 //      currently-bound HDR FBO.
 #include "shader.h"
 #include <glm/glm.hpp>
@@ -39,14 +41,32 @@ public:
     // Must be called before any renderNode() calls for this frame.
     void beginFrame();
 
-    // Rasterize one point cloud with a single compute dispatch.
-    //   vbo           – GL buffer holding PointCloudPoint data (7 floats / 28 bytes per point)
-    //   numPoints     – total number of points in that buffer
-    //   mvp           – combined model-view-projection matrix for this point cloud
-    //   pointBaseSize – world-space splat radius in metres
-    //   fieldOfView   – vertical FOV in radians
-    void renderNode(GLuint vbo, uint32_t numPoints, const glm::mat4& mvp,
-                    float pointBaseSize, float fieldOfView);
+    // Rasterize one point cloud using the Schütz batch-based compute path.
+    //
+    //   batchSSBO        – binding 40: ComputeBatch descriptor array
+    //   xyz12bSSBO       – binding 41: finest packed coord tier  (10 bits/axis)
+    //   xyz8bSSBO        – binding 42: middle packed coord tier
+    //   xyz4bSSBO        – binding 43: coarsest packed coord tier (always read)
+    //   rgbaSSBO         – binding 44: pre-packed uint RGBA per point
+    //   numBatches       – number of workgroups to dispatch (one per batch)
+    //   pointsPerThread  – ceil(kComputeBatchSize / 128)
+    //   mvp              – proj * view * model  (projection + frustum culling)
+    //   modelView        – view * model         (precision-level sphere projection)
+    //   proj             – projection matrix    (precision-level sphere projection)
+    //   pointBaseSize    – world-space splat radius in metres
+    //   fieldOfView      – vertical FOV in radians
+    void renderNode(GLuint batchSSBO,
+                    GLuint xyz12bSSBO,
+                    GLuint xyz8bSSBO,
+                    GLuint xyz4bSSBO,
+                    GLuint rgbaSSBO,
+                    uint32_t numBatches,
+                    int      pointsPerThread,
+                    const glm::mat4& mvp,
+                    const glm::mat4& modelView,
+                    const glm::mat4& proj,
+                    float pointBaseSize,
+                    float fieldOfView);
 
     // Wait for all compute work to finish, then composite the point cloud result
     // over the currently-bound HDR framebuffer with a fullscreen quad.
@@ -64,16 +84,9 @@ private:
     int  m_width  = 0;
     int  m_height = 0;
 
-    // GPU resources
     // Framebuffer SSBO: uint64_t[width*height] – packed (depth:32 | index:32).
     // Matches Schütz's ssFramebuffer (binding 1).
     GLuint m_framebufferSSBO = 0;
-
-    // Per-point colour SSBO: uint[numPoints] – packed ABGR.
-    // Matches Schütz's ssColors (binding 44).
-    // Allocated lazily in renderNode(); grown as needed.
-    GLuint   m_colorsSSBO         = 0;
-    uint32_t m_colorsSSBOCapacity = 0;
 
     // Shaders (no clear shader – cleared via glClearNamedBufferSubData)
     Shader* m_rasterShader  = nullptr;   // pointcloud_rasterize.comp
@@ -84,11 +97,13 @@ private:
     GLuint m_quadVBO = 0;
 
     // Cached rasterize-shader uniform locations (queried once at init)
-    GLint m_locImageSize      = -1;
-    GLint m_locNumPoints      = -1;
-    GLint m_locMVP            = -1;
-    GLint m_locPointBaseSize  = -1;
-    GLint m_locFieldOfView    = -1;
+    GLint m_locImageSize         = -1;
+    GLint m_locMVP               = -1;
+    GLint m_locModelView         = -1;
+    GLint m_locProj              = -1;
+    GLint m_locPointsPerThread   = -1;
+    GLint m_locPointBaseSize     = -1;
+    GLint m_locFieldOfView       = -1;
 
     // Cached resolve-shader uniform location
     GLint m_locResolveImageSize = -1;

--- a/StereoVista/headers/Engine/Data.h
+++ b/StereoVista/headers/Engine/Data.h
@@ -30,6 +30,23 @@ namespace Engine {
         glm::vec3 color;
     };
 
+    // GPU-side batch descriptor for the Schütz compute rasterizer.
+    // Each batch covers up to kComputeBatchSize contiguous points in the flat
+    // packed-coordinate SSBOs.  The bounding box (local space) lets the shader
+    // cull the whole batch with a single frustum test and decode quantised
+    // coordinates back to float.
+    //
+    // Layout must match the GLSL Batch struct in pointcloud_rasterize.comp
+    // (std430, 8 × 4 = 32 bytes, no padding required).
+    struct ComputeBatch {
+        float min_x, min_y, min_z;
+        float max_x, max_y, max_z;
+        int   numPoints;
+        int   firstPoint;
+    };
+    static_assert(sizeof(ComputeBatch) == 32,
+                  "ComputeBatch size mismatch – GLSL struct alignment will break");
+
     // Octree-based point cloud node
     struct PointCloudOctreeNode {
         // Node identification
@@ -110,6 +127,19 @@ namespace Engine {
         // buildOctree() clears the cpu-side points vector.
         uint32_t totalPointCount = 0;
 
+        // ── Schütz batch system (compute rasterizer) ─────────────────────────
+        // Points are partitioned into batches of kComputeBatchSize.  Per-batch
+        // bounding boxes enable a single frustum-cull test per workgroup, and
+        // coordinates are quantised to 10/20/30-bit integers to cut bandwidth.
+        static constexpr int kComputeBatchSize = 10240; // multiple of 128
+        GLuint computeBatchSSBO  = 0; // binding 40 – ComputeBatch descriptors
+        GLuint computeXyz12bSSBO = 0; // binding 41 – finest 10 bits per axis
+        GLuint computeXyz8bSSBO  = 0; // binding 42 – middle 10 bits per axis
+        GLuint computeXyz4bSSBO  = 0; // binding 43 – coarsest 10 bits per axis
+        GLuint computeRGBASSBO   = 0; // binding 44 – pre-packed uint RGBA
+        uint32_t numBatches           = 0;
+        int      computePointsPerThread = 0; // ceil(kComputeBatchSize / 128)
+
         float basePointSize = 2.0f;
 
         // Octree-based system
@@ -156,7 +186,14 @@ namespace Engine {
               useOctree(other.useOctree), useDiskCache(other.useDiskCache),
               totalLoadedNodes(other.totalLoadedNodes), chunkOutlineVAO(other.chunkOutlineVAO),
               chunkOutlineVBO(other.chunkOutlineVBO), chunkOutlineVertices(std::move(other.chunkOutlineVertices)),
-              visualizeOctree(other.visualizeOctree), visualizeDepth(other.visualizeDepth) {
+              visualizeOctree(other.visualizeOctree), visualizeDepth(other.visualizeDepth),
+              computeBatchSSBO(other.computeBatchSSBO),
+              computeXyz12bSSBO(other.computeXyz12bSSBO),
+              computeXyz8bSSBO(other.computeXyz8bSSBO),
+              computeXyz4bSSBO(other.computeXyz4bSSBO),
+              computeRGBASSBO(other.computeRGBASSBO),
+              numBatches(other.numBatches),
+              computePointsPerThread(other.computePointsPerThread) {
 
             // Copy lodDistances array
             for (int i = 0; i < 5; i++) {
@@ -169,6 +206,13 @@ namespace Engine {
             other.totalPointCount = 0;
             other.chunkOutlineVAO = 0;
             other.chunkOutlineVBO = 0;
+            other.computeBatchSSBO   = 0;
+            other.computeXyz12bSSBO  = 0;
+            other.computeXyz8bSSBO   = 0;
+            other.computeXyz4bSSBO   = 0;
+            other.computeRGBASSBO    = 0;
+            other.numBatches         = 0;
+            other.computePointsPerThread = 0;
         }
 
         // Move assignment operator
@@ -212,12 +256,27 @@ namespace Engine {
                 visualizeOctree = other.visualizeOctree;
                 visualizeDepth = other.visualizeDepth;
 
+                computeBatchSSBO        = other.computeBatchSSBO;
+                computeXyz12bSSBO       = other.computeXyz12bSSBO;
+                computeXyz8bSSBO        = other.computeXyz8bSSBO;
+                computeXyz4bSSBO        = other.computeXyz4bSSBO;
+                computeRGBASSBO         = other.computeRGBASSBO;
+                numBatches              = other.numBatches;
+                computePointsPerThread  = other.computePointsPerThread;
+
                 // Reset other object
                 other.vao = 0;
                 other.vbo = 0;
                 other.totalPointCount = 0;
                 other.chunkOutlineVAO = 0;
                 other.chunkOutlineVBO = 0;
+                other.computeBatchSSBO   = 0;
+                other.computeXyz12bSSBO  = 0;
+                other.computeXyz8bSSBO   = 0;
+                other.computeXyz4bSSBO   = 0;
+                other.computeRGBASSBO    = 0;
+                other.numBatches         = 0;
+                other.computePointsPerThread = 0;
             }
             return *this;
         }

--- a/StereoVista/src/Engine/ComputePointCloudRenderer.cpp
+++ b/StereoVista/src/Engine/ComputePointCloudRenderer.cpp
@@ -146,10 +146,6 @@ void ComputePointCloudRenderer::beginFrame() {
 
     // Bind framebuffer SSBO to slot 1 (matches shader binding)
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, m_framebufferSSBO);
-
-    // Bind rasterize shader once for the whole frame
-    m_rasterShader->use();
-    glUniform2i(m_locImageSize, m_width, m_height);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -170,6 +166,16 @@ void ComputePointCloudRenderer::renderNode(
 {
     if (!m_initialized || numBatches == 0) return;
     if (!batchSSBO || !xyz4bSSBO || !rgbaSSBO) return;
+
+    // Always re-bind the rasterize shader before setting uniforms.
+    // main.cpp calls shader->set*(…) on the *scene* shader between beginFrame()
+    // and renderNode().  Those methods use glGetUniformLocation on the scene
+    // shader's program ID, but issue glUniform* against the *currently-bound*
+    // program (our rasterize shader after beginFrame()).  A colliding location
+    // number would silently overwrite one of our uniforms, including uImageSize
+    // which is only set here and not anywhere else per-cloud.
+    m_rasterShader->use();
+    glUniform2i(m_locImageSize, m_width, m_height);
 
     // Bind packed-coordinate and batch SSBOs (matching shader bindings)
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 40, batchSSBO);

--- a/StereoVista/src/Engine/ComputePointCloudRenderer.cpp
+++ b/StereoVista/src/Engine/ComputePointCloudRenderer.cpp
@@ -44,7 +44,7 @@ void ComputePointCloudRenderer::init(int width, int height) {
         }
     }
 
-    // Load shaders (clear.comp is no longer needed – we use glClearNamedBufferSubData)
+    // Load shaders
     try {
         m_rasterShader = new Shader(
             "assets/shaders/core/pointcloud_rasterize.comp", Shader::ComputeShaderTag{});
@@ -60,14 +60,16 @@ void ComputePointCloudRenderer::init(int width, int height) {
 
     // Cache rasterize shader uniform locations
     m_rasterShader->use();
-    GLuint pid      = m_rasterShader->getID();
-    m_locImageSize     = glGetUniformLocation(pid, "uImageSize");
-    m_locNumPoints     = glGetUniformLocation(pid, "uNumPoints");
-    m_locMVP           = glGetUniformLocation(pid, "uMVP");
-    m_locPointBaseSize = glGetUniformLocation(pid, "uPointBaseSize");
-    m_locFieldOfView   = glGetUniformLocation(pid, "uFieldOfView");
+    GLuint pid = m_rasterShader->getID();
+    m_locImageSize        = glGetUniformLocation(pid, "uImageSize");
+    m_locMVP              = glGetUniformLocation(pid, "uMVP");
+    m_locModelView        = glGetUniformLocation(pid, "uModelView");
+    m_locProj             = glGetUniformLocation(pid, "uProj");
+    m_locPointsPerThread  = glGetUniformLocation(pid, "uPointsPerThread");
+    m_locPointBaseSize    = glGetUniformLocation(pid, "uPointBaseSize");
+    m_locFieldOfView      = glGetUniformLocation(pid, "uFieldOfView");
 
-    // Cache resolve shader uniform locations
+    // Cache resolve shader uniform location
     m_resolveShader->use();
     m_locResolveImageSize = glGetUniformLocation(m_resolveShader->getID(), "uImageSize");
 
@@ -77,13 +79,9 @@ void ComputePointCloudRenderer::init(int width, int height) {
     glBindVertexArray(m_quadVAO);
     glBindBuffer(GL_ARRAY_BUFFER, m_quadVBO);
     glBufferData(GL_ARRAY_BUFFER, sizeof(kQuadVerts), kQuadVerts, GL_STATIC_DRAW);
-    // location 0 → pos (vec2)
-    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE,
-                          4 * sizeof(float), (void*)0);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)0);
     glEnableVertexAttribArray(0);
-    // location 1 → uv (vec2)
-    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE,
-                          4 * sizeof(float), (void*)(2 * sizeof(float)));
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)(2 * sizeof(float)));
     glEnableVertexAttribArray(1);
     glBindVertexArray(0);
 
@@ -99,7 +97,6 @@ void ComputePointCloudRenderer::allocateBuffers() {
     int totalPixels = m_width * m_height;
 
     // Framebuffer SSBO: one uint64_t per pixel (depth:32 | point_index:32).
-    // Matches Schütz's ssFramebuffer exactly.
     glGenBuffers(1, &m_framebufferSSBO);
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, m_framebufferSSBO);
     glBufferData(GL_SHADER_STORAGE_BUFFER,
@@ -110,7 +107,6 @@ void ComputePointCloudRenderer::allocateBuffers() {
 
 void ComputePointCloudRenderer::freeBuffers() {
     if (m_framebufferSSBO) { glDeleteBuffers(1, &m_framebufferSSBO); m_framebufferSSBO = 0; }
-    if (m_colorsSSBO)      { glDeleteBuffers(1, &m_colorsSSBO);      m_colorsSSBO      = 0; }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -139,10 +135,6 @@ void ComputePointCloudRenderer::beginFrame() {
     if (!m_initialized) return;
 
     // Clear the framebuffer SSBO to 0xFFFFFFFFFFFFFFFF (sentinel: no point).
-    // glClearNamedBufferSubData is faster than a compute clear shader
-    // (single driver call, no shader dispatch overhead).
-    // We clear as GL_R32UI in two passes (high and low 32-bit halves) since
-    // OpenGL has no 64-bit clear format. Using 0xFFFFFFFF for both halves.
     GLuint clearVal = 0xFFFFFFFFu;
     glClearNamedBufferSubData(m_framebufferSSBO, GL_R32UI,
                               0,
@@ -162,43 +154,40 @@ void ComputePointCloudRenderer::beginFrame() {
 
 // ─────────────────────────────────────────────────────────────────────────────
 
-void ComputePointCloudRenderer::renderNode(GLuint vbo,
-                                           uint32_t numPoints,
-                                           const glm::mat4& mvp,
-                                           float pointBaseSize,
-                                           float fieldOfView) {
-    if (!m_initialized || numPoints == 0 || vbo == 0) return;
+void ComputePointCloudRenderer::renderNode(
+        GLuint batchSSBO,
+        GLuint xyz12bSSBO,
+        GLuint xyz8bSSBO,
+        GLuint xyz4bSSBO,
+        GLuint rgbaSSBO,
+        uint32_t numBatches,
+        int      pointsPerThread,
+        const glm::mat4& mvp,
+        const glm::mat4& modelView,
+        const glm::mat4& proj,
+        float pointBaseSize,
+        float fieldOfView)
+{
+    if (!m_initialized || numBatches == 0) return;
+    if (!batchSSBO || !xyz4bSSBO || !rgbaSSBO) return;
 
-    // Allocate (or reallocate) the per-point colour SSBO if needed.
-    // The colour SSBO is sized to the current cloud; reuse it if large enough.
-    if (m_colorsSSBO == 0 || m_colorsSSBOCapacity < numPoints) {
-        if (m_colorsSSBO) glDeleteBuffers(1, &m_colorsSSBO);
-        glGenBuffers(1, &m_colorsSSBO);
-        glBindBuffer(GL_SHADER_STORAGE_BUFFER, m_colorsSSBO);
-        glBufferData(GL_SHADER_STORAGE_BUFFER,
-                     numPoints * static_cast<GLsizeiptr>(sizeof(GLuint)),
-                     nullptr, GL_DYNAMIC_COPY);
-        m_colorsSSBOCapacity = numPoints;
-        glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
-    }
+    // Bind packed-coordinate and batch SSBOs (matching shader bindings)
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 40, batchSSBO);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 41, xyz12bSSBO);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 42, xyz8bSSBO);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 43, xyz4bSSBO);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 44, rgbaSSBO);
 
-    // Bind point data as SSBO slot 0 (VBOs can be used as SSBOs in OpenGL 4.6)
-    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, vbo);
-    // Bind per-point colour output buffer at slot 44 (matches Schütz's ssColors)
-    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 44, m_colorsSSBO);
+    // Per-cloud uniforms
+    glUniformMatrix4fv(m_locMVP,       1, GL_FALSE, glm::value_ptr(mvp));
+    glUniformMatrix4fv(m_locModelView, 1, GL_FALSE, glm::value_ptr(modelView));
+    glUniformMatrix4fv(m_locProj,      1, GL_FALSE, glm::value_ptr(proj));
+    glUniform1i(m_locPointsPerThread, pointsPerThread);
+    glUniform1f(m_locPointBaseSize,   pointBaseSize);
+    glUniform1f(m_locFieldOfView,     fieldOfView);
 
-    // Set per-cloud uniforms via cached locations (zero string lookups)
-    glUniformMatrix4fv(m_locMVP,          1, GL_FALSE, glm::value_ptr(mvp));
-    glUniform1f(m_locPointBaseSize, pointBaseSize);
-    glUniform1f(m_locFieldOfView,   fieldOfView);
-    glUniform1ui(m_locNumPoints,    numPoints);
-
-    // ONE dispatch covers the entire point cloud – matching Schütz's
-    // glDispatchCompute(numBatches, 1, 1) where numBatches = ceil(N / groupSize).
-    int groups = (static_cast<int>(numPoints) + 127) / 128;
-    glDispatchCompute(static_cast<GLuint>(groups), 1, 1);
-
-    // No per-cloud barrier – endFrame() issues a single barrier after all clouds.
+    // One workgroup per batch (matches Schütz's glDispatchCompute(numBatches,1,1))
+    glDispatchCompute(numBatches, 1, 1);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -210,10 +199,9 @@ void ComputePointCloudRenderer::endFrame() {
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 
     // ── Resolve / composite pass ────────────────────────────────────────────
-    // Framebuffer SSBO (binding 1) and colours SSBO (binding 44) remain bound
+    // Framebuffer SSBO (binding 1) and RGBA SSBO (binding 44) remain bound
     // from the rasterize pass; the fragment shader reads both.
 
-    // Save and disable depth test so we composite over the existing scene
     GLboolean depthWasEnabled = glIsEnabled(GL_DEPTH_TEST);
     GLboolean depthWriteWasOn;
     glGetBooleanv(GL_DEPTH_WRITEMASK, &depthWriteWasOn);
@@ -231,9 +219,12 @@ void ComputePointCloudRenderer::endFrame() {
     if (depthWasEnabled) glEnable(GL_DEPTH_TEST);
     if (depthWriteWasOn) glDepthMask(GL_TRUE);
 
-    // Unbind SSBOs to avoid hazards in subsequent render passes
-    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0,  0);
-    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1,  0);
+    // Unbind SSBOs
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER,  1, 0);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 40, 0);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 41, 0);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 42, 0);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 43, 0);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 44, 0);
 }
 

--- a/StereoVista/src/Loaders/PointCloudLoader.cpp
+++ b/StereoVista/src/Loaders/PointCloudLoader.cpp
@@ -444,16 +444,25 @@ namespace Engine {
             for (int i = first; i < last; i++) {
                 const glm::vec3& p = pts[i].position;
 
-                // Normalise to [0,1] within batch bounds, then scale to 30 bits
-                uint32_t Xbits = static_cast<uint32_t>(
-                    glm::clamp((p.x - bMin.x) / boxSize.x, 0.0f, 1.0f)
-                    * static_cast<float>(STEPS_30BIT - 1));
-                uint32_t Ybits = static_cast<uint32_t>(
-                    glm::clamp((p.y - bMin.y) / boxSize.y, 0.0f, 1.0f)
-                    * static_cast<float>(STEPS_30BIT - 1));
-                uint32_t Zbits = static_cast<uint32_t>(
-                    glm::clamp((p.z - bMin.z) / boxSize.z, 0.0f, 1.0f)
-                    * static_cast<float>(STEPS_30BIT - 1));
+                // Normalise to [0,1] within batch bounds, then scale to 30 bits.
+                //
+                // Important: STEPS_30BIT = 2^30 = 1073741824 is exactly representable
+                // as a float (it is a power of 2).  We multiply by that, then clamp
+                // the result to STEPS_30BIT-1 (= 0x3FFFFFFF, the maximum 30-bit value).
+                // This avoids the float-rounding trap: float(STEPS_30BIT - 1) rounds UP
+                // to STEPS_30BIT itself (since 1073741823 needs more than 24 mantissa
+                // bits), which would produce Xbits = 0x40000000 → X4 masked to 0 after
+                // & 0x3FF, making the maximum-coordinate point decode to wgMin.
+                auto quantise = [&](float v, float lo, float sz) -> uint32_t {
+                    float n = glm::clamp((v - lo) / sz, 0.0f, 1.0f);
+                    // Scale by exactly 2^30 (representable as float), then cap at 2^30-1
+                    uint32_t bits = static_cast<uint32_t>(n * static_cast<float>(STEPS_30BIT));
+                    return std::min(bits, static_cast<uint32_t>(STEPS_30BIT - 1));
+                };
+
+                uint32_t Xbits = quantise(p.x, bMin.x, boxSize.x);
+                uint32_t Ybits = quantise(p.y, bMin.y, boxSize.y);
+                uint32_t Zbits = quantise(p.z, bMin.z, boxSize.z);
 
                 // Split into three 10-bit tiers
                 // _4b  = high bits [29:20] → coarsest, always loaded

--- a/StereoVista/src/Loaders/PointCloudLoader.cpp
+++ b/StereoVista/src/Loaders/PointCloudLoader.cpp
@@ -369,6 +369,151 @@ namespace Engine {
     }
 
 
+    // ── buildComputeBatches ──────────────────────────────────────────────────
+    // Partitions the flat points vector into batches of kComputeBatchSize and
+    // builds four SSBOs that the Schütz compute rasterizer reads:
+    //
+    //   binding 40 – ComputeBatch descriptors (bounding box + range)
+    //   binding 41 – ssXyz_12b: lowest 10 bits of each 30-bit quantised axis
+    //   binding 42 – ssXyz_8b:  middle 10 bits
+    //   binding 43 – ssXyz_4b:  highest 10 bits (always read; coarsest alone
+    //                           gives 10-bit / 1024-step resolution per axis)
+    //   binding 44 – ssRGBA:    pre-packed uint RGBA (written once on CPU,
+    //                           read by the resolve fragment shader)
+    //
+    // Coordinate quantisation (matches Schütz exactly):
+    //   normalised = (pos - batchMin) / batchSize   ∈ [0,1]
+    //   bits30     = uint32( normalised * STEPS_30BIT )   (30-bit integer)
+    //   ssXyz_4b   packs  bits30[29:20]  for X,Y,Z into one uint
+    //   ssXyz_8b   packs  bits30[19:10]
+    //   ssXyz_12b  packs  bits30[ 9: 0]
+    //
+    // The shader decodes with the inverse of this transform using the batch
+    // bounding box stored in ssBatches.
+    static void buildComputeBatches(PointCloud& pc) {
+        const auto& pts      = pc.points;
+        const int   N        = static_cast<int>(pts.size());
+        const int   batchSz  = PointCloud::kComputeBatchSize;
+
+        if (N == 0) return;
+
+        // Delete old SSBOs if this cloud is being re-uploaded
+        auto deleteIfNonZero = [](GLuint& id) {
+            if (id) { glDeleteBuffers(1, &id); id = 0; }
+        };
+        deleteIfNonZero(pc.computeBatchSSBO);
+        deleteIfNonZero(pc.computeXyz12bSSBO);
+        deleteIfNonZero(pc.computeXyz8bSSBO);
+        deleteIfNonZero(pc.computeXyz4bSSBO);
+        deleteIfNonZero(pc.computeRGBASSBO);
+
+        pc.numBatches = static_cast<uint32_t>((N + batchSz - 1) / batchSz);
+        // Each thread handles ceil(batchSz / 128) points
+        pc.computePointsPerThread = (batchSz + 127) / 128;
+
+        std::vector<ComputeBatch> batches(pc.numBatches);
+        std::vector<uint32_t> xyz4b(N), xyz8b(N), xyz12b(N), rgba(N);
+
+        constexpr int   STEPS_30BIT = 1073741824; // 2^30
+        constexpr uint32_t MASK_10BIT = 1023u;
+
+        for (uint32_t b = 0; b < pc.numBatches; b++) {
+            const int first = b * batchSz;
+            const int last  = std::min(first + batchSz, N);
+            const int count = last - first;
+
+            // Per-batch bounding box
+            glm::vec3 bMin = pts[first].position;
+            glm::vec3 bMax = pts[first].position;
+            for (int i = first + 1; i < last; i++) {
+                bMin = glm::min(bMin, pts[i].position);
+                bMax = glm::max(bMax, pts[i].position);
+            }
+
+            // Guard against degenerate (zero-size) batches
+            glm::vec3 boxSize = bMax - bMin;
+            if (boxSize.x < 1e-6f) boxSize.x = 1e-6f;
+            if (boxSize.y < 1e-6f) boxSize.y = 1e-6f;
+            if (boxSize.z < 1e-6f) boxSize.z = 1e-6f;
+
+            batches[b] = { bMin.x, bMin.y, bMin.z,
+                           bMax.x, bMax.y, bMax.z,
+                           count, first };
+
+            // Quantise each point and pack per-axis 10-bit groups
+            for (int i = first; i < last; i++) {
+                const glm::vec3& p = pts[i].position;
+
+                // Normalise to [0,1] within batch bounds, then scale to 30 bits
+                uint32_t Xbits = static_cast<uint32_t>(
+                    glm::clamp((p.x - bMin.x) / boxSize.x, 0.0f, 1.0f)
+                    * static_cast<float>(STEPS_30BIT - 1));
+                uint32_t Ybits = static_cast<uint32_t>(
+                    glm::clamp((p.y - bMin.y) / boxSize.y, 0.0f, 1.0f)
+                    * static_cast<float>(STEPS_30BIT - 1));
+                uint32_t Zbits = static_cast<uint32_t>(
+                    glm::clamp((p.z - bMin.z) / boxSize.z, 0.0f, 1.0f)
+                    * static_cast<float>(STEPS_30BIT - 1));
+
+                // Split into three 10-bit tiers
+                // _4b  = high bits [29:20] → coarsest, always loaded
+                // _8b  = mid  bits [19:10]
+                // _12b = low  bits [ 9: 0] → finest, level-0 only
+                uint32_t X4 = (Xbits >> 20) & MASK_10BIT;
+                uint32_t Y4 = (Ybits >> 20) & MASK_10BIT;
+                uint32_t Z4 = (Zbits >> 20) & MASK_10BIT;
+
+                uint32_t X8 = (Xbits >> 10) & MASK_10BIT;
+                uint32_t Y8 = (Ybits >> 10) & MASK_10BIT;
+                uint32_t Z8 = (Zbits >> 10) & MASK_10BIT;
+
+                uint32_t X12 = Xbits & MASK_10BIT;
+                uint32_t Y12 = Ybits & MASK_10BIT;
+                uint32_t Z12 = Zbits & MASK_10BIT;
+
+                // Pack three 10-bit values into one uint (same layout as Schütz)
+                xyz4b [i] = X4  | (Y4  << 10) | (Z4  << 20);
+                xyz8b [i] = X8  | (Y8  << 10) | (Z8  << 20);
+                xyz12b[i] = X12 | (Y12 << 10) | (Z12 << 20);
+
+                // Pre-pack colour to uint ABGR (alpha=FF, then B, G, R)
+                const auto& c = pts[i].color;
+                uint32_t r8 = static_cast<uint32_t>(glm::clamp(c.r, 0.0f, 1.0f) * 255.0f + 0.5f);
+                uint32_t g8 = static_cast<uint32_t>(glm::clamp(c.g, 0.0f, 1.0f) * 255.0f + 0.5f);
+                uint32_t b8 = static_cast<uint32_t>(glm::clamp(c.b, 0.0f, 1.0f) * 255.0f + 0.5f);
+                rgba[i] = (0xFFu << 24) | (b8 << 16) | (g8 << 8) | r8;
+            }
+        }
+
+        // Upload all four SSBOs
+        auto uploadSSBO = [](GLuint& id, const void* data, GLsizeiptr bytes) {
+            glGenBuffers(1, &id);
+            glBindBuffer(GL_SHADER_STORAGE_BUFFER, id);
+            glBufferData(GL_SHADER_STORAGE_BUFFER, bytes, data, GL_STATIC_DRAW);
+            glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+        };
+
+        uploadSSBO(pc.computeBatchSSBO,
+                   batches.data(),
+                   static_cast<GLsizeiptr>(batches.size() * sizeof(ComputeBatch)));
+        uploadSSBO(pc.computeXyz4bSSBO,
+                   xyz4b.data(),
+                   static_cast<GLsizeiptr>(N * sizeof(uint32_t)));
+        uploadSSBO(pc.computeXyz8bSSBO,
+                   xyz8b.data(),
+                   static_cast<GLsizeiptr>(N * sizeof(uint32_t)));
+        uploadSSBO(pc.computeXyz12bSSBO,
+                   xyz12b.data(),
+                   static_cast<GLsizeiptr>(N * sizeof(uint32_t)));
+        uploadSSBO(pc.computeRGBASSBO,
+                   rgba.data(),
+                   static_cast<GLsizeiptr>(N * sizeof(uint32_t)));
+
+        std::cout << "[ComputePC] Built " << pc.numBatches << " batches ("
+                  << N << " points, " << pc.computePointsPerThread
+                  << " pts/thread, batch size " << batchSz << ")\n";
+    }
+
     void PointCloudLoader::setupPointCloudGLBuffers(PointCloud& pointCloud) {
         glGenVertexArrays(1, &pointCloud.vao);
         glGenBuffers(1, &pointCloud.vbo);
@@ -391,6 +536,9 @@ namespace Engine {
         glEnableVertexAttribArray(2);
 
         glBindVertexArray(0);
+
+        // Build Schütz-style packed SSBOs for the compute rasterizer path
+        buildComputeBatches(pointCloud);
     }
 
     PointCloud PointCloudLoader::loadFromHDF5(const std::string& filePath, size_t downsampleFactor) {

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -3519,6 +3519,12 @@ void cleanup() {
   for (auto &pointCloud : currentScene.pointClouds) {
     glDeleteVertexArrays(1, &pointCloud.vao);
     glDeleteBuffers(1, &pointCloud.vbo);
+    // Schütz batch SSBOs (compute rasterizer path)
+    if (pointCloud.computeBatchSSBO)  glDeleteBuffers(1, &pointCloud.computeBatchSSBO);
+    if (pointCloud.computeXyz4bSSBO)  glDeleteBuffers(1, &pointCloud.computeXyz4bSSBO);
+    if (pointCloud.computeXyz8bSSBO)  glDeleteBuffers(1, &pointCloud.computeXyz8bSSBO);
+    if (pointCloud.computeXyz12bSSBO) glDeleteBuffers(1, &pointCloud.computeXyz12bSSBO);
+    if (pointCloud.computeRGBASSBO)   glDeleteBuffers(1, &pointCloud.computeRGBASSBO);
   }
 
   // Delete triangle buffer resources
@@ -5256,15 +5262,20 @@ void renderPointClouds(Engine::Shader *shader,
     shader->setBool("isPointCloud", true);
 
     if (useCompute) {
-      // Schütz compute path: single dispatch over the entire flat VBO.
-      // No octree traversal, no LOD selection, no per-node API calls.
-      // pointCloud.vbo was fully uploaded by setupPointCloudGLBuffers() before
-      // buildOctree() cleared pointCloud.points.
-      if (pointCloud.vbo != 0 && pointCloud.totalPointCount > 0) {
+      // Schütz compute path: one workgroup per batch, with per-batch frustum
+      // culling and packed 10/20/30-bit coordinate decoding.
+      if (pointCloud.computeBatchSSBO != 0 && pointCloud.numBatches > 0) {
         computePointCloudRenderer->renderNode(
-            pointCloud.vbo,
-            pointCloud.totalPointCount,
-            projection * view * modelMatrix,
+            pointCloud.computeBatchSSBO,
+            pointCloud.computeXyz12bSSBO,
+            pointCloud.computeXyz8bSSBO,
+            pointCloud.computeXyz4bSSBO,
+            pointCloud.computeRGBASSBO,
+            pointCloud.numBatches,
+            pointCloud.computePointsPerThread,
+            projection * view * modelMatrix,    // uMVP
+            view * modelMatrix,                  // uModelView (for precision level)
+            projection,                          // uProj      (for precision level)
             preferences.pointCloudBaseSize,
             glm::radians(preferences.fov));
       }


### PR DESCRIPTION
Ports two improvements from m-schuetz/compute_rasterizer (standard method)
into the StereoVista compute point-cloud pipeline:

1. Per-batch frustum culling
   Points are now partitioned into batches of 10 240 (kComputeBatchSize).
   Each batch stores a bounding box in a ComputeBatch SSBO (binding 40).
   The compute shader dispatches one workgroup per batch; the first thing
   each workgroup does is test its AABB against the 6 MVP clip planes
   (Gribb/Hartmann, adapted from Schütz/three.js).  Fully-outside batches
   return immediately, replacing up to 10 240 per-point clip-space transforms
   with a single 6-plane AABB test.

2. Packed 10/20/30-bit quantised coordinates
   Positions are quantised per-batch relative to the batch bounding box and
   stored in three uint SSBOs (bindings 41-43), 4 bytes per point per tier:
     _4b  [29:20] – coarsest, always loaded
     _8b  [19:10] – medium, loaded at precision levels 0-1
     _12b [ 9: 0] – finest, loaded only at level 0
   getPrecisionLevel() (Schütz verbatim) projects the batch bounding sphere
   and selects the tier based on screen pixel size (thresholds 100/200/500/
   10000 px).  This reduces per-point bandwidth from 28 bytes (7×float32)
   to 4-12 bytes.  Per-point RGBA is pre-packed on the CPU at load time and
   uploaded to a separate SSBO (binding 44, read by the resolve shader).

Files changed:
  Data.h                      – ComputeBatch struct; new SSBO handles in PointCloud
  PointCloudLoader.cpp        – buildComputeBatches() called from setupPointCloudGLBuffers
  pointcloud_rasterize.comp   – full rewrite: batch dispatch, frustum cull, packed decode
  ComputePointCloudRenderer.h – new renderNode signature
  ComputePointCloudRenderer.cpp – bind new SSBOs; dispatch numBatches workgroups
  main.cpp                    – pass batch SSBOs to renderNode; clean up on exit

https://claude.ai/code/session_01KHtN3ptRkaXXby4RVVcjWq