### PR TITLE
Fix type conversion errors: narrowing char casts and glm::max overload

### DIFF
--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -247,12 +247,12 @@ static void ShowIconTestWindow() {
   ImGui::Text("Try different codes:");
 
   // Test with manual UTF-8 encoding of 0xF0EB
-  char manual_lightbulb[4] = {0xEF, 0x83, 0xAB,
+  char manual_lightbulb[4] = {(char)0xEF, (char)0x83, (char)0xAB,
                               0x00}; // UTF-8 encoding of U+F0EB
   ImGui::Text("Manual UTF-8 lightbulb: %s", manual_lightbulb);
 
   // Test with other manual codes
-  char manual_star[4] = {0xEF, 0x80, 0x85, 0x00}; // UTF-8 encoding of U+F005
+  char manual_star[4] = {(char)0xEF, (char)0x80, (char)0x85, 0x00}; // UTF-8 encoding of U+F005
   ImGui::Text("Manual UTF-8 star: %s", manual_star);
 
   // Test with known working characters

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -5125,7 +5125,7 @@ void renderModels(Engine::Shader *shader, const glm::mat4 &viewProj) {
     // Frustum culling: skip models whose bounding sphere is outside the view frustum
     if (model.boundingSphereRadius > 0.0f) {
       glm::vec3 worldCenter = glm::vec3(modelMatrix * glm::vec4(model.localBoundsCenter, 1.0f));
-      float maxScale = glm::max({model.scale.x, model.scale.y, model.scale.z});
+      float maxScale = glm::max(model.scale.x, glm::max(model.scale.y, model.scale.z));
       float worldRadius = model.boundingSphereRadius * maxScale;
       if (!camera.isInFrustum(worldCenter, worldRadius, viewProj))
         continue;


### PR DESCRIPTION
- Cast hex literals > 127 to (char) in GUI.cpp to fix C4838 narrowing conversion warnings
- Replace glm::max initializer list with nested glm::max calls in main.cpp to fix C2672 no matching overload error on MSVC

https://claude.ai/code/session_0173Php7asWNwHK5tuv8RbWy