### PR TITLE
Fix point cloud export/scene saving and add 3D measurement tool

### DIFF
--- a/StereoVista/StereoVista.vcxproj
+++ b/StereoVista/StereoVista.vcxproj
@@ -214,6 +214,7 @@ IF %ERRORLEVEL% LEQ 7 SET ERRORLEVEL=0</Command>
     <ClCompile Include="src\Gui\CursorPreview3D.cpp" />
     <ClCompile Include="src\Gui\GUI.cpp" />
     <ClCompile Include="src\Tools\BrushTool.cpp" />
+    <ClCompile Include="src\Tools\MeasurementTool.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="headers\core.h" />
@@ -238,6 +239,7 @@ IF %ERRORLEVEL% LEQ 7 SET ERRORLEVEL=0</Command>
     <ClInclude Include="headers\engine\window.h" />
     <ClInclude Include="headers\Camera.h" />
     <ClInclude Include="headers\Tools\BrushTool.h" />
+    <ClInclude Include="headers\Tools\MeasurementTool.h" />
     <ClInclude Include="headers\libs\assimp\aabb.h" />
     <ClInclude Include="headers\libs\assimp\ai_assert.h" />
     <ClInclude Include="headers\libs\assimp\anim.h" />

--- a/StereoVista/StereoVista.vcxproj.filters
+++ b/StereoVista/StereoVista.vcxproj.filters
@@ -123,6 +123,9 @@
     <ClCompile Include="src\Tools\BrushTool.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Tools\MeasurementTool.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\Engine\DDGIVolume.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -471,6 +474,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="headers\Tools\BrushTool.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="headers\Tools\MeasurementTool.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="headers\Loaders\ModelLoader.h">

