### PR TITLE
Fix MSVC compiler warnings and errors

### DIFF
--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -247,12 +247,12 @@ static void ShowIconTestWindow() {
   ImGui::Text("Try different codes:");
 
   // Test with manual UTF-8 encoding of 0xF0EB
-  char manual_lightbulb[4] = {0xEF, 0x83, 0xAB,
+  char manual_lightbulb[4] = {(char)0xEF, (char)0x83, (char)0xAB,
                               0x00}; // UTF-8 encoding of U+F0EB
   ImGui::Text("Manual UTF-8 lightbulb: %s", manual_lightbulb);
 
   // Test with other manual codes
-  char manual_star[4] = {0xEF, 0x80, 0x85, 0x00}; // UTF-8 encoding of U+F005
+  char manual_star[4] = {(char)0xEF, (char)0x80, (char)0x85, 0x00}; // UTF-8 encoding of U+F005
   ImGui::Text("Manual UTF-8 star: %s", manual_star);
 
   // Test with known working characters

--- a/StereoVista/src/Loaders/PointCloudLoader.cpp
+++ b/StereoVista/src/Loaders/PointCloudLoader.cpp
@@ -374,17 +374,17 @@ namespace Engine {
                 float x, y, z, intensity = 1.0f;
                 int   r = 255, g = 255, b = 255;
 
-                const int n7 = sscanf(lineData,
-                                      "%f %f %f %f %d %d %d",
-                                      &x, &y, &z, &intensity, &r, &g, &b);
+                const int n7 = sscanf_s(lineData,
+                                        "%f %f %f %f %d %d %d",
+                                        &x, &y, &z, &intensity, &r, &g, &b);
                 if (n7 == 7) {
                     // XYZIRGB – all fields present, nothing to do
                 } else {
                     // Re-try with integer 4th field to detect XYZRGB
                     int ri = 255;
-                    const int n6 = sscanf(lineData,
-                                         "%f %f %f %d %d %d",
-                                         &x, &y, &z, &ri, &g, &b);
+                    const int n6 = sscanf_s(lineData,
+                                            "%f %f %f %d %d %d",
+                                            &x, &y, &z, &ri, &g, &b);
                     if (n6 == 6) {
                         // XYZRGB (no intensity column)
                         r = ri;
@@ -423,13 +423,13 @@ namespace Engine {
             if ((first >= '0' && first <= '9') || first == '-' || first == '+') {
                 float x, y, z, intensity = 1.0f;
                 int   r = 255, g = 255, b = 255;
-                const int n7 = sscanf(lineData, "%f %f %f %f %d %d %d",
-                                      &x, &y, &z, &intensity, &r, &g, &b);
+                const int n7 = sscanf_s(lineData, "%f %f %f %f %d %d %d",
+                                        &x, &y, &z, &intensity, &r, &g, &b);
                 bool valid = true;
                 if (n7 < 7) {
                     int ri = 255;
-                    const int n6 = sscanf(lineData, "%f %f %f %d %d %d",
-                                         &x, &y, &z, &ri, &g, &b);
+                    const int n6 = sscanf_s(lineData, "%f %f %f %d %d %d",
+                                            &x, &y, &z, &ri, &g, &b);
                     if (n6 == 6)      { r = ri; intensity = 1.0f; }
                     else if (n7 >= 4) { r = g = b = 255; }
                     else if (n7 == 3 || n6 >= 3) { intensity = 1.0f; r = g = b = 255; }
@@ -1526,7 +1526,9 @@ namespace Engine {
             std::time_t time = std::chrono::system_clock::to_time_t(now);
             
             char timeBuffer[26] = {};
-            std::strftime(timeBuffer, sizeof(timeBuffer), "%c", std::localtime(&time));
+            struct tm tmInfo = {};
+            localtime_s(&tmInfo, &time);
+            std::strftime(timeBuffer, sizeof(timeBuffer), "%c", &tmInfo);
             std::string timeStr(timeBuffer);
             
             StrType timeStringType(PredType::C_S1, timeStr.length() + 1);


### PR DESCRIPTION
- GUI.cpp: Cast hex literals to (char) to resolve C4838 narrowing
  conversion warnings in UTF-8 char array initializers
- PointCloudLoader.cpp: Replace sscanf with sscanf_s to fix C4996
  deprecation errors (4 call sites, numeric-only format strings)
- PointCloudLoader.cpp: Replace localtime with localtime_s to fix
  C4996 deprecation error, using the (tm*, time_t*) signature

https://claude.ai/code/session_012AP8pryd5kFRuBQ5QGjgZo