### PR TITLE
Fix auto-convergence depth buffer reading in stereo+HDR mode

### DIFF
--- a/StereoVista/headers/Core/Camera.h
+++ b/StereoVista/headers/Core/Camera.h
@@ -648,13 +648,11 @@ public:
       return farPlane;
     }
 
-    // Check if OpenGL context is current (basic validation)
-    GLint currentFBO;
-    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &currentFBO);
-    GLenum error = glGetError();
-    if (error != GL_NO_ERROR) {
-      return farPlane; // OpenGL context issue
-    }
+    // Drain any pending OpenGL errors from previous operations so they don't
+    // prematurely abort the depth sampling (e.g. errors from the cursor
+    // subsystem calling glReadBuffer on a custom FBO).
+    while (glGetError() != GL_NO_ERROR) {}
+    GLenum error;
 
     const int numSamples = 9;     // 3x3 sampling grid
     const int sampleOffset = 100; // Pixel offset from center

--- a/StereoVista/src/Cursors/Base/CursorManager.cpp
+++ b/StereoVista/src/Cursors/Base/CursorManager.cpp
@@ -143,6 +143,15 @@ void CursorManager::updateCursorPosition(
     float leftDepth = 0.0;
     float rightDepth = 0.0;
 
+    // GL_BACK_LEFT/RIGHT are only valid on the default framebuffer (FBO 0).
+    // If an HDR FBO is currently bound, calling glReadBuffer with a stereo
+    // back-buffer enum generates GL_INVALID_OPERATION, which then poisons
+    // subsequent glGetError() checks in other subsystems (e.g. the auto-
+    // convergence depth read). Save and restore the read FBO around these calls.
+    GLint prevReadFBO;
+    glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &prevReadFBO);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+
     // Read depth from left eye buffer
     glReadBuffer(GL_BACK_LEFT);
     glReadPixels(m_lastX, (float)m_windowHeight - m_lastY, 1, 1,
@@ -152,6 +161,9 @@ void CursorManager::updateCursorPosition(
     glReadBuffer(GL_BACK_RIGHT);
     glReadPixels(m_lastX, (float)m_windowHeight - m_lastY, 1, 1,
                  GL_DEPTH_COMPONENT, GL_FLOAT, &rightDepth);
+
+    // Restore the previous read framebuffer
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, prevReadFBO);
 
     // Determine which eye has geometry (depth < threshold means hit on actual
     // geometry, not skybox)

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -4909,6 +4909,16 @@ void renderEye(GLenum drawBuffer, const glm::mat4 &projection,
   }
 
   if (!distanceCalculatedThisFrame) {
+    // Explicitly bind the correct read framebuffer before depth sampling.
+    // The scene was rendered into the HDR FBO (when HDR is on) or the default
+    // framebuffer (non-HDR). Using GL_READ_FRAMEBUFFER leaves the draw
+    // framebuffer untouched so ongoing rendering is not disrupted.
+    if (preferences.hdrSettings.enabled && bloomRenderer != nullptr) {
+      Engine::BloomSettings &bloomSettings = bloomRenderer->getSettings();
+      glBindFramebuffer(GL_READ_FRAMEBUFFER, bloomSettings.hdrFBO);
+    } else {
+      glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+    }
     float distanceToNearestObject = camera.getDistanceToNearestObject(
         camera, projection, view, preferences.farPlane, windowWidth,
         windowHeight);


### PR DESCRIPTION
Root cause: In stereo+HDR mode, CursorManager::updateCursorPosition() was
called while the HDR FBO was still bound. The stereo branch called
glReadBuffer(GL_BACK_LEFT/RIGHT), which is only valid on the default
framebuffer (FBO 0). With a custom FBO bound, OpenGL generated
GL_INVALID_OPERATION, poisoning the error queue. On the next frame,
getDistanceToNearestObject() detected the stale error and returned farPlane
without reading any depth, causing preferences.convergence to stay fixed at
its initial value.

Three-part fix:
1. CursorManager.cpp: Save/bind FBO 0/restore around glReadBuffer calls
   so GL_BACK_LEFT/RIGHT are called on a valid target.
2. Camera.h getDistanceToNearestObject(): Drain the GL error queue with a
   while loop instead of early-exiting on the first pending error, making
   the depth sampling robust against stale errors from other subsystems.
3. main.cpp renderEye(): Explicitly bind the correct read framebuffer
   (hdrFBO in HDR mode, FBO 0 otherwise) before calling
   getDistanceToNearestObject() so depth is always sampled from the buffer
   the scene was rendered into.

https://claude.ai/code/session_01PM3LkakVT4cPqqtf9Ws74t