--- a/StereoVista/headers/Core/SceneManager.h
+++ b/StereoVista/headers/Core/SceneManager.h
@@ -14,6 +14,7 @@ namespace Engine {
         std::vector<PointCloud> pointClouds;
         std::vector<PointLight> pointLights;
         std::vector<SpotLight> spotLights;
+        std::vector<Measurement> measurements;
         Camera::CameraState cameraState;
         
         // Default constructor with default camera state

--- a/StereoVista/headers/Engine/Data.h
+++ b/StereoVista/headers/Engine/Data.h
@@ -321,6 +321,41 @@ namespace Engine {
 
 
 
+    // A single measurement annotation created with the measurement tool.
+    // Points are stored in world space; measurements are part of the scene and
+    // serialized to/from scene files by SceneManager.
+    struct Measurement {
+        enum class Type {
+            Distance = 0, // polyline: per-segment + total length
+            Angle    = 1, // exactly 3 points: angle at the middle point
+            Point    = 2  // single point: world-coordinate annotation
+        };
+
+        Type type = Type::Distance;
+        std::string name;
+        std::vector<glm::vec3> points;
+        glm::vec3 color = glm::vec3(1.0f, 0.76f, 0.03f);
+        bool visible = true;
+
+        float totalLength() const {
+            float len = 0.0f;
+            for (size_t i = 1; i < points.size(); i++)
+                len += glm::length(points[i] - points[i - 1]);
+            return len;
+        }
+
+        // Angle (degrees) at the middle point of a 3-point measurement.
+        float angleDegrees() const {
+            if (points.size() < 3) return 0.0f;
+            const glm::vec3 a = points[0] - points[1];
+            const glm::vec3 b = points[2] - points[1];
+            const float la = glm::length(a), lb = glm::length(b);
+            if (la < 1e-6f || lb < 1e-6f) return 0.0f;
+            const float c = glm::clamp(glm::dot(a, b) / (la * lb), -1.0f, 1.0f);
+            return glm::degrees(glm::acos(c));
+        }
+    };
+
     struct Sun {
         glm::vec3 direction;
         glm::vec3 color;

--- a/StereoVista/headers/Engine/ShortcutManager.h
+++ b/StereoVista/headers/Engine/ShortcutManager.h
@@ -56,9 +56,10 @@ enum class ShortcutAction {
   TogglePlaneCursor,  // Toggle surface plane cursor
 
   // Window Management
-  OpenSettings,       // Open settings window
-  OpenCursorSettings, // Open cursor settings
-  OpenBrushTool,      // Open brush tool window
+  OpenSettings,        // Open settings window
+  OpenCursorSettings,  // Open cursor settings
+  OpenBrushTool,       // Open brush tool window
+  OpenMeasurementTool, // Open measurement tool window
 
   // File Operations
   ImportModel,      // Open import model dialog

--- a/StereoVista/headers/Gui/Gui.h
+++ b/StereoVista/headers/Gui/Gui.h
@@ -29,6 +29,7 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
 void renderSettingsWindow();
 void renderCursorSettingsWindow();
 void renderBrushToolWindow();
+void renderMeasurementToolWindow();
 void renderSunManipulationPanel();
 void renderModelManipulationPanel(Engine::Model &model, Engine::Shader *shader);
 void renderMeshManipulationPanel(Engine::Model &model, int meshIndex,

--- a/StereoVista/headers/Loaders/PointCloudLoader.h
+++ b/StereoVista/headers/Loaders/PointCloudLoader.h
@@ -1,6 +1,7 @@
 // point_cloud_loader.h
 #pragma once
 #include "../Engine/Data.h"
+#include <functional>
 #include <sstream>
 
 namespace Engine {
@@ -8,15 +9,31 @@ namespace Engine {
     class PointCloudLoader {
     public:
         static PointCloud loadPointCloudFile(const std::string& filePath, size_t downsampleFactor = 1);
-        static bool exportToXYZ(const PointCloud& pointCloud, const std::string& filePath);
-        static bool exportToBinary(const PointCloud& pointCloud, const std::string& filePath);
+        // Exporters stream the cloud back from the GPU compute SSBOs (the CPU
+        // points vector is cleared after upload), so they work for any loaded
+        // cloud. applyTransform bakes position/rotation/scale into the written
+        // coordinates; scene saving passes false to keep points in local space
+        // (the transform is stored separately in the scene JSON).
+        static bool exportToXYZ(const PointCloud& pointCloud, const std::string& filePath,
+                                bool applyTransform = true);
+        static bool exportToBinary(const PointCloud& pointCloud, const std::string& filePath,
+                                   bool applyTransform = true);
+        static bool exportToHDF5(const PointCloud& pointCloud, const std::string& filePath,
+                                 bool applyTransform = true);
         static PointCloud loadFromBinary(const std::string& filePath);
         static PointCloud loadFromHDF5(const std::string& filePath, size_t downsampleFactor = 1);
         static PointCloud loadFromLAS(const std::string& filePath, size_t downsampleFactor = 1,
                                       const glm::dvec3* globalCenter = nullptr);
         static std::vector<PointCloud> loadFromLASMultiple(const std::vector<std::string>& filePaths,
                                                            size_t downsampleFactor = 1);
-        static bool exportToHDF5(const PointCloud& pointCloud, const std::string& filePath);
+
+        // Streams every point of the cloud to the callback, one decoded batch
+        // at a time (peak CPU RAM = one batch). Sources the legacy CPU vector
+        // when populated, otherwise reads the quantised compute SSBOs back
+        // from the GPU. Returns false if the cloud holds no point data.
+        // Must be called on the thread that owns the GL context.
+        static bool forEachPointBatch(const PointCloud& pointCloud,
+            const std::function<void(const PointCloudPoint* pts, size_t count)>& callback);
 
     private:
         static void setupPointCloudGLBuffers(PointCloud& pointCloud);

--- a/StereoVista/headers/Tools/MeasurementTool.h
+++ b/StereoVista/headers/Tools/MeasurementTool.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "Engine/Core.h"
+#include "Engine/Data.h"
+#include <glm/glm.hpp>
+#include <string>
+#include <vector>
+
+namespace Tools {
+
+    // Interactive 3D measurement tool built on the 3D cursor pipeline.
+    // Clicks place measurement points at the cursor's world position; the tool
+    // renders the annotations (lines + point markers) as a world-space overlay
+    // and exposes the data for screen-space labels drawn by the GUI.
+    //
+    // Committed measurements live in the active scene
+    // (Engine::Scene::measurements) so they are saved/loaded with scene files.
+    class MeasurementTool {
+    public:
+        MeasurementTool();
+        ~MeasurementTool();
+
+        void initialize(); // create GL resources (requires a current context)
+        void cleanup();
+
+        // Bind the tool to the scene's measurement storage. The pointer must
+        // outlive the tool (it points into the global scene object).
+        void setMeasurements(std::vector<Engine::Measurement>* measurements) {
+            m_measurements = measurements;
+        }
+        std::vector<Engine::Measurement>* getMeasurements() { return m_measurements; }
+
+        void setEnabled(bool enabled);
+        bool isEnabled() const { return m_enabled; }
+
+        void setMode(Engine::Measurement::Type mode);
+        Engine::Measurement::Type getMode() const { return m_mode; }
+
+        // ── Interaction ──────────────────────────────────────────────────────
+        // Appends a point (world space) to the in-progress measurement,
+        // starting a new one if needed. Angle measurements auto-commit at 3
+        // points, Point annotations at 1.
+        void addPoint(const glm::vec3& worldPos);
+        void finishActive();   // commit the in-progress polyline (>= 2 points)
+        void cancelActive();
+        void undoLastPoint();  // remove last placed point of the active measurement
+        bool hasActive() const { return m_hasActive; }
+        const Engine::Measurement& getActive() const { return m_active; }
+
+        void deleteMeasurement(int index);
+        void clearAll();
+
+        // ── Rendering ────────────────────────────────────────────────────────
+        // World-space overlay (lines + point markers). Called once per eye with
+        // that eye's matrices. previewPoint is the current 3D cursor position
+        // (nullptr when invalid / tool disabled) used for the live rubber-band
+        // segment.
+        void render(const glm::mat4& projection, const glm::mat4& view,
+                    const glm::vec3* previewPoint);
+
+        // Last preview point passed to render(), consumed by the GUI label pass.
+        bool getPreviewPoint(glm::vec3& out) const {
+            if (m_previewValid) out = m_previewPoint;
+            return m_previewValid;
+        }
+
+        // ── Display settings (runtime) ───────────────────────────────────────
+        float lineWidth = 2.5f;
+        bool  showLabels = true;
+        bool  showSegmentLabels = true;
+        bool  xRay = true;          // ghost-render occluded parts of the overlay
+        float unitScale = 1.0f;     // world units → displayed units
+        std::string unitSuffix = "m";
+        glm::vec3 nextColor = glm::vec3(1.0f, 0.76f, 0.03f); // color for new measurements
+
+        // Format a world-space length with the configured unit scale/suffix.
+        std::string formatLength(float worldLength) const;
+
+    private:
+        void commitActive();
+        void appendLine(std::vector<float>& out, const glm::vec3& a,
+                        const glm::vec3& b, const glm::vec3& color) const;
+        void appendPoint(std::vector<float>& out, const glm::vec3& p,
+                         const glm::vec3& color) const;
+        void drawBuffers(const glm::mat4& projection, const glm::mat4& view,
+                         const std::vector<float>& lineVerts,
+                         const std::vector<float>& pointVerts);
+
+        bool m_enabled = false;
+        Engine::Measurement::Type m_mode = Engine::Measurement::Type::Distance;
+
+        std::vector<Engine::Measurement>* m_measurements = nullptr;
+        Engine::Measurement m_active;
+        bool m_hasActive = false;
+        int  m_nameCounter = 0;
+
+        glm::vec3 m_previewPoint = glm::vec3(0.0f);
+        bool m_previewValid = false;
+
+        // GL resources (interleaved pos3 + color3, dynamic)
+        bool   m_initialized = false;
+        GLuint m_lineVAO = 0, m_lineVBO = 0;
+        GLuint m_pointVAO = 0, m_pointVBO = 0;
+        GLuint m_lineProgram = 0;
+        GLuint m_pointProgram = 0;
+    };
+
+} // namespace Tools

--- a/StereoVista/src/Core/SceneManager.cpp
+++ b/StereoVista/src/Core/SceneManager.cpp
@@ -227,7 +227,7 @@ namespace Engine {
                 std::filesystem::path pcPath = sceneDir / "pointClouds" / pcFilename;
                 if (!Engine::PointCloudLoader::exportToBinary(pointCloud, pcPath.string(), false)) {
                     std::cerr << "Warning: failed to write point cloud data for '"
-                              << pointCloud.name << "' — it will be missing from the scene"
+                              << pointCloud.name << "' - it will be missing from the scene"
                               << std::endl;
                     continue;
                 }

--- a/StereoVista/src/Core/SceneManager.cpp
+++ b/StereoVista/src/Core/SceneManager.cpp
@@ -193,21 +193,66 @@ namespace Engine {
 
             // Save point clouds
             json pointCloudsJson = json::array();
+            int pcIndex = 0;
+            std::unordered_set<std::string> usedPcFilenames;
             for (const auto& pointCloud : scene.pointClouds) {
                 json pointCloudJson;
                 pointCloudJson["name"] = pointCloud.name;
                 pointCloudJson["position"] = { pointCloud.position.x, pointCloud.position.y, pointCloud.position.z };
                 pointCloudJson["rotation"] = { pointCloud.rotation.x, pointCloud.rotation.y, pointCloud.rotation.z };
                 pointCloudJson["scale"] = { pointCloud.scale.x, pointCloud.scale.y, pointCloud.scale.z };
+                pointCloudJson["visible"] = pointCloud.visible;
+                pointCloudJson["basePointSize"] = pointCloud.basePointSize;
 
-                std::string pcFilename = pointCloud.name + ".pcb";
+                // Cloud names can contain path-hostile characters (they default
+                // to the source filename) and may collide — sanitize and dedupe.
+                std::string baseName = pointCloud.name.empty()
+                    ? ("pointCloud_" + std::to_string(pcIndex)) : pointCloud.name;
+                for (char& c : baseName) {
+                    if (c == '/' || c == '\\' || c == ':' || c == '*' || c == '?' ||
+                        c == '"' || c == '<' || c == '>' || c == '|') {
+                        c = '_';
+                    }
+                }
+                std::string pcFilename = baseName + ".pcb";
+                while (!usedPcFilenames.insert(pcFilename).second) {
+                    pcFilename = baseName + "_" + std::to_string(pcIndex) + ".pcb";
+                    baseName += "_";
+                }
+                pcIndex++;
+
+                // Export in LOCAL space (applyTransform = false): the transform
+                // is stored in the JSON above and re-applied on load. Baking it
+                // into the points as well would apply it twice.
                 std::filesystem::path pcPath = sceneDir / "pointClouds" / pcFilename;
-                Engine::PointCloudLoader::exportToBinary(pointCloud, pcPath.string());
+                if (!Engine::PointCloudLoader::exportToBinary(pointCloud, pcPath.string(), false)) {
+                    std::cerr << "Warning: failed to write point cloud data for '"
+                              << pointCloud.name << "' — it will be missing from the scene"
+                              << std::endl;
+                    continue;
+                }
 
                 pointCloudJson["dataPath"] = "pointClouds/" + pcFilename;
                 pointCloudsJson.push_back(pointCloudJson);
             }
             sceneJson["pointClouds"] = pointCloudsJson;
+
+            // Save measurements (world-space annotation points)
+            json measurementsJson = json::array();
+            for (const auto& measurement : scene.measurements) {
+                json measurementJson;
+                measurementJson["type"] = static_cast<int>(measurement.type);
+                measurementJson["name"] = measurement.name;
+                measurementJson["color"] = { measurement.color.r, measurement.color.g, measurement.color.b };
+                measurementJson["visible"] = measurement.visible;
+                json pointsJson = json::array();
+                for (const auto& p : measurement.points) {
+                    pointsJson.push_back({ p.x, p.y, p.z });
+                }
+                measurementJson["points"] = pointsJson;
+                measurementsJson.push_back(measurementJson);
+            }
+            sceneJson["measurements"] = measurementsJson;
 
             // Save point lights
             json pointLightsJson = json::array();
@@ -613,14 +658,62 @@ namespace Engine {
                             pointCloudJson["scale"][1].get<float>(),
                             pointCloudJson["scale"][2].get<float>()
                         );
+                        pointCloud.visible = pointCloudJson.value("visible", true);
+                        pointCloud.basePointSize = pointCloudJson.value("basePointSize", 2.0f);
+                        pointCloud.filePath = pcPath.string();
 
                         // Set source scene path for grouping in GUI
                         pointCloud.sourceScenePath = filename;
+
+                        if (!pointCloud.isLoaded()) {
+                            std::cerr << "Warning: point cloud '" << pointCloud.name
+                                      << "' loaded with no points (data file: " << pcPath << ")"
+                                      << std::endl;
+                        }
 
                         scene.pointClouds.push_back(std::move(pointCloud));
                     }
                     catch (const std::exception& e) {
                         std::cerr << "Failed to load point cloud: " << e.what() << std::endl;
+                    }
+                }
+            }
+
+            // Load measurements
+            if (sceneJson.contains("measurements")) {
+                for (const auto& measurementJson : sceneJson["measurements"]) {
+                    try {
+                        Measurement measurement;
+                        measurement.type = static_cast<Measurement::Type>(
+                            measurementJson.value("type", 0));
+                        measurement.name = measurementJson.value("name", std::string("Measurement"));
+                        measurement.visible = measurementJson.value("visible", true);
+                        if (measurementJson.contains("color") &&
+                            measurementJson["color"].is_array() &&
+                            measurementJson["color"].size() == 3) {
+                            measurement.color = glm::vec3(
+                                measurementJson["color"][0].get<float>(),
+                                measurementJson["color"][1].get<float>(),
+                                measurementJson["color"][2].get<float>()
+                            );
+                        }
+                        if (measurementJson.contains("points") &&
+                            measurementJson["points"].is_array()) {
+                            for (const auto& pointJson : measurementJson["points"]) {
+                                if (pointJson.is_array() && pointJson.size() == 3) {
+                                    measurement.points.emplace_back(
+                                        pointJson[0].get<float>(),
+                                        pointJson[1].get<float>(),
+                                        pointJson[2].get<float>());
+                                }
+                            }
+                        }
+                        if (!measurement.points.empty()) {
+                            scene.measurements.push_back(std::move(measurement));
+                        }
+                    }
+                    catch (const std::exception& e) {
+                        std::cerr << "Failed to load measurement: " << e.what() << std::endl;
                     }
                 }
             }

--- a/StereoVista/src/Engine/ShortcutManager.cpp
+++ b/StereoVista/src/Engine/ShortcutManager.cpp
@@ -432,6 +432,8 @@ ShortcutProfile ShortcutManager::createDefaultProfile() {
                      KeyBinding(GLFW_KEY_I, true, false, true),
                      0); // Ctrl+Shift+I
   profile.setBinding(ShortcutAction::ResetCamera, KeyBinding(GLFW_KEY_HOME), 0);
+  profile.setBinding(ShortcutAction::OpenMeasurementTool, KeyBinding(GLFW_KEY_M),
+                     0);
 
   // New actions start unbound - users can assign keys as needed
 
@@ -612,6 +614,8 @@ std::string ShortcutManager::getActionName(ShortcutAction action) {
     return "OpenCursorSettings";
   case ShortcutAction::OpenBrushTool:
     return "OpenBrushTool";
+  case ShortcutAction::OpenMeasurementTool:
+    return "OpenMeasurementTool";
 
   // File Operations
   case ShortcutAction::ImportModel:
@@ -715,6 +719,8 @@ std::string ShortcutManager::getActionDescription(ShortcutAction action) {
     return "Open Cursor Settings";
   case ShortcutAction::OpenBrushTool:
     return "Open Brush Tool Window";
+  case ShortcutAction::OpenMeasurementTool:
+    return "Open Measurement Tool Window";
 
   // File Operations
   case ShortcutAction::ImportModel:

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -5400,7 +5400,7 @@ void renderMeasurementToolWindow() {
     ImGui::Spacing();
     DrawSectionHeader("In Progress");
     const auto &active = measurementTool.getActive();
-    ImGui::Text("%s — %d point(s)", active.name.c_str(),
+    ImGui::Text("%s - %d point(s)", active.name.c_str(),
                 static_cast<int>(active.points.size()));
     if (active.type == Engine::Measurement::Type::Distance &&
         active.points.size() >= 2) {

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -9,9 +9,11 @@
 #include "Engine/ThreeDConnexionSync.h"
 #include "Gui/GUITypes.h"
 #include "Tools/BrushTool.h"
+#include "Tools/MeasurementTool.h"
 #include "imgui/IconsFontAwesome5.h"
 #include "imgui/imgui_sytle.h"
 #include "libs/portable-file-dialogs.h"
+#include <cstdio>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -28,6 +30,7 @@ void updateSpaceMouseBounds();
 void updateSpaceMouseCursorAnchor();
 void renderPointLightManipulationPanel();
 void renderSpotLightManipulationPanel();
+static void drawMeasurementLabels();
 
 // Application globals used throughout the GUI system
 extern int windowWidth;
@@ -59,6 +62,17 @@ extern Cursor::CursorManager cursorManager;
 
 // Brush tool
 extern Tools::BrushTool brushTool;
+
+// Measurement tool
+extern Tools::MeasurementTool measurementTool;
+extern bool showMeasurementToolWindow;
+
+// 3D viewport rectangle (window pixels) — used to project measurement labels
+extern int g_viewportX;
+extern int g_viewportTopInset;
+extern int g_viewportWidth;
+extern int g_viewportHeight;
+extern float aspectRatio;
 
 extern GUI::LightingMode currentLightingMode;
 extern bool enableShadows;
@@ -1132,6 +1146,11 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
       showBrushToolWindow = true;
     }
 
+    // Measurement Tool Menu
+    if (ImGui::MenuItem("Measure")) {
+      showMeasurementToolWindow = true;
+    }
+
     // AI Assistant quick access (accent-highlighted, deep-links into Settings)
     ImGui::PushStyleColor(ImGuiCol_Text, g_StyleColors.accent);
     if (ImGui::MenuItem("AI Assistant")) {
@@ -1805,6 +1824,14 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
   if (showBrushToolWindow) {
     renderBrushToolWindow();
   }
+
+  if (showMeasurementToolWindow) {
+    renderMeasurementToolWindow();
+  }
+
+  // Screen-space measurement labels (distances/angles/coordinates) projected
+  // from the world-space measurement overlay
+  drawMeasurementLabels();
 
   // FPS Counter (always in top-right corner)
   if (showFPS) {
@@ -4520,6 +4547,7 @@ void renderSettingsWindow() {
           renderAction(StereoVista::ShortcutAction::OpenSettings);
           renderAction(StereoVista::ShortcutAction::OpenCursorSettings);
           renderAction(StereoVista::ShortcutAction::OpenBrushTool);
+          renderAction(StereoVista::ShortcutAction::OpenMeasurementTool);
         }
 
         // GROUP: File Operations
@@ -5144,7 +5172,11 @@ void renderBrushToolWindow() {
   // Enable/Disable brush tool
   if (ImGui::Checkbox("Enable Brush Tool",
                       &preferences.brushToolSettings.enabled)) {
-    // Will be handled in main.cpp
+    // Enabling/disabling is handled in main.cpp; just keep the measurement
+    // tool exclusive since both consume left clicks.
+    if (preferences.brushToolSettings.enabled) {
+      measurementTool.setEnabled(false);
+    }
   }
 
   if (!preferences.brushToolSettings.enabled) {
@@ -5331,6 +5363,260 @@ void renderBrushToolWindow() {
       "4. Hold LEFT MOUSE BUTTON and drag over surfaces to paint");
 
   ImGui::End();
+}
+
+void renderMeasurementToolWindow() {
+  ImGui::SetNextWindowSize(ImVec2(430, 580), ImGuiCond_FirstUseEver);
+  ImGui::Begin("Measurement Tool", &showMeasurementToolWindow);
+
+  DrawSectionHeader("Measurement Tool");
+
+  bool enabled = measurementTool.isEnabled();
+  if (ImGui::Checkbox("Enable Measuring", &enabled)) {
+    measurementTool.setEnabled(enabled);
+    if (enabled) {
+      // Measuring and brush painting both consume left clicks — keep them
+      // mutually exclusive.
+      preferences.brushToolSettings.enabled = false;
+    }
+  }
+  ImGui::SameLine();
+  DrawHelpMarker("While enabled, LEFT CLICK places a measurement point at the "
+                 "3D cursor. RIGHT CLICK or ENTER finishes a polyline, "
+                 "BACKSPACE removes the last point, DELETE cancels.");
+
+  int mode = static_cast<int>(measurementTool.getMode());
+  const char *modeNames[] = {"Distance (polyline)", "Angle (3 points)",
+                             "Point (coordinates)"};
+  if (ImGui::Combo("Mode", &mode, modeNames, IM_ARRAYSIZE(modeNames))) {
+    measurementTool.setMode(static_cast<Engine::Measurement::Type>(mode));
+  }
+
+  ImGui::ColorEdit3("New Measurement Color",
+                    glm::value_ptr(measurementTool.nextColor));
+
+  // In-progress measurement status + controls
+  if (measurementTool.hasActive()) {
+    ImGui::Spacing();
+    DrawSectionHeader("In Progress");
+    const auto &active = measurementTool.getActive();
+    ImGui::Text("%s — %d point(s)", active.name.c_str(),
+                static_cast<int>(active.points.size()));
+    if (active.type == Engine::Measurement::Type::Distance &&
+        active.points.size() >= 2) {
+      ImGui::Text("Length so far: %s",
+                  measurementTool.formatLength(active.totalLength()).c_str());
+    }
+    if (ImGui::Button("Finish", ImVec2(100, 0))) {
+      measurementTool.finishActive();
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Undo Point", ImVec2(100, 0))) {
+      measurementTool.undoLastPoint();
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Cancel", ImVec2(100, 0))) {
+      measurementTool.cancelActive();
+    }
+  }
+
+  ImGui::Spacing();
+  DrawSectionHeader("Display");
+
+  ImGui::Checkbox("Show Labels", &measurementTool.showLabels);
+  ImGui::SameLine();
+  ImGui::Checkbox("Segment Labels", &measurementTool.showSegmentLabels);
+  ImGui::SameLine();
+  DrawHelpMarker("Show a length label on every segment of a polyline, not "
+                 "just the total");
+  ImGui::Checkbox("X-Ray", &measurementTool.xRay);
+  ImGui::SameLine();
+  DrawHelpMarker("Ghost-render measurement lines that are hidden behind "
+                 "geometry");
+  ImGui::SliderFloat("Line Width", &measurementTool.lineWidth, 1.0f, 8.0f,
+                     "%.1f");
+
+  // Unit selection: world units are treated as meters
+  static const char *unitNames[] = {"m", "dm", "cm", "mm", "km", "ft", "in"};
+  static const float unitScales[] = {1.0f,    10.0f,    100.0f, 1000.0f,
+                                     0.001f,  3.28084f, 39.3701f};
+  static int unitIndex = 0;
+  if (ImGui::Combo("Units", &unitIndex, unitNames, IM_ARRAYSIZE(unitNames))) {
+    measurementTool.unitScale = unitScales[unitIndex];
+    measurementTool.unitSuffix = unitNames[unitIndex];
+  }
+
+  ImGui::Spacing();
+  DrawSectionHeader("Measurements");
+
+  auto *measurements = measurementTool.getMeasurements();
+  if (!measurements || measurements->empty()) {
+    ImGui::TextDisabled("No measurements yet");
+  } else {
+    int deleteIndex = -1;
+    for (int i = 0; i < static_cast<int>(measurements->size()); i++) {
+      auto &m = (*measurements)[i];
+      ImGui::PushID(i);
+
+      ImGui::Checkbox("##visible", &m.visible);
+      ImGui::SameLine();
+      ImGui::ColorEdit3("##color", glm::value_ptr(m.color),
+                        ImGuiColorEditFlags_NoInputs |
+                            ImGuiColorEditFlags_NoLabel);
+      ImGui::SameLine();
+
+      std::string value;
+      switch (m.type) {
+      case Engine::Measurement::Type::Angle:
+        value = std::to_string(m.angleDegrees());
+        value = value.substr(0, value.find('.') + 2) + " deg";
+        break;
+      case Engine::Measurement::Type::Point:
+        if (!m.points.empty()) {
+          char buf[96];
+          snprintf(buf, sizeof(buf), "(%.2f, %.2f, %.2f)", m.points[0].x,
+                   m.points[0].y, m.points[0].z);
+          value = buf;
+        }
+        break;
+      case Engine::Measurement::Type::Distance:
+      default:
+        value = measurementTool.formatLength(m.totalLength());
+        break;
+      }
+      ImGui::Text("%s: %s", m.name.c_str(), value.c_str());
+
+      ImGui::SameLine(ImGui::GetWindowWidth() - 40 * g_GuiScale.currentScale);
+      if (ImGui::SmallButton("X")) {
+        deleteIndex = i;
+      }
+
+      ImGui::PopID();
+    }
+    if (deleteIndex >= 0) {
+      measurementTool.deleteMeasurement(deleteIndex);
+    }
+
+    ImGui::Spacing();
+    if (ImGui::Button("Clear All Measurements", ImVec2(-1, 0))) {
+      measurementTool.clearAll();
+    }
+  }
+
+  ImGui::Spacing();
+  ImGui::TextDisabled("Measurements are saved with the scene file.");
+
+  ImGui::End();
+}
+
+// Projects measurement values (segment lengths, angles, coordinates) into
+// screen space and draws them as labels on the foreground draw list.
+static void drawMeasurementLabels() {
+  if (!measurementTool.showLabels)
+    return;
+  auto *measurements = measurementTool.getMeasurements();
+
+  const glm::mat4 viewProj =
+      camera.GetProjectionMatrix(aspectRatio, preferences.nearPlane,
+                                 preferences.farPlane) *
+      camera.GetViewMatrix();
+  ImDrawList *drawList = ImGui::GetForegroundDrawList();
+
+  auto project = [&](const glm::vec3 &world, ImVec2 &out) -> bool {
+    glm::vec4 clip = viewProj * glm::vec4(world, 1.0f);
+    if (clip.w <= 1e-4f)
+      return false;
+    const glm::vec3 ndc = glm::vec3(clip) / clip.w;
+    if (ndc.x < -1.1f || ndc.x > 1.1f || ndc.y < -1.1f || ndc.y > 1.1f)
+      return false;
+    out = ImVec2(static_cast<float>(g_viewportX) +
+                     (ndc.x + 1.0f) * 0.5f * static_cast<float>(g_viewportWidth),
+                 static_cast<float>(g_viewportTopInset) +
+                     (1.0f - ndc.y) * 0.5f *
+                         static_cast<float>(g_viewportHeight));
+    return true;
+  };
+
+  auto drawLabel = [&](const glm::vec3 &world, const std::string &text,
+                       ImU32 color) {
+    ImVec2 px;
+    if (!project(world, px))
+      return;
+    const ImVec2 size = ImGui::CalcTextSize(text.c_str());
+    const ImVec2 p0(px.x - size.x * 0.5f - 4.0f, px.y - size.y - 10.0f);
+    const ImVec2 p1(p0.x + size.x + 8.0f, p0.y + size.y + 4.0f);
+    drawList->AddRectFilled(p0, p1, IM_COL32(15, 15, 15, 200), 4.0f);
+    drawList->AddText(ImVec2(p0.x + 4.0f, p0.y + 2.0f), color, text.c_str());
+  };
+
+  auto drawForMeasurement = [&](const Engine::Measurement &m) {
+    const ImU32 color = ImGui::ColorConvertFloat4ToU32(
+        ImVec4(m.color.r, m.color.g, m.color.b, 1.0f));
+    char buf[96];
+    switch (m.type) {
+    case Engine::Measurement::Type::Angle:
+      if (m.points.size() >= 3) {
+        snprintf(buf, sizeof(buf), "%.1f\xC2\xB0", m.angleDegrees());
+        drawLabel(m.points[1], buf, color);
+      }
+      break;
+    case Engine::Measurement::Type::Point:
+      if (!m.points.empty()) {
+        snprintf(buf, sizeof(buf), "(%.2f, %.2f, %.2f)", m.points[0].x,
+                 m.points[0].y, m.points[0].z);
+        drawLabel(m.points[0], buf, color);
+      }
+      break;
+    case Engine::Measurement::Type::Distance:
+    default: {
+      const size_t segments = m.points.size() >= 2 ? m.points.size() - 1 : 0;
+      if (measurementTool.showSegmentLabels || segments == 1) {
+        for (size_t i = 1; i < m.points.size(); i++) {
+          const float len = glm::length(m.points[i] - m.points[i - 1]);
+          drawLabel((m.points[i - 1] + m.points[i]) * 0.5f,
+                    measurementTool.formatLength(len), color);
+        }
+      }
+      if (segments > 1) {
+        drawLabel(m.points.back(),
+                  "Total " + measurementTool.formatLength(m.totalLength()),
+                  color);
+      }
+      break;
+    }
+    }
+  };
+
+  if (measurements) {
+    for (const auto &m : *measurements) {
+      if (m.visible)
+        drawForMeasurement(m);
+    }
+  }
+
+  // In-progress measurement: same labels plus a live readout to the cursor
+  if (measurementTool.hasActive()) {
+    const auto &active = measurementTool.getActive();
+    drawForMeasurement(active);
+
+    glm::vec3 preview;
+    if (measurementTool.getPreviewPoint(preview) && !active.points.empty()) {
+      const ImU32 liveColor = IM_COL32(255, 255, 255, 230);
+      if (active.type == Engine::Measurement::Type::Angle &&
+          active.points.size() == 2) {
+        // Live angle preview with the cursor as the third point
+        Engine::Measurement tmp = active;
+        tmp.points.push_back(preview);
+        char buf[32];
+        snprintf(buf, sizeof(buf), "%.1f\xC2\xB0", tmp.angleDegrees());
+        drawLabel(tmp.points[1], buf, liveColor);
+      } else if (active.type == Engine::Measurement::Type::Distance) {
+        const float len = glm::length(preview - active.points.back());
+        drawLabel((active.points.back() + preview) * 0.5f,
+                  measurementTool.formatLength(len), liveColor);
+      }
+    }
+  }
 }
 
 void renderSunManipulationPanel() {
@@ -5750,12 +6036,25 @@ void renderPointCloudManipulationPanel(Engine::PointCloud &pointCloud) {
 
   if (ImGui::CollapsingHeader("Export")) {
     static int exportFormat = 0;
-    ImGui::RadioButton("XYZ Format", &exportFormat, 0);
+    ImGui::RadioButton("XYZ", &exportFormat, 0);
     ImGui::SameLine();
-    ImGui::RadioButton("Binary Format", &exportFormat, 1);
+    ImGui::RadioButton("Binary (.pcb)", &exportFormat, 1);
+    ImGui::SameLine();
+    ImGui::RadioButton("HDF5", &exportFormat, 2);
+
+    static bool exportApplyTransform = true;
+    ImGui::Checkbox("Apply transform", &exportApplyTransform);
+    ImGui::SameLine();
+    DrawHelpMarker("Bake the cloud's position/rotation/scale into the "
+                   "exported coordinates. Disable to export the raw "
+                   "local-space points.");
+
+    static std::string lastExportStatus;
+    static bool lastExportOk = false;
 
     if (ImGui::Button("Export Point Cloud...", ImVec2(-1, 0))) {
-      std::string defaultExt = (exportFormat == 0) ? ".xyz" : ".pcb";
+      std::string defaultExt =
+          (exportFormat == 0) ? ".xyz" : (exportFormat == 1) ? ".pcb" : ".h5";
       auto destination = pfd::save_file("Export point cloud", ".",
                                         {"Point Cloud Files", "*" + defaultExt,
                                          "All Files", "*"})
@@ -5764,21 +6063,35 @@ void renderPointCloudManipulationPanel(Engine::PointCloud &pointCloud) {
       if (!destination.empty()) {
         bool success = false;
         if (exportFormat == 0) {
-          success =
-              Engine::PointCloudLoader::exportToXYZ(pointCloud, destination);
+          success = Engine::PointCloudLoader::exportToXYZ(
+              pointCloud, destination, exportApplyTransform);
+        } else if (exportFormat == 1) {
+          success = Engine::PointCloudLoader::exportToBinary(
+              pointCloud, destination, exportApplyTransform);
         } else {
-          success =
-              Engine::PointCloudLoader::exportToBinary(pointCloud, destination);
+          success = Engine::PointCloudLoader::exportToHDF5(
+              pointCloud, destination, exportApplyTransform);
         }
 
+        lastExportOk = success;
         if (success) {
+          lastExportStatus = "Exported to " + destination;
           std::cout << "Point cloud exported successfully to " << destination
                     << std::endl;
         } else {
+          lastExportStatus = "Export FAILED (see console)";
           std::cerr << "Failed to export point cloud to " << destination
                     << std::endl;
         }
       }
+    }
+
+    if (!lastExportStatus.empty()) {
+      ImGui::PushStyleColor(ImGuiCol_Text,
+                            lastExportOk ? ImVec4(0.4f, 0.9f, 0.4f, 1.0f)
+                                         : ImVec4(0.95f, 0.4f, 0.4f, 1.0f));
+      ImGui::TextWrapped("%s", lastExportStatus.c_str());
+      ImGui::PopStyleColor();
     }
   }
 

--- a/StereoVista/src/Loaders/PointCloudLoader.cpp
+++ b/StereoVista/src/Loaders/PointCloudLoader.cpp
@@ -158,7 +158,10 @@ namespace Engine {
             const uint32_t r8 = static_cast<uint32_t>(glm::clamp(c.r,0.f,1.f)*255.f+0.5f);
             const uint32_t g8 = static_cast<uint32_t>(glm::clamp(c.g,0.f,1.f)*255.f+0.5f);
             const uint32_t b8 = static_cast<uint32_t>(glm::clamp(c.b,0.f,1.f)*255.f+0.5f);
-            rgba[i] = (0xFFu<<24)|(b8<<16)|(g8<<8)|r8;
+            // The resolve shader ignores the alpha byte, so it is repurposed to
+            // carry the point intensity (8-bit, [0,1]) for GPU readback/export.
+            const uint32_t a8 = static_cast<uint32_t>(glm::clamp(pts[i].intensity,0.f,1.f)*255.f+0.5f);
+            rgba[i] = (a8<<24)|(b8<<16)|(g8<<8)|r8;
         }
 
         glBindBuffer(GL_SHADER_STORAGE_BUFFER, pc.computeBatchSSBO);
@@ -466,75 +469,213 @@ namespace Engine {
         return std::move(pointCloud);
     }
 
-    bool PointCloudLoader::exportToXYZ(const PointCloud& pointCloud, const std::string& filePath) {
+    // Build the local→world matrix from a cloud's transform fields (identity
+    // when applyTransform is false, i.e. when exporting local-space data).
+    static glm::mat4 pointCloudTransform(const PointCloud& pointCloud, bool applyTransform) {
+        if (!applyTransform) return glm::mat4(1.0f);
+        glm::mat4 transform = glm::mat4(1.0f);
+        transform = glm::translate(transform, pointCloud.position);
+        transform = glm::rotate(transform, glm::radians(pointCloud.rotation.x), glm::vec3(1, 0, 0));
+        transform = glm::rotate(transform, glm::radians(pointCloud.rotation.y), glm::vec3(0, 1, 0));
+        transform = glm::rotate(transform, glm::radians(pointCloud.rotation.z), glm::vec3(0, 0, 1));
+        transform = glm::scale(transform, pointCloud.scale);
+        return transform;
+    }
+
+    bool PointCloudLoader::forEachPointBatch(const PointCloud& pointCloud,
+        const std::function<void(const PointCloudPoint*, size_t)>& callback)
+    {
+        // Legacy path: CPU vector still populated (loader hasn't streamed yet).
+        if (!pointCloud.points.empty()) {
+            const size_t batchSz = PointCloud::kComputeBatchSize;
+            for (size_t first = 0; first < pointCloud.points.size(); first += batchSz) {
+                const size_t count = std::min(batchSz, pointCloud.points.size() - first);
+                callback(pointCloud.points.data() + first, count);
+            }
+            return true;
+        }
+
+        if (pointCloud.numBatches == 0 || pointCloud.totalPointCount == 0 ||
+            pointCloud.computeBatchSSBO == 0 || pointCloud.computeXyz4bSSBO == 0 ||
+            pointCloud.computeXyz8bSSBO == 0 || pointCloud.computeXyz12bSSBO == 0 ||
+            pointCloud.computeRGBASSBO == 0) {
+            std::cerr << "[PCExport] Point cloud '" << pointCloud.name
+                      << "' has no point data to read back\n";
+            return false;
+        }
+
+        // Read the batch descriptors once (32 bytes per batch).
+        std::vector<ComputeBatch> batches(pointCloud.numBatches);
+        glBindBuffer(GL_SHADER_STORAGE_BUFFER, pointCloud.computeBatchSSBO);
+        glGetBufferSubData(GL_SHADER_STORAGE_BUFFER, 0,
+                           static_cast<GLsizeiptr>(batches.size() * sizeof(ComputeBatch)),
+                           batches.data());
+
+        constexpr double   STEPS_30BIT = 1073741824.0; // 2^30
+        constexpr uint32_t MASK_10BIT  = 1023u;
+
+        std::vector<uint32_t> xyz4b, xyz8b, xyz12b, rgba;
+        std::vector<PointCloudPoint> decoded;
+
+        for (const ComputeBatch& batch : batches) {
+            if (batch.numPoints <= 0) continue;
+            const size_t count = static_cast<size_t>(batch.numPoints);
+
+            xyz4b.resize(count); xyz8b.resize(count); xyz12b.resize(count); rgba.resize(count);
+            const GLintptr   off = static_cast<GLintptr>(batch.firstPoint) * sizeof(uint32_t);
+            const GLsizeiptr byt = static_cast<GLsizeiptr>(count) * sizeof(uint32_t);
+
+            glBindBuffer(GL_SHADER_STORAGE_BUFFER, pointCloud.computeXyz4bSSBO);
+            glGetBufferSubData(GL_SHADER_STORAGE_BUFFER, off, byt, xyz4b.data());
+            glBindBuffer(GL_SHADER_STORAGE_BUFFER, pointCloud.computeXyz8bSSBO);
+            glGetBufferSubData(GL_SHADER_STORAGE_BUFFER, off, byt, xyz8b.data());
+            glBindBuffer(GL_SHADER_STORAGE_BUFFER, pointCloud.computeXyz12bSSBO);
+            glGetBufferSubData(GL_SHADER_STORAGE_BUFFER, off, byt, xyz12b.data());
+            glBindBuffer(GL_SHADER_STORAGE_BUFFER, pointCloud.computeRGBASSBO);
+            glGetBufferSubData(GL_SHADER_STORAGE_BUFFER, off, byt, rgba.data());
+
+            // Decode the 30-bit quantised coordinates back to floats using the
+            // batch bounds (inverse of uploadComputeBatch). +0.5 centres the
+            // value inside its quantisation step to minimise round-trip error.
+            const glm::dvec3 bMin(batch.min_x, batch.min_y, batch.min_z);
+            const glm::dvec3 bSize(
+                std::max(static_cast<double>(batch.max_x) - bMin.x, 1e-6),
+                std::max(static_cast<double>(batch.max_y) - bMin.y, 1e-6),
+                std::max(static_cast<double>(batch.max_z) - bMin.z, 1e-6));
+
+            decoded.resize(count);
+            for (size_t i = 0; i < count; i++) {
+                const uint32_t X = ((xyz4b[i]      ) & MASK_10BIT) << 20 |
+                                   ((xyz8b[i]      ) & MASK_10BIT) << 10 |
+                                   ((xyz12b[i]     ) & MASK_10BIT);
+                const uint32_t Y = ((xyz4b[i] >> 10) & MASK_10BIT) << 20 |
+                                   ((xyz8b[i] >> 10) & MASK_10BIT) << 10 |
+                                   ((xyz12b[i]>> 10) & MASK_10BIT);
+                const uint32_t Z = ((xyz4b[i] >> 20) & MASK_10BIT) << 20 |
+                                   ((xyz8b[i] >> 20) & MASK_10BIT) << 10 |
+                                   ((xyz12b[i]>> 20) & MASK_10BIT);
+
+                PointCloudPoint& pt = decoded[i];
+                pt.position = glm::vec3(
+                    static_cast<float>(bMin.x + (X + 0.5) / STEPS_30BIT * bSize.x),
+                    static_cast<float>(bMin.y + (Y + 0.5) / STEPS_30BIT * bSize.y),
+                    static_cast<float>(bMin.z + (Z + 0.5) / STEPS_30BIT * bSize.z));
+                pt.color = glm::vec3(( rgba[i]        & 0xFFu) / 255.0f,
+                                     ((rgba[i] >>  8) & 0xFFu) / 255.0f,
+                                     ((rgba[i] >> 16) & 0xFFu) / 255.0f);
+                pt.intensity = ((rgba[i] >> 24) & 0xFFu) / 255.0f;
+            }
+
+            callback(decoded.data(), count);
+        }
+
+        glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+        return true;
+    }
+
+    bool PointCloudLoader::exportToXYZ(const PointCloud& pointCloud, const std::string& filePath,
+                                       bool applyTransform) {
         std::ofstream file(filePath);
         if (!file.is_open()) {
             std::cerr << "Failed to open file for writing: " << filePath << std::endl;
             return false;
         }
 
-        // Create transformation matrix
-        glm::mat4 transform = glm::mat4(1.0f);
-        transform = glm::translate(transform, pointCloud.position);
-        transform = glm::rotate(transform, glm::radians(pointCloud.rotation.x), glm::vec3(1, 0, 0));
-        transform = glm::rotate(transform, glm::radians(pointCloud.rotation.y), glm::vec3(0, 1, 0));
-        transform = glm::rotate(transform, glm::radians(pointCloud.rotation.z), glm::vec3(0, 0, 1));
-        transform = glm::scale(transform, pointCloud.scale);
+        const glm::mat4 transform = pointCloudTransform(pointCloud, applyTransform);
 
-        for (const auto& point : pointCloud.points) {
-            // Apply transformation
-            glm::vec4 transformedPos = transform * glm::vec4(point.position, 1.0f);
+        size_t written = 0;
+        const bool ok = forEachPointBatch(pointCloud,
+            [&](const PointCloudPoint* pts, size_t count) {
+                for (size_t i = 0; i < count; i++) {
+                    const glm::vec3 pos = applyTransform
+                        ? glm::vec3(transform * glm::vec4(pts[i].position, 1.0f))
+                        : pts[i].position;
 
-            file << std::fixed << std::setprecision(3)
-                << transformedPos.x << " "
-                << transformedPos.y << " "
-                << transformedPos.z << " "
-                << static_cast<int>(point.intensity * 1000) << " "
-                << static_cast<int>(point.color.r * 255) << " "
-                << static_cast<int>(point.color.g * 255) << " "
-                << static_cast<int>(point.color.b * 255) << "\n";
-        }
+                    // x y z intensity r g b — intensity written as a float so
+                    // the text loader round-trips it unchanged.
+                    file << std::fixed << std::setprecision(4)
+                        << pos.x << " " << pos.y << " " << pos.z << " "
+                        << pts[i].intensity << " "
+                        << static_cast<int>(glm::clamp(pts[i].color.r, 0.0f, 1.0f) * 255.0f + 0.5f) << " "
+                        << static_cast<int>(glm::clamp(pts[i].color.g, 0.0f, 1.0f) * 255.0f + 0.5f) << " "
+                        << static_cast<int>(glm::clamp(pts[i].color.b, 0.0f, 1.0f) * 255.0f + 0.5f) << "\n";
+                }
+                written += count;
+            });
 
         file.close();
+        if (!ok || written == 0) {
+            std::cerr << "[PCExport] XYZ export failed — no point data written to "
+                      << filePath << std::endl;
+            std::error_code ec;
+            std::filesystem::remove(filePath, ec); // don't leave an empty stub behind
+            return false;
+        }
+        std::cout << "[PCExport] Wrote " << written << " points to " << filePath << std::endl;
         return true;
     }
 
-    bool PointCloudLoader::exportToBinary(const PointCloud& pointCloud, const std::string& filePath) {
+    bool PointCloudLoader::exportToBinary(const PointCloud& pointCloud, const std::string& filePath,
+                                          bool applyTransform) {
         std::ofstream file(filePath, std::ios::binary);
         if (!file.is_open()) {
             std::cerr << "Failed to open file for writing: " << filePath << std::endl;
             return false;
         }
 
-        // Create transformation matrix
-        glm::mat4 transform = glm::mat4(1.0f);
-        transform = glm::translate(transform, pointCloud.position);
-        transform = glm::rotate(transform, glm::radians(pointCloud.rotation.x), glm::vec3(1, 0, 0));
-        transform = glm::rotate(transform, glm::radians(pointCloud.rotation.y), glm::vec3(0, 1, 0));
-        transform = glm::rotate(transform, glm::radians(pointCloud.rotation.z), glm::vec3(0, 0, 1));
-        transform = glm::scale(transform, pointCloud.scale);
+        const glm::mat4 transform = pointCloudTransform(pointCloud, applyTransform);
 
-        // Write header
+        // Write header. The point count is patched after streaming in case a
+        // batch read fails partway through.
         file.write(BINARY_MAGIC_NUMBER, 4);
-        uint32_t numPoints = pointCloud.points.size();
+        uint32_t numPoints = 0;
         file.write(reinterpret_cast<const char*>(&numPoints), sizeof(numPoints));
 
-        // Write point data
-        for (const auto& point : pointCloud.points) {
-            // Apply transformation
-            glm::vec4 transformedPos = transform * glm::vec4(point.position, 1.0f);
-            glm::vec3 finalPos(transformedPos);
+        // Per-point record: vec3 position | uint32 intensity*1000 | u8vec3 color
+        constexpr size_t PT_SIZE = sizeof(glm::vec3) + sizeof(uint32_t) + sizeof(glm::u8vec3);
+        std::vector<char> recordBuf;
 
-            file.write(reinterpret_cast<const char*>(&finalPos), sizeof(finalPos));
+        size_t written = 0;
+        const bool ok = forEachPointBatch(pointCloud,
+            [&](const PointCloudPoint* pts, size_t count) {
+                recordBuf.resize(count * PT_SIZE);
+                char* dst = recordBuf.data();
+                for (size_t i = 0; i < count; i++) {
+                    const glm::vec3 pos = applyTransform
+                        ? glm::vec3(transform * glm::vec4(pts[i].position, 1.0f))
+                        : pts[i].position;
+                    std::memcpy(dst, &pos, sizeof(pos));
+                    dst += sizeof(pos);
 
-            uint32_t intensity = static_cast<uint32_t>(point.intensity * 1000);
-            file.write(reinterpret_cast<const char*>(&intensity), sizeof(intensity));
+                    const uint32_t intensity = static_cast<uint32_t>(
+                        glm::max(pts[i].intensity, 0.0f) * 1000.0f);
+                    std::memcpy(dst, &intensity, sizeof(intensity));
+                    dst += sizeof(intensity);
 
-            glm::u8vec3 color = glm::u8vec3(point.color * 255.0f);
-            file.write(reinterpret_cast<const char*>(&color), sizeof(color));
+                    const glm::u8vec3 color(glm::clamp(pts[i].color, 0.0f, 1.0f) * 255.0f);
+                    std::memcpy(dst, &color, sizeof(color));
+                    dst += sizeof(color);
+                }
+                file.write(recordBuf.data(), static_cast<std::streamsize>(recordBuf.size()));
+                written += count;
+            });
+
+        if (!ok || written == 0) {
+            file.close();
+            std::cerr << "[PCExport] Binary export failed — no point data written to "
+                      << filePath << std::endl;
+            std::error_code ec;
+            std::filesystem::remove(filePath, ec); // don't leave an empty stub behind
+            return false;
         }
 
+        // Patch the header with the actual point count.
+        numPoints = static_cast<uint32_t>(written);
+        file.seekp(4, std::ios::beg);
+        file.write(reinterpret_cast<const char*>(&numPoints), sizeof(numPoints));
         file.close();
+
+        std::cout << "[PCExport] Wrote " << written << " points to " << filePath << std::endl;
         return true;
     }
 
@@ -1466,13 +1607,23 @@ namespace Engine {
         return std::move(pointCloud);
     }
 
-    bool PointCloudLoader::exportToHDF5(const PointCloud& pointCloud, const std::string& filePath) {
+    bool PointCloudLoader::exportToHDF5(const PointCloud& pointCloud, const std::string& filePath,
+                                        bool applyTransform) {
         try {
             std::cout << "Exporting point cloud to HDF5: " << filePath << std::endl;
-            
+
+            const size_t totalPoints = !pointCloud.points.empty()
+                                     ? pointCloud.points.size()
+                                     : static_cast<size_t>(pointCloud.totalPointCount);
+            if (totalPoints == 0) {
+                std::cerr << "[PCExport] HDF5 export failed — point cloud '"
+                          << pointCloud.name << "' has no point data\n";
+                return false;
+            }
+
             // Create the HDF5 file
             H5File file(filePath, H5F_ACC_TRUNC);
-            
+
             // Define the HDF5 compound type for PointCloudPoint
             CompType pointType(sizeof(PointCloudPoint));
             pointType.insertMember("position_x", HOFFSET(PointCloudPoint, position.x), PredType::NATIVE_FLOAT);
@@ -1483,37 +1634,47 @@ namespace Engine {
             pointType.insertMember("color_g", HOFFSET(PointCloudPoint, color.g), PredType::NATIVE_FLOAT);
             pointType.insertMember("color_b", HOFFSET(PointCloudPoint, color.b), PredType::NATIVE_FLOAT);
 
-            // Create transformation matrix
-            glm::mat4 transform = glm::mat4(1.0f);
-            transform = glm::translate(transform, pointCloud.position);
-            transform = glm::rotate(transform, glm::radians(pointCloud.rotation.x), glm::vec3(1, 0, 0));
-            transform = glm::rotate(transform, glm::radians(pointCloud.rotation.y), glm::vec3(0, 1, 0));
-            transform = glm::rotate(transform, glm::radians(pointCloud.rotation.z), glm::vec3(0, 0, 1));
-            transform = glm::scale(transform, pointCloud.scale);
+            const glm::mat4 transform = pointCloudTransform(pointCloud, applyTransform);
 
-            // Apply transformations to points if needed
-            std::vector<PointCloudPoint> transformedPoints = pointCloud.points;
-            for (auto& point : transformedPoints) {
-                glm::vec4 transformedPos = transform * glm::vec4(point.position, 1.0f);
-                point.position = glm::vec3(transformedPos);
+            // Create dataspace and dataset sized for the full cloud, then
+            // stream the points into it one decoded batch (hyperslab) at a
+            // time — peak CPU RAM stays at one batch regardless of cloud size.
+            hsize_t dims[1] = { static_cast<hsize_t>(totalPoints) };
+            DataSpace dataspace(1, dims);
+            DataSet dataset = file.createDataSet("points", pointType, dataspace);
+
+            std::vector<PointCloudPoint> chunkBuf;
+            hsize_t writeOffset = 0;
+            const bool ok = forEachPointBatch(pointCloud,
+                [&](const PointCloudPoint* pts, size_t count) {
+                    chunkBuf.assign(pts, pts + count);
+                    if (applyTransform) {
+                        for (auto& point : chunkBuf) {
+                            point.position = glm::vec3(transform * glm::vec4(point.position, 1.0f));
+                        }
+                    }
+
+                    hsize_t start[1] = { writeOffset };
+                    hsize_t cnt[1]   = { static_cast<hsize_t>(count) };
+                    DataSpace memspace(1, cnt);
+                    DataSpace filespace = dataset.getSpace();
+                    filespace.selectHyperslab(H5S_SELECT_SET, cnt, start);
+                    dataset.write(chunkBuf.data(), pointType, memspace, filespace);
+                    writeOffset += count;
+                });
+
+            if (!ok || writeOffset == 0) {
+                std::cerr << "[PCExport] HDF5 export failed — no point data written to "
+                          << filePath << std::endl;
+                return false;
             }
 
-            // Create dataspace
-            hsize_t dims[1] = { transformedPoints.size() };
-            DataSpace dataspace(1, dims);
-            
-            // Create dataset
-            DataSet dataset = file.createDataSet("points", pointType, dataspace);
-            
-            // Write data
-            dataset.write(transformedPoints.data(), pointType);
-            
             // Add metadata attributes
             DataSpace scalarSpace(H5S_SCALAR);
-            
+
             // Add point count attribute
             Attribute pointCountAttr = dataset.createAttribute("point_count", PredType::NATIVE_HSIZE, scalarSpace);
-            hsize_t pointCount = transformedPoints.size();
+            hsize_t pointCount = writeOffset;
             pointCountAttr.write(PredType::NATIVE_HSIZE, &pointCount);
             
             // Add name attribute
@@ -1536,8 +1697,8 @@ namespace Engine {
             timeAttr.write(timeStringType, timeStr.c_str());
 
             file.close();
-            
-            std::cout << "Successfully exported " << transformedPoints.size() 
+
+            std::cout << "Successfully exported " << writeOffset
                      << " points to HDF5 file: " << filePath << std::endl;
             return true;
 

--- a/StereoVista/src/Loaders/PointCloudLoader.cpp
+++ b/StereoVista/src/Loaders/PointCloudLoader.cpp
@@ -605,7 +605,7 @@ namespace Engine {
 
         file.close();
         if (!ok || written == 0) {
-            std::cerr << "[PCExport] XYZ export failed — no point data written to "
+            std::cerr << "[PCExport] XYZ export failed - no point data written to "
                       << filePath << std::endl;
             std::error_code ec;
             std::filesystem::remove(filePath, ec); // don't leave an empty stub behind
@@ -662,7 +662,7 @@ namespace Engine {
 
         if (!ok || written == 0) {
             file.close();
-            std::cerr << "[PCExport] Binary export failed — no point data written to "
+            std::cerr << "[PCExport] Binary export failed - no point data written to "
                       << filePath << std::endl;
             std::error_code ec;
             std::filesystem::remove(filePath, ec); // don't leave an empty stub behind
@@ -1616,7 +1616,7 @@ namespace Engine {
                                      ? pointCloud.points.size()
                                      : static_cast<size_t>(pointCloud.totalPointCount);
             if (totalPoints == 0) {
-                std::cerr << "[PCExport] HDF5 export failed — point cloud '"
+                std::cerr << "[PCExport] HDF5 export failed - point cloud '"
                           << pointCloud.name << "' has no point data\n";
                 return false;
             }
@@ -1664,7 +1664,7 @@ namespace Engine {
                 });
 
             if (!ok || writeOffset == 0) {
-                std::cerr << "[PCExport] HDF5 export failed — no point data written to "
+                std::cerr << "[PCExport] HDF5 export failed - no point data written to "
                           << filePath << std::endl;
                 return false;
             }

--- a/StereoVista/src/Tools/MeasurementTool.cpp
+++ b/StereoVista/src/Tools/MeasurementTool.cpp
@@ -1,0 +1,369 @@
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include "Tools/MeasurementTool.h"
+#include <cstdio>
+#include <iostream>
+
+namespace Tools {
+
+    // ── Embedded overlay shaders ─────────────────────────────────────────────
+    // Same pattern as BVHDebugRenderer: tiny self-contained programs so the
+    // tool has no asset-file dependency.
+
+    static const char* kLineVertexSrc = R"(
+#version 330 core
+layout (location = 0) in vec3 aPos;
+layout (location = 1) in vec3 aColor;
+
+uniform mat4 uViewProj;
+
+out vec3 vColor;
+
+void main() {
+    gl_Position = uViewProj * vec4(aPos, 1.0);
+    vColor = aColor;
+}
+)";
+
+    static const char* kLineFragmentSrc = R"(
+#version 330 core
+in vec3 vColor;
+out vec4 FragColor;
+
+uniform float uAlpha;
+
+void main() {
+    FragColor = vec4(vColor, uAlpha);
+}
+)";
+
+    static const char* kPointVertexSrc = R"(
+#version 330 core
+layout (location = 0) in vec3 aPos;
+layout (location = 1) in vec3 aColor;
+
+uniform mat4 uViewProj;
+uniform float uPointSize;
+
+out vec3 vColor;
+
+void main() {
+    gl_Position = uViewProj * vec4(aPos, 1.0);
+    gl_PointSize = uPointSize;
+    vColor = aColor;
+}
+)";
+
+    static const char* kPointFragmentSrc = R"(
+#version 330 core
+in vec3 vColor;
+out vec4 FragColor;
+
+uniform float uAlpha;
+
+void main() {
+    // Round marker with a dark rim for contrast on any background.
+    vec2 d = gl_PointCoord * 2.0 - 1.0;
+    float r2 = dot(d, d);
+    if (r2 > 1.0) discard;
+    float rim = smoothstep(0.45, 0.85, r2);
+    FragColor = vec4(mix(vColor, vec3(0.05), rim), uAlpha);
+}
+)";
+
+    static GLuint compileProgram(const char* vsSrc, const char* fsSrc, const char* label) {
+        auto compile = [&](GLenum type, const char* src) -> GLuint {
+            GLuint shader = glCreateShader(type);
+            glShaderSource(shader, 1, &src, nullptr);
+            glCompileShader(shader);
+            GLint ok = GL_FALSE;
+            glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
+            if (!ok) {
+                char log[1024];
+                glGetShaderInfoLog(shader, sizeof(log), nullptr, log);
+                std::cerr << "[MeasurementTool] " << label << " shader compile error: "
+                          << log << std::endl;
+            }
+            return shader;
+        };
+
+        GLuint vs = compile(GL_VERTEX_SHADER, vsSrc);
+        GLuint fs = compile(GL_FRAGMENT_SHADER, fsSrc);
+        GLuint program = glCreateProgram();
+        glAttachShader(program, vs);
+        glAttachShader(program, fs);
+        glLinkProgram(program);
+        glDeleteShader(vs);
+        glDeleteShader(fs);
+
+        GLint ok = GL_FALSE;
+        glGetProgramiv(program, GL_LINK_STATUS, &ok);
+        if (!ok) {
+            char log[1024];
+            glGetProgramInfoLog(program, sizeof(log), nullptr, log);
+            std::cerr << "[MeasurementTool] " << label << " program link error: "
+                      << log << std::endl;
+        }
+        return program;
+    }
+
+    MeasurementTool::MeasurementTool() = default;
+
+    MeasurementTool::~MeasurementTool() {
+        cleanup();
+    }
+
+    void MeasurementTool::initialize() {
+        if (m_initialized) return;
+
+        auto makeBuffers = [](GLuint& vao, GLuint& vbo) {
+            glGenVertexArrays(1, &vao);
+            glGenBuffers(1, &vbo);
+            glBindVertexArray(vao);
+            glBindBuffer(GL_ARRAY_BUFFER, vbo);
+            glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 6 * sizeof(float), (void*)0);
+            glEnableVertexAttribArray(0);
+            glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 6 * sizeof(float),
+                                  (void*)(3 * sizeof(float)));
+            glEnableVertexAttribArray(1);
+            glBindBuffer(GL_ARRAY_BUFFER, 0);
+            glBindVertexArray(0);
+        };
+
+        makeBuffers(m_lineVAO, m_lineVBO);
+        makeBuffers(m_pointVAO, m_pointVBO);
+
+        m_lineProgram = compileProgram(kLineVertexSrc, kLineFragmentSrc, "line");
+        m_pointProgram = compileProgram(kPointVertexSrc, kPointFragmentSrc, "point");
+
+        m_initialized = true;
+    }
+
+    void MeasurementTool::cleanup() {
+        if (m_lineVAO) { glDeleteVertexArrays(1, &m_lineVAO); m_lineVAO = 0; }
+        if (m_lineVBO) { glDeleteBuffers(1, &m_lineVBO); m_lineVBO = 0; }
+        if (m_pointVAO) { glDeleteVertexArrays(1, &m_pointVAO); m_pointVAO = 0; }
+        if (m_pointVBO) { glDeleteBuffers(1, &m_pointVBO); m_pointVBO = 0; }
+        if (m_lineProgram) { glDeleteProgram(m_lineProgram); m_lineProgram = 0; }
+        if (m_pointProgram) { glDeleteProgram(m_pointProgram); m_pointProgram = 0; }
+        m_initialized = false;
+    }
+
+    void MeasurementTool::setEnabled(bool enabled) {
+        if (m_enabled == enabled) return;
+        m_enabled = enabled;
+        if (!enabled) {
+            finishActive(); // commit (or discard) whatever was in progress
+            m_previewValid = false;
+        }
+    }
+
+    void MeasurementTool::setMode(Engine::Measurement::Type mode) {
+        if (m_mode == mode) return;
+        finishActive();
+        m_mode = mode;
+    }
+
+    void MeasurementTool::addPoint(const glm::vec3& worldPos) {
+        if (!m_hasActive) {
+            m_active = Engine::Measurement();
+            m_active.type = m_mode;
+            m_active.color = nextColor;
+            m_nameCounter++;
+            const char* prefix =
+                (m_mode == Engine::Measurement::Type::Angle) ? "Angle" :
+                (m_mode == Engine::Measurement::Type::Point) ? "Point" : "Distance";
+            m_active.name = std::string(prefix) + " " + std::to_string(m_nameCounter);
+            m_hasActive = true;
+        }
+
+        m_active.points.push_back(worldPos);
+
+        if (m_active.type == Engine::Measurement::Type::Point &&
+            m_active.points.size() >= 1) {
+            commitActive();
+        } else if (m_active.type == Engine::Measurement::Type::Angle &&
+                   m_active.points.size() >= 3) {
+            commitActive();
+        }
+    }
+
+    void MeasurementTool::finishActive() {
+        if (!m_hasActive) return;
+        const size_t required =
+            (m_active.type == Engine::Measurement::Type::Angle) ? 3 :
+            (m_active.type == Engine::Measurement::Type::Point) ? 1 : 2;
+        if (m_active.points.size() >= required) {
+            commitActive();
+        } else {
+            cancelActive();
+        }
+    }
+
+    void MeasurementTool::cancelActive() {
+        m_hasActive = false;
+        m_active = Engine::Measurement();
+    }
+
+    void MeasurementTool::undoLastPoint() {
+        if (!m_hasActive || m_active.points.empty()) return;
+        m_active.points.pop_back();
+        if (m_active.points.empty()) {
+            cancelActive();
+        }
+    }
+
+    void MeasurementTool::commitActive() {
+        if (m_measurements && !m_active.points.empty()) {
+            m_measurements->push_back(std::move(m_active));
+        }
+        m_hasActive = false;
+        m_active = Engine::Measurement();
+    }
+
+    void MeasurementTool::deleteMeasurement(int index) {
+        if (!m_measurements) return;
+        if (index >= 0 && index < static_cast<int>(m_measurements->size())) {
+            m_measurements->erase(m_measurements->begin() + index);
+        }
+    }
+
+    void MeasurementTool::clearAll() {
+        cancelActive();
+        if (m_measurements) m_measurements->clear();
+    }
+
+    std::string MeasurementTool::formatLength(float worldLength) const {
+        char buf[64];
+        std::snprintf(buf, sizeof(buf), "%.3f %s",
+                      worldLength * unitScale, unitSuffix.c_str());
+        return buf;
+    }
+
+    void MeasurementTool::appendLine(std::vector<float>& out, const glm::vec3& a,
+                                     const glm::vec3& b, const glm::vec3& color) const {
+        out.insert(out.end(), { a.x, a.y, a.z, color.r, color.g, color.b,
+                                b.x, b.y, b.z, color.r, color.g, color.b });
+    }
+
+    void MeasurementTool::appendPoint(std::vector<float>& out, const glm::vec3& p,
+                                      const glm::vec3& color) const {
+        out.insert(out.end(), { p.x, p.y, p.z, color.r, color.g, color.b });
+    }
+
+    void MeasurementTool::render(const glm::mat4& projection, const glm::mat4& view,
+                                 const glm::vec3* previewPoint) {
+        if (!m_initialized) initialize();
+
+        std::vector<float> lineVerts;
+        std::vector<float> pointVerts;
+
+        // Committed measurements (scene data)
+        if (m_measurements) {
+            for (const auto& m : *m_measurements) {
+                if (!m.visible) continue;
+                for (size_t i = 1; i < m.points.size(); i++)
+                    appendLine(lineVerts, m.points[i - 1], m.points[i], m.color);
+                for (const auto& p : m.points)
+                    appendPoint(pointVerts, p, m.color);
+            }
+        }
+
+        // In-progress measurement + live rubber-band to the cursor
+        const glm::vec3 activeColor = glm::mix(nextColor, glm::vec3(1.0f), 0.25f);
+        if (m_hasActive) {
+            for (size_t i = 1; i < m_active.points.size(); i++)
+                appendLine(lineVerts, m_active.points[i - 1], m_active.points[i], activeColor);
+            for (const auto& p : m_active.points)
+                appendPoint(pointVerts, p, activeColor);
+        }
+
+        m_previewValid = false;
+        if (m_enabled && previewPoint) {
+            m_previewPoint = *previewPoint;
+            m_previewValid = true;
+            if (m_hasActive && !m_active.points.empty()) {
+                appendLine(lineVerts, m_active.points.back(), m_previewPoint,
+                           glm::mix(activeColor, glm::vec3(1.0f), 0.5f));
+            }
+            appendPoint(pointVerts, m_previewPoint, glm::vec3(1.0f));
+        }
+
+        if (lineVerts.empty() && pointVerts.empty()) return;
+
+        drawBuffers(projection, view, lineVerts, pointVerts);
+    }
+
+    void MeasurementTool::drawBuffers(const glm::mat4& projection, const glm::mat4& view,
+                                      const std::vector<float>& lineVerts,
+                                      const std::vector<float>& pointVerts) {
+        // Save the GL state we touch.
+        GLint prevDepthFunc = GL_LESS;
+        glGetIntegerv(GL_DEPTH_FUNC, &prevDepthFunc);
+        GLboolean prevDepthMask = GL_TRUE;
+        glGetBooleanv(GL_DEPTH_WRITEMASK, &prevDepthMask);
+        const GLboolean prevBlend = glIsEnabled(GL_BLEND);
+        const GLboolean prevPointSize = glIsEnabled(GL_PROGRAM_POINT_SIZE);
+
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        glEnable(GL_PROGRAM_POINT_SIZE);
+        // Overlay must never write depth: the cursor system samples scene depth
+        // from this buffer.
+        glDepthMask(GL_FALSE);
+        glLineWidth(lineWidth);
+
+        const glm::mat4 viewProj = projection * view;
+
+        auto drawPass = [&](float alpha) {
+            if (!lineVerts.empty()) {
+                glUseProgram(m_lineProgram);
+                glUniformMatrix4fv(glGetUniformLocation(m_lineProgram, "uViewProj"),
+                                   1, GL_FALSE, &viewProj[0][0]);
+                glUniform1f(glGetUniformLocation(m_lineProgram, "uAlpha"), alpha);
+                glBindVertexArray(m_lineVAO);
+                glBindBuffer(GL_ARRAY_BUFFER, m_lineVBO);
+                glBufferData(GL_ARRAY_BUFFER,
+                             static_cast<GLsizeiptr>(lineVerts.size() * sizeof(float)),
+                             lineVerts.data(), GL_DYNAMIC_DRAW);
+                glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(lineVerts.size() / 6));
+            }
+            if (!pointVerts.empty()) {
+                glUseProgram(m_pointProgram);
+                glUniformMatrix4fv(glGetUniformLocation(m_pointProgram, "uViewProj"),
+                                   1, GL_FALSE, &viewProj[0][0]);
+                glUniform1f(glGetUniformLocation(m_pointProgram, "uAlpha"), alpha);
+                glUniform1f(glGetUniformLocation(m_pointProgram, "uPointSize"),
+                            glm::max(6.0f, lineWidth * 4.0f));
+                glBindVertexArray(m_pointVAO);
+                glBindBuffer(GL_ARRAY_BUFFER, m_pointVBO);
+                glBufferData(GL_ARRAY_BUFFER,
+                             static_cast<GLsizeiptr>(pointVerts.size() * sizeof(float)),
+                             pointVerts.data(), GL_DYNAMIC_DRAW);
+                glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(pointVerts.size() / 6));
+            }
+        };
+
+        // Pass 1: normally depth-tested, fully opaque.
+        glDepthFunc(GL_LEQUAL);
+        drawPass(1.0f);
+
+        // Pass 2: occluded parts re-drawn ghosted so measurements stay legible
+        // through geometry.
+        if (xRay) {
+            glDepthFunc(GL_GREATER);
+            drawPass(0.22f);
+        }
+
+        // Restore state.
+        glDepthFunc(prevDepthFunc);
+        glDepthMask(prevDepthMask);
+        if (!prevBlend) glDisable(GL_BLEND);
+        if (!prevPointSize) glDisable(GL_PROGRAM_POINT_SIZE);
+        glBindVertexArray(0);
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+        glUseProgram(0);
+    }
+
+} // namespace Tools

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -30,6 +30,7 @@
 #include "Loaders/ModelLoader.h"
 #include "Loaders/PointCloudLoader.h"
 #include "Tools/BrushTool.h"
+#include "Tools/MeasurementTool.h"
 
 
 // ---- GUI and Dialog ----
@@ -193,6 +194,7 @@ bool showSettingsWindow = false;
 bool show3DCursor = true;
 bool showCursorSettingsWindow = false;
 bool showBrushToolWindow = false;
+bool showMeasurementToolWindow = false;
 enum class SelectedType {
   None,
   Model,
@@ -280,6 +282,9 @@ bool orbitFollowsCursor = false;
 
 // ---- Brush Tool ----
 Tools::BrushTool brushTool;
+
+// ---- Measurement Tool ----
+Tools::MeasurementTool measurementTool;
 
 // ---- Window Configuration ----
 int windowWidth = 1920;
@@ -3113,6 +3118,12 @@ int main() {
       brushTool.disable();
     }
 
+    // ---- Measurement Tool ----
+    // Keep the tool bound to the current scene's measurement storage
+    // (idempotent; the scene object is a global, so the pointer stays valid
+    // across scene loads).
+    measurementTool.setMeasurements(&currentScene.measurements);
+
     // ---- Update Model Depth Movement Physics ----
     // Apply smooth scrolling physics to model depth movement when dragging
     if (isMovingModel && currentSelectedType == SelectedType::Model &&
@@ -3852,6 +3863,9 @@ void cleanup() {
 
   // Clean up cursor preview before GUI shutdown
   cursorPreview3D.cleanup();
+
+  // Clean up measurement tool GL resources while the context is still valid
+  measurementTool.cleanup();
 
   // Clean up GUI before destroying window (ImGui needs valid OpenGL context)
   CleanupGUI();
@@ -5146,6 +5160,18 @@ void renderEye(GLenum drawBuffer, const glm::mat4 &projection,
 
   if (camera.IsPanning == false) {
     cursorManager.renderCursors(projection, view);
+  }
+
+  // Render measurement overlay (committed measurements always; rubber-band
+  // preview only while the tool is active and the cursor is on geometry)
+  {
+    glm::vec3 measurePreviewPos;
+    const glm::vec3 *measurePreview = nullptr;
+    if (measurementTool.isEnabled() && cursorManager.isCursorPositionValid()) {
+      measurePreviewPos = cursorManager.getCursorPosition();
+      measurePreview = &measurePreviewPos;
+    }
+    measurementTool.render(projection, view, measurePreview);
   }
 
   // Render brush tool indicator
@@ -6499,6 +6525,16 @@ void mouse_button_callback(GLFWwindow *window, int button, int action,
       bool ctrlPressed = (mods & GLFW_MOD_CONTROL);
       bool altPressed = (mods & GLFW_MOD_ALT);
 
+      // Measurement tool: place a point at the 3D cursor position and consume
+      // the click (no orbiting/selection while measuring). Ctrl/Alt clicks
+      // still fall through to object selection.
+      if (!ctrlPressed && !altPressed && measurementTool.isEnabled()) {
+        if (cursorManager.isCursorPositionValid()) {
+          measurementTool.addPoint(cursorManager.getCursorPosition());
+        }
+        return;
+      }
+
       // Handle brush tool painting (when enabled and no modifiers pressed)
       if (!ctrlPressed && !altPressed &&
           preferences.brushToolSettings.enabled &&
@@ -7031,6 +7067,13 @@ void mouse_button_callback(GLFWwindow *window, int button, int action,
     }
   } else if (button == GLFW_MOUSE_BUTTON_RIGHT) {
     if (action == GLFW_PRESS) {
+      // Measurement tool: right-click finishes the in-progress polyline
+      // instead of starting a camera rotation.
+      if (measurementTool.isEnabled() && measurementTool.hasActive()) {
+        measurementTool.finishActive();
+        return;
+      }
+
       rightMousePressed = true;
 
       // Capture cursor state for synchronization before starting rotation
@@ -7161,6 +7204,24 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
 
   if (action != GLFW_PRESS) {
     return; // Only handle PRESS actions below for other keys
+  }
+
+  // Measurement tool editing keys (only while a measurement is in progress).
+  // Note: Escape can't be used to cancel — Input::handleKeyInput closes the
+  // application on Escape.
+  if (measurementTool.isEnabled() && measurementTool.hasActive()) {
+    if (key == GLFW_KEY_ENTER || key == GLFW_KEY_KP_ENTER) {
+      measurementTool.finishActive();
+      return;
+    }
+    if (key == GLFW_KEY_DELETE) {
+      measurementTool.cancelActive();
+      return;
+    }
+    if (key == GLFW_KEY_BACKSPACE) {
+      measurementTool.undoLastPoint();
+      return;
+    }
   }
 
   // Check if this key press matches any shortcut action
@@ -7501,6 +7562,11 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
     case StereoVista::ShortcutAction::OpenBrushTool:
       showBrushToolWindow = true;
       std::cout << "Opening brush tool window" << std::endl;
+      break;
+
+    case StereoVista::ShortcutAction::OpenMeasurementTool:
+      showMeasurementToolWindow = true;
+      std::cout << "Opening measurement tool window" << std::endl;
       break;
 
     // File Operations - these will trigger file dialogs through GUI


### PR DESCRIPTION
Point cloud export and scene saving were completely broken: loaders
stream points directly into the GPU compute SSBOs and clear the
CPU-side points vector, but all three exporters (XYZ, binary, HDF5)
and the scene saver still read from that now-empty vector, silently
writing 0-point files that loaded back as invisible clouds.

Export/scene fixes:
- Add PointCloudLoader::forEachPointBatch(): streams points back from
  the quantised compute SSBOs one batch at a time, decoding the 30-bit
  coordinates via each batch's bounding box (falls back to the CPU
  vector when populated)
- Repurpose the unused alpha byte of the RGBA SSBO (the resolve shader
  hardcodes alpha to 1.0) to carry 8-bit point intensity so exports can
  round-trip it
- Rewrite exportToXYZ/exportToBinary/exportToHDF5 on top of the
  readback; they now fail loudly (and remove stub files) instead of
  reporting success on empty output. XYZ writes intensity as a float so
  the text loader round-trips it
- Scene save now exports point clouds in LOCAL space (previously the
  transform was baked into the points AND stored in the JSON, so it
  would have been applied twice on load), sanitizes/dedupes .pcb
  filenames, and persists visible + basePointSize
- Scene load restores the new fields and warns when a cloud comes back
  empty
- Export UI gains an HDF5 option, an apply-transform toggle, and
  in-panel success/failure feedback

New measurement tool (integrated with the 3D cursor pipeline):
- Tools::MeasurementTool: left click places points at the 3D cursor
  position; supports Distance polylines (per-segment + total length),
  Angle (3 points), and Point (coordinate annotation) modes
- World-space overlay rendered per eye (correct in stereo) with
  depth-tested lines/markers plus an optional x-ray ghost pass, and a
  live rubber-band preview to the cursor
- Screen-space value labels projected into the viewport via the ImGui
  foreground draw list, with live distance/angle readout while placing
- Right click / Enter finishes a polyline, Backspace undoes the last
  point, Delete cancels; Brush and Measurement tools are mutually
  exclusive since both consume left clicks
- Measurement Tool window (menu entry + OpenMeasurementTool shortcut,
  default key M): mode, units (m/dm/cm/mm/km/ft/in), labels, x-ray,
  line width, per-measurement visibility/color/delete
- Measurements are part of Engine::Scene and persist through scene
  save/load

https://claude.ai/code/session_01KfvmJJGP48iJKavKaiRchC