### PR TITLE
Add option to keep 3D cursor at last depth over background

### DIFF
--- a/StereoVista/headers/Cursors/Base/CursorManager.h
+++ b/StereoVista/headers/Cursors/Base/CursorManager.h
@@ -118,6 +118,20 @@ public:
   void setPositionLocked(bool locked) { m_positionLocked = locked; }
   bool isPositionLocked() const { return m_positionLocked; }
 
+  // When enabled, the 3D cursor does not fall back to the Windows cursor over
+  // the background. Instead it stays at the last valid depth and follows the
+  // mouse at that depth until geometry is hit again. Useful for sparse point
+  // clouds where the cursor would otherwise flicker between 2D and 3D.
+  void setKeepLastDepthOnBackground(bool keep) {
+    m_keepLastDepthOnBackground = keep;
+    if (!keep) {
+      m_hasLastValidDepth = false;
+    }
+  }
+  bool isKeepLastDepthOnBackground() const {
+    return m_keepLastDepthOnBackground;
+  }
+
 private:
   std::unique_ptr<SphereCursor> m_sphereCursor;
   std::unique_ptr<FragmentCursor> m_fragmentCursor;
@@ -160,6 +174,11 @@ private:
 
   // Position locking
   bool m_positionLocked;
+
+  // Last-known-depth caching (see setKeepLastDepthOnBackground)
+  bool m_keepLastDepthOnBackground = false;
+  float m_lastValidDepth = 0.5f; // depth buffer value of the last geometry hit
+  bool m_hasLastValidDepth = false;
 
   // Helper function to calculate background cursor position
   glm::vec3 calculateBackgroundCursorPosition(GLFWwindow *window,

--- a/StereoVista/headers/Gui/GuiTypes.h
+++ b/StereoVista/headers/Gui/GuiTypes.h
@@ -111,6 +111,10 @@ struct ApplicationPreferences {
   float cameraSpeedFactor = 1.0f;
   bool showFPS = true;
   bool show3DCursor = true;
+  // Keep the 3D cursor at the last valid depth when the mouse is over the
+  // background instead of switching to the Windows cursor (helps with sparse
+  // point clouds).
+  bool cursorKeepLastDepthOnBackground = false;
   bool useNewStereoMethod = true;
   float fov = 45.0f;
 

--- a/StereoVista/src/Cursors/Base/CursorManager.cpp
+++ b/StereoVista/src/Cursors/Base/CursorManager.cpp
@@ -152,9 +152,29 @@ void CursorManager::updateCursorPosition(
   auto worldPos = worldPosH / worldPosH.w;
   auto isHit = depth < DEPTH_THRESHOLD;
 
+  const bool anyCursorVisible = m_sphereCursor->isVisible() ||
+                                m_fragmentCursor->isVisible() ||
+                                m_planeCursor->isVisible();
+
+  if (isHit) {
+    // Remember the depth of the last geometry hit so the cursor can stay at
+    // this depth while the mouse passes over the background (sparse point
+    // clouds would otherwise make it flicker between 2D and 3D).
+    m_lastValidDepth = depth;
+    m_hasLastValidDepth = true;
+  } else if (m_keepLastDepthOnBackground && m_hasLastValidDepth &&
+             anyCursorVisible) {
+    // Over background: re-project the mouse position at the cached depth so
+    // the 3D cursor keeps following the mouse at the last known distance from
+    // the camera until it hits geometry again.
+    ndc.z = m_lastValidDepth * 2.0f - 1.0f;
+    worldPosH = vpInv * ndc;
+    worldPos = worldPosH / worldPosH.w;
+    isHit = true;
+  }
+
   // Update cursor properties based on whether it hit geometry
-  if (isHit && (m_sphereCursor->isVisible() || m_fragmentCursor->isVisible() ||
-                m_planeCursor->isVisible())) {
+  if (isHit && anyCursorVisible) {
     m_cursorPositionValid = true;
     m_cursorPosition = glm::vec3(worldPos);
 

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -4786,6 +4786,28 @@ void renderCursorSettingsWindow() {
   ImGui::Separator();
   ImGui::Spacing();
 
+  // Behavior Section
+  DrawSectionHeader("Behavior");
+
+  bool keepLastDepth = cursorManager.isKeepLastDepthOnBackground();
+  if (ImGui::Checkbox("Keep Cursor At Last Depth Over Background",
+                      &keepLastDepth)) {
+    cursorManager.setKeepLastDepthOnBackground(keepLastDepth);
+    preferences.cursorKeepLastDepthOnBackground = keepLastDepth;
+    savePreferences();
+  }
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip(
+        "Instead of switching to the Windows cursor over the background,\n"
+        "the 3D cursor stays at the last valid depth and follows the mouse\n"
+        "at that distance until it hits geometry again.\n"
+        "Useful for sparse point clouds.");
+  }
+
+  ImGui::Spacing();
+  ImGui::Separator();
+  ImGui::Spacing();
+
   // 3D Preview Section
   DrawSectionHeader("3D Preview");
 

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -1563,6 +1563,8 @@ void savePreferences() {
   j["ui"]["darkTheme"] = preferences.isDarkTheme;
   j["ui"]["showFPS"] = preferences.showFPS;
   j["ui"]["show3DCursor"] = preferences.show3DCursor;
+  j["ui"]["cursorKeepLastDepthOnBackground"] =
+      preferences.cursorKeepLastDepthOnBackground;
   j["ui"]["enableSpawnAnimation"] = preferences.enableSpawnAnimation;
   j["ui"]["guiScaleFactor"] = preferences.guiScaleFactor;
 
@@ -1843,6 +1845,8 @@ void applyPreferencesToProgram() {
   SetupImGuiStyle(isDarkTheme, 1.0f);
   showFPS = preferences.showFPS;
   show3DCursor = preferences.show3DCursor;
+  cursorManager.setKeepLastDepthOnBackground(
+      preferences.cursorKeepLastDepthOnBackground);
   g_GuiScale.userScaleFactor = preferences.guiScaleFactor;
 
   // Apply radiance/BVH preferences to the globals the renderer reads.
@@ -2006,6 +2010,8 @@ void loadPreferences() {
       preferences.isDarkTheme = j["ui"].value("darkTheme", true);
       preferences.showFPS = j["ui"].value("showFPS", true);
       preferences.show3DCursor = j["ui"].value("show3DCursor", true);
+      preferences.cursorKeepLastDepthOnBackground =
+          j["ui"].value("cursorKeepLastDepthOnBackground", false);
       preferences.enableSpawnAnimation =
           j["ui"].value("enableSpawnAnimation", true);
       preferences.guiScaleFactor = j["ui"].value("guiScaleFactor", 1.0f);


### PR DESCRIPTION
When the mouse moves over the background (e.g. gaps in sparse point
clouds), the cursor previously switched back to the Windows cursor,
causing constant flickering between 2D and 3D. With the new option
enabled, the 3D cursor caches the depth of the last geometry hit and
keeps following the mouse at that distance from the camera until it
hits a valid point again.

- CursorManager: cache last valid depth and re-project mouse x,y at
  that depth when over background (opt-in)
- New preference cursorKeepLastDepthOnBackground (saved under ui in
  preferences.json, default off)
- Checkbox in Cursor Settings window under new Behavior section

https://claude.ai/code/session_01UoUMcThAogtUmiiLpxCiV5