### PR TITLE
Fix point cloud / mesh depth interaction

### DIFF
--- a/StereoVista/assets/shaders/core/pointcloud_rasterize.comp
+++ b/StereoVista/assets/shaders/core/pointcloud_rasterize.comp
@@ -257,8 +257,13 @@ void main() {
         ivec2 px = ivec2((ndc.xy * 0.5 + 0.5) * vec2(uImageSize));
 
         // ── Depth + index packed into 64 bits ─────────────────────────────────
-        // floatBitsToUint preserves IEEE-754 sort order → atomicMin works as depth test
-        uint     depth = floatBitsToUint(clip.w);
+        // Store NDC depth in [0,1] so it can be written directly to the OpenGL
+        // depth buffer during the resolve pass, enabling correct point/mesh
+        // depth interaction.  floatBitsToUint on a [0,1] float still preserves
+        // IEEE-754 sort order → atomicMin still works as a correct depth test.
+        float    ndc_z   = clip.z / clip.w;      // NDC z in [-1, 1]
+        float    depth01 = ndc_z * 0.5 + 0.5;   // map to OpenGL [0, 1] depth range
+        uint     depth   = floatBitsToUint(depth01);
         uint64_t entry = (uint64_t(depth) << 32UL) | uint64_t(index);
 
         // ── Single-pixel write (matches Schütz's basic compute_loop_las) ──────

--- a/StereoVista/assets/shaders/core/pointcloud_rasterize.comp
+++ b/StereoVista/assets/shaders/core/pointcloud_rasterize.comp
@@ -259,10 +259,10 @@ void main() {
         // ── Depth + index packed into 64 bits ─────────────────────────────────
         // Store NDC depth in [0,1] so it can be written directly to the OpenGL
         // depth buffer during the resolve pass, enabling correct point/mesh
-        // depth interaction.  floatBitsToUint on a [0,1] float still preserves
-        // IEEE-754 sort order → atomicMin still works as a correct depth test.
-        float    ndc_z   = clip.z / clip.w;      // NDC z in [-1, 1]
-        float    depth01 = ndc_z * 0.5 + 0.5;   // map to OpenGL [0, 1] depth range
+        // depth interaction.  ndc.z is already computed and guarded ∈ [-1,1]
+        // above.  floatBitsToUint on a [0,1] float preserves IEEE-754 sort
+        // order → atomicMin still works as a correct depth test.
+        float    depth01 = ndc.z * 0.5 + 0.5;   // map NDC z [-1,1] → OpenGL [0,1]
         uint     depth   = floatBitsToUint(depth01);
         uint64_t entry = (uint64_t(depth) << 32UL) | uint64_t(index);
 

--- a/StereoVista/assets/shaders/core/pointcloud_resolve.frag
+++ b/StereoVista/assets/shaders/core/pointcloud_resolve.frag
@@ -31,6 +31,12 @@ void main() {
     // Sentinel: no point was rasterised here – keep the scene pixel.
     if (entry == 0xFFFFFFFFFFFFFFFFUL) discard;
 
+    // Write the point's NDC depth [0,1] so the hardware depth test compares it
+    // against the existing depth buffer (written by mesh rendering).  Points
+    // behind meshes are discarded; points in front overwrite the mesh pixel.
+    uint depth_uint = uint(entry >> 32UL);
+    gl_FragDepth    = uintBitsToFloat(depth_uint);
+
     // Extract point index from the low 32 bits.
     uint idx    = uint(entry & 0xFFFFFFFFUL);
     uint packed = packedColor[idx];

--- a/StereoVista/src/Engine/ComputePointCloudRenderer.cpp
+++ b/StereoVista/src/Engine/ComputePointCloudRenderer.cpp
@@ -201,11 +201,18 @@ void ComputePointCloudRenderer::endFrame() {
     // Framebuffer SSBO (binding 1) and RGBA SSBO (binding 44) remain bound
     // from the rasterize pass; the fragment shader reads both.
 
+    // Enable depth testing so the resolve pass correctly handles point/mesh
+    // occlusion: points behind meshes are discarded, points in front overwrite
+    // the mesh colour and update the depth buffer.
     GLboolean depthWasEnabled = glIsEnabled(GL_DEPTH_TEST);
     GLboolean depthWriteWasOn;
     glGetBooleanv(GL_DEPTH_WRITEMASK, &depthWriteWasOn);
-    glDisable(GL_DEPTH_TEST);
-    glDepthMask(GL_FALSE);
+    GLint prevDepthFunc;
+    glGetIntegerv(GL_DEPTH_FUNC, &prevDepthFunc);
+
+    glEnable(GL_DEPTH_TEST);
+    glDepthFunc(GL_LESS);
+    glDepthMask(GL_TRUE);
 
     m_resolveShader->use();
     glUniform2i(m_locResolveImageSize, m_width, m_height);
@@ -215,8 +222,9 @@ void ComputePointCloudRenderer::endFrame() {
     glBindVertexArray(0);
 
     // Restore depth state
-    if (depthWasEnabled) glEnable(GL_DEPTH_TEST);
-    if (depthWriteWasOn) glDepthMask(GL_TRUE);
+    if (!depthWasEnabled) glDisable(GL_DEPTH_TEST);
+    glDepthFunc(prevDepthFunc);
+    if (!depthWriteWasOn) glDepthMask(GL_FALSE);
 
     // Unbind SSBOs
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER,  1, 0);


### PR DESCRIPTION
Point clouds and meshes now correctly occlude each other.

Previously the compute rasteriser stored clip.w (not an OpenGL-compatible
depth) in the SSBO and the resolve pass disabled GL_DEPTH_TEST / GL_DEPTH_MASK
entirely, so point pixels blindly overwrote mesh pixels regardless of depth.

Three coordinated changes:
- pointcloud_rasterize.comp: pack NDC depth [0,1] (clip.z/clip.w * 0.5 + 0.5)
  instead of clip.w. floatBitsToUint on [0,1] floats still preserves sort
  order, so atomicMin continues to select the closest point per pixel.
- pointcloud_resolve.frag: after the sentinel discard, extract the NDC depth
  from the high 32 bits of the SSBO entry and write it to gl_FragDepth. This
  makes OpenGL compare the point's depth against the mesh depth buffer value.
- ComputePointCloudRenderer.cpp endFrame(): enable GL_DEPTH_TEST (GL_LESS) and
  GL_DEPTH_MASK during the resolve quad draw instead of disabling them.

Result: points behind meshes are discarded by the depth test; points in front
overwrite the mesh colour and update the depth buffer. EDL also improves
because depthTexture now contains point cloud depths at mixed-content edges.

https://claude.ai/code/session_01B6vKrNxZyKZUCdpYrDyadG