### PR TITLE
Fix SSAO performance: upload kernel samples once at init, not every frame

### DIFF
--- a/StereoVista/src/Engine/SSAORenderer.cpp
+++ b/StereoVista/src/Engine/SSAORenderer.cpp
@@ -34,6 +34,13 @@ bool SSAORenderer::initialize(int width, int height) {
   generateNoiseTexture();
   setupQuad();
 
+  // Upload kernel samples once — they never change after generation
+  m_ssaoShader->use();
+  for (unsigned int i = 0; i < 64; ++i) {
+    m_ssaoShader->setVec3("samples[" + std::to_string(i) + "]",
+                          m_ssaoKernel[i]);
+  }
+
   m_initialized = true;
   return true;
 }
@@ -365,11 +372,6 @@ void SSAORenderer::computeSSAO(const glm::mat4 &projection) {
 
   m_ssaoShader->use();
 
-  // Send kernel samples
-  for (unsigned int i = 0; i < 64; ++i) {
-    m_ssaoShader->setVec3("samples[" + std::to_string(i) + "]",
-                          m_ssaoKernel[i]);
-  }
   m_ssaoShader->setMat4("projection", projection);
   m_ssaoShader->setInt("kernelSize", m_settings.kernelSize);
   m_ssaoShader->setFloat("radius", m_settings.radius);


### PR DESCRIPTION
The 64 sample kernel uniforms were being sent via string-format loops on
every call to computeSSAO(). Since the kernel never changes after
generateSampleKernel(), they are now uploaded once at the end of
initialize() and removed from the per-frame path.

https://claude.ai/code/session_01FYahJVWUrsptLGk3uJfX7q