### PR TITLE
Fix GPU stalls caused by synchronous depth readback and missing SSBO barrier

### DIFF
--- a/StereoVista/headers/Cursors/Base/CursorManager.h
+++ b/StereoVista/headers/Cursors/Base/CursorManager.h
@@ -141,6 +141,13 @@ private:
   // Position locking
   bool m_positionLocked;
 
+  // Async depth PBO for cursor position (avoids per-frame glReadPixels stall).
+  // Pattern: kick off async read each frame; consume previous frame's result
+  // via a fence sync (non-blocking poll). 0-or-1-frame latency is imperceptible.
+  GLuint m_depthPBO    = 0;
+  GLsync m_depthFence  = nullptr;
+  float  m_cachedDepth = 1.0f;
+
   // Helper function to calculate background cursor position
   glm::vec3 calculateBackgroundCursorPosition(GLFWwindow *window,
                                               const glm::mat4 &projection,

--- a/StereoVista/src/Cursors/Base/CursorManager.cpp
+++ b/StereoVista/src/Cursors/Base/CursorManager.cpp
@@ -33,6 +33,12 @@ void CursorManager::initialize() {
 
   m_windowWidth = windowWidth;
   m_windowHeight = windowHeight;
+
+  // Allocate 1-float PBO for async cursor depth readback.
+  glGenBuffers(1, &m_depthPBO);
+  glBindBuffer(GL_PIXEL_PACK_BUFFER, m_depthPBO);
+  glBufferData(GL_PIXEL_PACK_BUFFER, sizeof(float), nullptr, GL_STREAM_READ);
+  glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 }
 
 // Updates 3D cursor position based on mouse position and depth buffer
@@ -127,61 +133,45 @@ void CursorManager::updateCursorPosition(
     return;
   }
 
-  // Read depth at cursor position
-  float depth = 0.0;
-
   // Depth threshold for detecting skybox/background (anything at or very close
   // to far plane)
   const float DEPTH_THRESHOLD = 0.9999f;
 
-  if (isStereo && leftProjection != nullptr && leftView != nullptr &&
-      rightProjection != nullptr && rightView != nullptr) {
-    // In stereo mode, check both eye buffers to find which has geometry under
-    // the cursor The 3D cursor should be rendered if EITHER eye has an object
-    // under the cursor The Windows cursor should only be displayed when BOTH
-    // eyes are over background
-    float leftDepth = 0.0;
-    float rightDepth = 0.0;
-
-    // Read depth from left eye buffer.
-    // glReadPixels(GL_DEPTH_COMPONENT) reads the depth attachment of
-    // GL_READ_FRAMEBUFFER regardless of glReadBuffer — glReadBuffer only
-    // affects color reads. main.cpp binds the correct read FBO (hdrFBO in HDR
-    // mode, FBO 0 otherwise) before calling updateCursorPosition, so we simply
-    // read from whatever is currently bound.
-    glReadPixels(m_lastX, (float)m_windowHeight - m_lastY, 1, 1,
-                 GL_DEPTH_COMPONENT, GL_FLOAT, &leftDepth);
-
-    // Read depth from right eye buffer (same FBO, same depth attachment)
-    glReadPixels(m_lastX, (float)m_windowHeight - m_lastY, 1, 1,
-                 GL_DEPTH_COMPONENT, GL_FLOAT, &rightDepth);
-
-    // Determine which eye has geometry (depth < threshold means hit on actual
-    // geometry, not skybox)
-    bool leftHit = leftDepth < DEPTH_THRESHOLD;
-    bool rightHit = rightDepth < DEPTH_THRESHOLD;
-
-    // 3D cursor should render if EITHER eye has a hit (OR logic)
-    // Windows cursor only if BOTH are on background (neither has hit)
-    if (leftHit || rightHit) {
-      // At least one eye has a hit - use the closer depth value
-      // Always use center projection/view for world position to avoid jumps
-      if (leftHit && rightHit) {
-        depth = (leftDepth < rightDepth) ? leftDepth : rightDepth;
-      } else if (leftHit) {
-        depth = leftDepth;
-      } else {
-        depth = rightDepth;
+  // Async PBO depth readback — eliminates the per-frame synchronous glReadPixels
+  // stall. Both stereo and mono paths read the same depth attachment on the same
+  // currently-bound FBO at the same cursor pixel, so a single read suffices.
+  //
+  // Pattern:
+  //   1. Poll the previous frame's fence (non-blocking). If done, map the PBO
+  //      and update m_cachedDepth.
+  //   2. Kick off this frame's async read into the PBO (GPU-to-PBO, no CPU wait).
+  //   3. Place a new fence so we can poll completion next frame.
+  //   4. Use m_cachedDepth (0 or 1 frame of latency — imperceptible at ≥60 FPS).
+  if (m_depthFence) {
+    GLenum res = glClientWaitSync(m_depthFence, GL_SYNC_FLUSH_COMMANDS_BIT, 0);
+    if (res != GL_TIMEOUT_EXPIRED) {
+      glBindBuffer(GL_PIXEL_PACK_BUFFER, m_depthPBO);
+      float *ptr = (float *)glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
+      if (ptr) {
+        m_cachedDepth = *ptr;
+        glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
       }
-    } else {
-      // Neither eye has a hit - show Windows cursor, hide 3D cursor
-      depth = 1.0f;
+      glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+      glDeleteSync(m_depthFence);
+      m_depthFence = nullptr;
     }
-  } else {
-    // Mono mode - read from current buffer
-    glReadPixels(m_lastX, (float)m_windowHeight - m_lastY, 1, 1,
-                 GL_DEPTH_COMPONENT, GL_FLOAT, &depth);
   }
+
+  // Kick off this frame's async read (nullptr → GPU writes directly to PBO).
+  // main.cpp already bound the correct read FBO before calling this function.
+  glBindBuffer(GL_PIXEL_PACK_BUFFER, m_depthPBO);
+  glReadPixels(m_lastX, (float)m_windowHeight - m_lastY, 1, 1,
+               GL_DEPTH_COMPONENT, GL_FLOAT, nullptr);
+  glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+  if (m_depthFence) glDeleteSync(m_depthFence);
+  m_depthFence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+
+  float depth = m_cachedDepth; // use cached value (0-or-1-frame latency)
 
   // Convert cursor position to world space using center projection/view
   // Always use the center matrices to avoid jumps when eye selection changes
@@ -351,6 +341,10 @@ void CursorManager::renderOrbitCenter(const glm::mat4 &projection,
 
 // Release resources for all cursor types
 void CursorManager::cleanup() {
+  // Release async depth-readback resources before cursor cleanup.
+  if (m_depthFence) { glDeleteSync(m_depthFence); m_depthFence = nullptr; }
+  if (m_depthPBO)   { glDeleteBuffers(1, &m_depthPBO); m_depthPBO = 0; }
+
   m_sphereCursor->cleanup();
   m_fragmentCursor->cleanup();
   m_planeCursor->cleanup();

--- a/StereoVista/src/Engine/ComputePointCloudRenderer.cpp
+++ b/StereoVista/src/Engine/ComputePointCloudRenderer.cpp
@@ -231,6 +231,10 @@ void ComputePointCloudRenderer::endFrame() {
                               m_width * m_height * static_cast<GLsizeiptr>(sizeof(uint64_t)),
                               GL_RED_INTEGER, GL_UNSIGNED_INT,
                               &clearVal);
+    // Make the clear visible to the next frame's compute dispatch.
+    // Without this barrier the driver must infer the SSBO write-after-clear
+    // dependency, which causes a periodic pipeline stall every 3-7 frames.
+    glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 }
 
 } // namespace Engine

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -263,6 +263,14 @@ bool hasModelGrabPoint = false; // Whether a valid grab point exists
 float deltaTime = 0.0f;
 float lastFrame = 0.0f;
 
+// ---- Async depth sampling for camera distance (avoids synchronous glReadPixels stall) ----
+// Double-buffered: while PBO[writeIdx] receives the current frame's read,
+// PBO[1-writeIdx] contains last frame's already-transferred depth value.
+GLuint g_distancePBO[2]       = {0, 0};
+int    g_distancePBOWriteIdx   = 0;
+float  g_cachedCenterDepth     = 1.0f;
+bool   g_distancePBOReady      = false;
+
 // ---- Cursor System ----
 Cursor::CursorManager cursorManager;
 glm::vec3 capturedCursorPos;
@@ -2647,6 +2655,14 @@ int main() {
   // Initialize cursor manager
   cursorManager.initialize();
 
+  // Initialize double-buffered PBO for async camera-distance depth sampling.
+  glGenBuffers(2, g_distancePBO);
+  for (GLuint pbo : g_distancePBO) {
+      glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo);
+      glBufferData(GL_PIXEL_PACK_BUFFER, sizeof(float), nullptr, GL_STREAM_READ);
+  }
+  glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
   setupShadowMapping();
   setupPointShadowMapping();
   setupSkyboxVAO(skyboxVAO, skyboxVBO);
@@ -3534,6 +3550,9 @@ int main() {
 // ---- Initialization and Cleanup -----
 #pragma region Initialization and Cleanup
 void cleanup() {
+  // Delete async camera-distance PBOs
+  glDeleteBuffers(2, g_distancePBO);
+
   // Delete cursor manager resources
   cursorManager.cleanup();
 
@@ -4909,13 +4928,50 @@ void renderEye(GLenum drawBuffer, const glm::mat4 &projection,
     } else {
       glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
     }
-    float distanceToNearestObject = camera.getDistanceToNearestObject(
-        camera, projection, view, preferences.farPlane, windowWidth,
-        windowHeight);
-    camera.UpdateDistanceToObject(distanceToNearestObject);
-    float largestDimension = calculateLargestModelDimension();
-    camera.AdjustMovementSpeed(distanceToNearestObject, largestDimension,
-                               preferences.farPlane);
+
+    // Async double-buffered PBO depth sampling — eliminates 9 synchronous
+    // glReadPixels stalls per frame that were caused by Camera::getDistanceToNearestObject.
+    // Pattern: consume previous frame's result (no stall), then kick off this
+    // frame's read (GPU-to-PBO transfer happens while the CPU continues).
+    // 1-frame latency is imperceptible for movement speed and auto-convergence.
+    {
+      int readIdx  = 1 - g_distancePBOWriteIdx;
+      int writeIdx = g_distancePBOWriteIdx;
+
+      // Consume previous frame's result — GPU has already finished by now.
+      if (g_distancePBOReady) {
+        glBindBuffer(GL_PIXEL_PACK_BUFFER, g_distancePBO[readIdx]);
+        float *ptr = (float *)glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
+        if (ptr) {
+          g_cachedCenterDepth = *ptr;
+          glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
+        }
+        glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+      }
+
+      // Kick off this frame's async read (nullptr → GPU writes directly to PBO).
+      glBindBuffer(GL_PIXEL_PACK_BUFFER, g_distancePBO[writeIdx]);
+      glReadPixels(windowWidth / 2, windowHeight / 2, 1, 1,
+                   GL_DEPTH_COMPONENT, GL_FLOAT, nullptr);
+      glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+      g_distancePBOWriteIdx = readIdx; // swap for next frame
+      g_distancePBOReady    = true;
+
+      // Reconstruct world-space distance from cached (previous-frame) depth.
+      float distanceToNearestObject = preferences.farPlane;
+      if (g_cachedCenterDepth < 1.0f) {
+        glm::vec4 ndc   = glm::vec4(0.0f, 0.0f, g_cachedCenterDepth * 2.0f - 1.0f, 1.0f);
+        glm::mat4 invPV = glm::inverse(projection * view);
+        glm::vec4 wp    = invPV * ndc;
+        wp /= wp.w;
+        distanceToNearestObject = glm::distance(camera.Position, glm::vec3(wp));
+      }
+
+      camera.UpdateDistanceToObject(distanceToNearestObject);
+      float largestDimension = calculateLargestModelDimension();
+      camera.AdjustMovementSpeed(distanceToNearestObject, largestDimension,
+                                 preferences.farPlane);
+    }
 
     // Update target convergence automatically if enabled
     if (preferences.autoConvergence) {


### PR DESCRIPTION
Four targeted fixes to eliminate FPS regression (300+ → ~60) introduced when
the resolve shader gained gl_FragDepth writes for correct depth-buffer
integration:

1. Add glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT) after
   glClearNamedBufferSubData in ComputePointCloudRenderer::endFrame(). Without
   it the driver inserts an implicit barrier to resolve the SSBO
   read-after-clear dependency, causing a periodic stall every 3-7 frames.

2. Remove the redundant second glReadPixels in CursorManager stereo path. Both
   calls read the same FBO at the same pixel, so leftDepth == rightDepth always;
   the second call was a wasted pipeline flush.

3. Replace Camera::getDistanceToNearestObject (9 synchronous glReadPixels/frame)
   with a double-buffered PBO in main.cpp. Each frame: map + consume the
   previous PBO result (no stall), then kick off a new async center-pixel read.
   1-frame depth latency is imperceptible for movement speed and auto-convergence.

4. Replace CursorManager's remaining synchronous glReadPixels with a
   fence-guarded single-slot PBO. A non-blocking glClientWaitSync poll
   retrieves the previous frame's value; a new fence marks the current
   frame's async read. 0-or-1-frame latency is imperceptible at ≥60 FPS.

https://claude.ai/code/session_0141yUsipXVMhmBDysskrLH5