### PR TITLE
Add universal undo/redo system

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ All cursor types are managed by a unified **Cursor Manager** that:
 * Easily toggle between lighting techniques with the **L** key
 
 ### 🔧 Additional Features
+* **Undo/Redo System** - Universal edit history (Ctrl+Z / Ctrl+Y) covering object add/delete, transforms, material edits, and light changes
 * **Complete Scene Management** - Save and load entire scenes including models and point clouds
 * **Dynamic Lighting System** - Emissive materials automatically generate point lights with customizable intensity caps
 * **Skybox & Environment Mapping** - Multiple skybox modes (cubemap, solid color, gradient)
@@ -156,6 +157,8 @@ All user preferences are automatically saved to `preferences.json` and restored 
 | **Ctrl + Left Mouse** | Select model or point cloud under cursor |
 | **Ctrl + Left Mouse** drag | Move selected model in the view plane |
 | **Delete** | Remove selected model or point cloud from scene |
+| **Ctrl + Z** | Undo last action (edits, moves, add/delete) |
+| **Ctrl + Y / Ctrl + Shift + Z** | Redo last undone action |
 
 > **Note:** When releasing the Ctrl key after moving a model, the cursor remains at its current position rather than resetting to the center of the window, allowing for more intuitive model manipulation.
 

--- a/StereoVista/StereoVista.vcxproj
+++ b/StereoVista/StereoVista.vcxproj
@@ -203,6 +203,7 @@ IF %ERRORLEVEL% LEQ 7 SET ERRORLEVEL=0</Command>
     <ClCompile Include="headers\libs\portable-file-dialogs.h" />
     <ClCompile Include="src\Loaders\PointCloudLoader.cpp" />
     <ClCompile Include="src\Core\SceneManager.cpp" />
+    <ClCompile Include="src\Core\UndoManager.cpp" />
     <ClCompile Include="src\Engine\StbImageImpl.cpp" />
     <ClCompile Include="src\Core\Voxalizer.cpp" />
     <ClCompile Include="src\Cursors\Base\Cursor.cpp" />
@@ -219,6 +220,7 @@ IF %ERRORLEVEL% LEQ 7 SET ERRORLEVEL=0</Command>
   <ItemGroup>
     <ClInclude Include="headers\core.h" />
     <ClInclude Include="headers\Core\SceneManager.h" />
+    <ClInclude Include="headers\Core\UndoManager.h" />
     <ClInclude Include="headers\Core\CursorSynchronizer.h" />
     <ClInclude Include="headers\Core\CursorSyncState.h" />
     <ClInclude Include="headers\cursor_presets.h" />

--- a/StereoVista/StereoVista.vcxproj.filters
+++ b/StereoVista/StereoVista.vcxproj.filters
@@ -90,6 +90,9 @@
     <ClCompile Include="src\Core\SceneManager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Core\UndoManager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\Engine\StbImageImpl.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -450,6 +453,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="headers\Core\SceneManager.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="headers\Core\UndoManager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="headers\Core\CursorSynchronizer.h">

--- a/StereoVista/headers/Core/UndoManager.h
+++ b/StereoVista/headers/Core/UndoManager.h
@@ -1,0 +1,184 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <glm/glm.hpp>
+
+#include "Engine/Data.h"
+#include "Loaders/ModelLoader.h"
+
+namespace Engine {
+
+    // -----------------------------------------------------------------------
+    // Universal undo/redo system.
+    //
+    // Actions are recorded *after* they have been performed, so undo() must
+    // revert an action and redo() must re-apply it. Commands reference scene
+    // objects by index; this is safe because commands are replayed in strict
+    // LIFO order and every structural scene change (add/delete) goes through
+    // this system. The history is cleared whenever a scene file is loaded,
+    // since recorded indices would no longer match the new scene.
+    // -----------------------------------------------------------------------
+
+    class UndoCommand {
+    public:
+        virtual ~UndoCommand() = default;
+        virtual void undo() = 0;
+        virtual void redo() = 0;
+        virtual std::string description() const = 0;
+    };
+
+    // Generic command built from a pair of closures. Used for property edits
+    // (transforms, materials, light parameters) where before/after snapshots
+    // are cheap to capture.
+    class LambdaUndoCommand : public UndoCommand {
+    public:
+        LambdaUndoCommand(std::string description, std::function<void()> undoFn,
+                          std::function<void()> redoFn)
+            : desc(std::move(description)), undoFn(std::move(undoFn)),
+              redoFn(std::move(redoFn)) {}
+
+        void undo() override { if (undoFn) undoFn(); }
+        void redo() override { if (redoFn) redoFn(); }
+        std::string description() const override { return desc; }
+
+    private:
+        std::string desc;
+        std::function<void()> undoFn;
+        std::function<void()> redoFn;
+    };
+
+    class UndoManager {
+    public:
+        static UndoManager& instance();
+
+        // Record an already-performed action. Clears the redo stack.
+        void record(std::unique_ptr<UndoCommand> command);
+
+        bool undo();
+        bool redo();
+
+        bool canUndo() const { return !undoStack.empty(); }
+        bool canRedo() const { return !redoStack.empty(); }
+        std::string undoDescription() const;
+        std::string redoDescription() const;
+
+        // Drops all history. Must be called when a scene file is loaded (the
+        // recorded indices would no longer match) and once at shutdown while
+        // the GL context is still valid (commands may own GPU resources of
+        // deleted objects).
+        void clear();
+
+        // Invoked after every successful undo/redo so dependent systems
+        // (voxelizer, SpaceMouse bounds, selection state) can resynchronize.
+        void setSceneChangedCallback(std::function<void()> callback);
+
+    private:
+        UndoManager() = default;
+        static constexpr size_t kMaxUndoEntries = 64;
+
+        std::vector<std::unique_ptr<UndoCommand>> undoStack;
+        std::vector<std::unique_ptr<UndoCommand>> redoStack;
+        std::function<void()> sceneChangedCallback;
+    };
+
+    // -----------------------------------------------------------------------
+    // High-level helpers used by the GUI and input callbacks. They operate on
+    // the global scene containers (currentScene, pointLights, spotLights).
+    // -----------------------------------------------------------------------
+    namespace Undo {
+
+        // Snapshot of every property the GUI panels can edit on a Mesh.
+        struct MeshMaterialState {
+            bool visible = true;
+            glm::vec3 color = glm::vec3(1.0f);
+            float shininess = 32.0f;
+            float emissive = 0.0f;
+        };
+
+        // Snapshot of every property the GUI panels can edit on a Model.
+        // Mesh geometry is intentionally not captured; mesh add/remove is
+        // recorded as a separate structural command.
+        struct ModelEditState {
+            glm::vec3 position = glm::vec3(0.0f);
+            glm::vec3 rotation = glm::vec3(0.0f);
+            glm::vec3 scale = glm::vec3(1.0f);
+            bool visible = true;
+            glm::vec3 color = glm::vec3(1.0f);
+            float shininess = 1.0f;
+            float emissive = 0.0f;
+            float metallicFactor = 0.0f;
+            float roughnessFactor = 0.5f;
+            glm::vec3 F0 = glm::vec3(0.04f);
+            float normalScale = 1.0f;
+            float heightScale = 0.02f;
+            float diffuseReflectivity = 0.8f;
+            glm::vec3 specularColor = glm::vec3(1.0f);
+            float specularDiffusion = 0.5f;
+            float specularReflectivity = 0.0f;
+            float refractiveIndex = 1.0f;
+            float transparency = 0.0f;
+            MaterialType materialType = MaterialType::CONCRETE;
+            std::vector<MeshMaterialState> meshMaterials;
+
+            static ModelEditState capture(const Model& model);
+            void apply(Model& model) const;
+            bool operator==(const ModelEditState& other) const;
+            bool operator!=(const ModelEditState& other) const { return !(*this == other); }
+        };
+
+        // Snapshot of every property the GUI panels can edit on a PointCloud.
+        struct PointCloudEditState {
+            glm::vec3 position = glm::vec3(0.0f);
+            glm::vec3 rotation = glm::vec3(0.0f);
+            glm::vec3 scale = glm::vec3(1.0f);
+            bool visible = true;
+            float basePointSize = 2.0f;
+
+            static PointCloudEditState capture(const PointCloud& pointCloud);
+            void apply(PointCloud& pointCloud) const;
+            bool operator==(const PointCloudEditState& other) const;
+            bool operator!=(const PointCloudEditState& other) const { return !(*this == other); }
+        };
+
+        // Property edits. All of these are no-ops when before == after, so
+        // callers can invoke them unconditionally at the end of an edit
+        // gesture. Lights and the sun are small PODs and use full copies as
+        // their edit snapshots.
+        void recordModelEdit(int index, const ModelEditState& before, const ModelEditState& after);
+        void recordPointCloudEdit(int index, const PointCloudEditState& before, const PointCloudEditState& after);
+        void recordPointLightEdit(int index, const PointLight& before, const PointLight& after);
+        void recordSpotLightEdit(int index, const SpotLight& before, const SpotLight& after);
+        void recordSunEdit(const Sun& before, const Sun& after);
+
+        // Viewport drag moves (Ctrl+drag). No-ops when before == after.
+        void recordModelMoved(int index, const glm::vec3& before, const glm::vec3& after);
+        void recordPointLightMoved(int index, const glm::vec3& before, const glm::vec3& after);
+        void recordSpotLightMoved(int index, const glm::vec3& before, const glm::vec3& after);
+
+        // Structural edits: these PERFORM the deletion and record it. Deleted
+        // objects are moved into the undo entry (keeping their GPU resources
+        // alive) and moved back into the scene on undo.
+        void deleteModel(int index);
+        void deletePointCloud(int index);
+        void deletePointLight(int index);
+        void deleteSpotLight(int index);
+        void deleteMesh(int modelIndex, int meshIndex);
+        void deleteSceneGroup(std::vector<int> modelIndices,
+                              std::vector<int> pointCloudIndices,
+                              std::vector<int> pointLightIndices,
+                              std::vector<int> spotLightIndices);
+
+        // Additions: call right after the new object was appended to its
+        // container so the addition can be undone.
+        void recordModelAdded(int index);
+        void recordPointCloudAdded(int index);
+        void recordPointLightAdded(int index);
+        void recordSpotLightAdded(int index);
+
+    }
+
+}

--- a/StereoVista/headers/Engine/ShortcutManager.h
+++ b/StereoVista/headers/Engine/ShortcutManager.h
@@ -70,6 +70,10 @@ enum class ShortcutAction {
   // Object Manipulation
   DeleteObject, // Delete - Delete selected object
 
+  // Edit History
+  Undo, // Ctrl+Z - Undo last action
+  Redo, // Ctrl+Y - Redo last undone action
+
   // Reserved for future actions
   ACTION_COUNT
 };

--- a/StereoVista/src/Core/UndoManager.cpp
+++ b/StereoVista/src/Core/UndoManager.cpp
@@ -1,0 +1,603 @@
+#include "Core/UndoManager.h"
+#include "Core/SceneManager.h"
+
+#include <algorithm>
+#include <iostream>
+#include <type_traits>
+
+// Global scene containers owned by main.cpp.
+extern Engine::Scene currentScene;
+extern std::vector<Engine::PointLight> pointLights;
+extern std::vector<Engine::SpotLight> spotLights;
+extern Engine::Sun sun;
+
+namespace Engine {
+
+    // ======================================================================
+    // UndoManager
+    // ======================================================================
+
+    UndoManager& UndoManager::instance() {
+        static UndoManager manager;
+        return manager;
+    }
+
+    void UndoManager::record(std::unique_ptr<UndoCommand> command) {
+        if (!command) return;
+        undoStack.push_back(std::move(command));
+        if (undoStack.size() > kMaxUndoEntries) {
+            undoStack.erase(undoStack.begin());
+        }
+        // A new action invalidates everything that was undone before it.
+        redoStack.clear();
+    }
+
+    bool UndoManager::undo() {
+        if (undoStack.empty()) return false;
+        std::unique_ptr<UndoCommand> command = std::move(undoStack.back());
+        undoStack.pop_back();
+        command->undo();
+        std::cout << "Undo: " << command->description() << std::endl;
+        redoStack.push_back(std::move(command));
+        if (sceneChangedCallback) sceneChangedCallback();
+        return true;
+    }
+
+    bool UndoManager::redo() {
+        if (redoStack.empty()) return false;
+        std::unique_ptr<UndoCommand> command = std::move(redoStack.back());
+        redoStack.pop_back();
+        command->redo();
+        std::cout << "Redo: " << command->description() << std::endl;
+        undoStack.push_back(std::move(command));
+        if (sceneChangedCallback) sceneChangedCallback();
+        return true;
+    }
+
+    std::string UndoManager::undoDescription() const {
+        return undoStack.empty() ? std::string() : undoStack.back()->description();
+    }
+
+    std::string UndoManager::redoDescription() const {
+        return redoStack.empty() ? std::string() : redoStack.back()->description();
+    }
+
+    void UndoManager::clear() {
+        undoStack.clear();
+        redoStack.clear();
+    }
+
+    void UndoManager::setSceneChangedCallback(std::function<void()> callback) {
+        sceneChangedCallback = std::move(callback);
+    }
+
+    // ======================================================================
+    // Commands
+    // ======================================================================
+
+    namespace Undo {
+
+        // Frees the GL objects of a point cloud held by a discarded undo
+        // entry. PointCloud's destructor does not release them (live clouds
+        // share handles through moves), so the undo system must.
+        static void freePointCloudGpuResources(PointCloud& pc) {
+            if (pc.vao) { glDeleteVertexArrays(1, &pc.vao); pc.vao = 0; }
+            if (pc.vbo) { glDeleteBuffers(1, &pc.vbo); pc.vbo = 0; }
+            if (pc.chunkOutlineVAO) { glDeleteVertexArrays(1, &pc.chunkOutlineVAO); pc.chunkOutlineVAO = 0; }
+            if (pc.chunkOutlineVBO) { glDeleteBuffers(1, &pc.chunkOutlineVBO); pc.chunkOutlineVBO = 0; }
+            GLuint ssbos[] = { pc.computeBatchSSBO, pc.computeXyz12bSSBO, pc.computeXyz8bSSBO,
+                               pc.computeXyz4bSSBO, pc.computeRGBASSBO };
+            for (GLuint ssbo : ssbos) {
+                if (ssbo) glDeleteBuffers(1, &ssbo);
+            }
+            pc.computeBatchSSBO = pc.computeXyz12bSSBO = pc.computeXyz8bSSBO = 0;
+            pc.computeXyz4bSSBO = pc.computeRGBASSBO = 0;
+            pc.numBatches = 0;
+        }
+
+        // GPU resources owned by an object stranded in a discarded undo entry
+        // are disposed here. Models and meshes never freed their GL buffers
+        // on deletion before this system existed, so only point clouds need
+        // explicit disposal.
+        template <typename T>
+        static void disposeItem(T&) {}
+        static void disposeItem(PointCloud& pc) { freePointCloudGpuResources(pc); }
+
+        // Ownership ping-pong command for objects living in one of the global
+        // scene vectors. While the object is deleted from the scene the
+        // command owns it (keeping GPU resources alive so undo can restore it
+        // cheaply); while it is in the scene the command holds an empty
+        // placeholder. Works for both deletions and additions: an addition is
+        // a deletion with undo/redo swapped.
+        template <typename T>
+        class VectorItemCommand : public UndoCommand {
+        public:
+            using ContainerGetter = std::vector<T>& (*)();
+
+            // For removals the constructor performs the erase, taking
+            // ownership of the object. For additions the object must already
+            // be in the container at `index`.
+            VectorItemCommand(ContainerGetter getContainer, int index, bool isRemoval,
+                              std::string description)
+                : getContainer(getContainer), index(index), isRemoval(isRemoval),
+                  desc(std::move(description)) {
+                if (isRemoval) takeFromScene();
+            }
+
+            ~VectorItemCommand() override {
+                if (owning) disposeItem(item);
+            }
+
+            void undo() override { isRemoval ? returnToScene() : takeFromScene(); }
+            void redo() override { isRemoval ? takeFromScene() : returnToScene(); }
+            std::string description() const override { return desc; }
+
+        private:
+            void takeFromScene() {
+                std::vector<T>& container = getContainer();
+                if (index < 0 || index >= static_cast<int>(container.size())) return;
+                item = std::move(container[index]);
+                container.erase(container.begin() + index);
+                owning = true;
+            }
+
+            void returnToScene() {
+                if (!owning) return;
+                std::vector<T>& container = getContainer();
+                int at = std::min(index, static_cast<int>(container.size()));
+                container.insert(container.begin() + at, std::move(item));
+                owning = false;
+            }
+
+            ContainerGetter getContainer;
+            int index;
+            bool isRemoval;
+            bool owning = false;
+            std::string desc;
+            T item{};
+        };
+
+        static std::vector<Model>& modelContainer() { return ::currentScene.models; }
+        static std::vector<PointCloud>& pointCloudContainer() { return ::currentScene.pointClouds; }
+        static std::vector<PointLight>& pointLightContainer() { return ::pointLights; }
+        static std::vector<SpotLight>& spotLightContainer() { return ::spotLights; }
+
+        // Removes a single mesh from a model and restores it on undo. Looks
+        // the model up by index on every replay because the models vector may
+        // reallocate. The stored mesh copy shares the original GL buffers
+        // (meshes never free them), so re-inserting it is cheap and safe.
+        class DeleteMeshCommand : public UndoCommand {
+        public:
+            DeleteMeshCommand(int modelIndex, int meshIndex)
+                : modelIndex(modelIndex), meshIndex(meshIndex),
+                  mesh(::currentScene.models[modelIndex].getMeshes()[meshIndex]) {
+                removeMesh();
+            }
+
+            void undo() override {
+                Model* model = getModel();
+                if (!model) return;
+                auto& meshes = model->getMeshes();
+                int at = std::min(meshIndex, static_cast<int>(meshes.size()));
+                meshes.insert(meshes.begin() + at, mesh);
+                model->initializeMeshSelection();
+            }
+
+            void redo() override { removeMesh(); }
+
+            std::string description() const override {
+                std::string modelName = (modelIndex >= 0 && modelIndex < static_cast<int>(::currentScene.models.size()))
+                                            ? ::currentScene.models[modelIndex].name
+                                            : "model";
+                return "Delete mesh from '" + modelName + "'";
+            }
+
+        private:
+            Model* getModel() {
+                if (modelIndex < 0 || modelIndex >= static_cast<int>(::currentScene.models.size()))
+                    return nullptr;
+                return &::currentScene.models[modelIndex];
+            }
+
+            void removeMesh() {
+                Model* model = getModel();
+                if (!model) return;
+                auto& meshes = model->getMeshes();
+                if (meshIndex < 0 || meshIndex >= static_cast<int>(meshes.size())) return;
+                meshes.erase(meshes.begin() + meshIndex);
+                model->initializeMeshSelection();
+            }
+
+            int modelIndex;
+            int meshIndex;
+            Mesh mesh;
+        };
+
+        // Groups several commands into one undo entry (e.g. deleting a whole
+        // scene group). Children are undone in reverse order so per-container
+        // indices stay consistent.
+        class CompositeCommand : public UndoCommand {
+        public:
+            explicit CompositeCommand(std::string description) : desc(std::move(description)) {}
+
+            void add(std::unique_ptr<UndoCommand> command) {
+                children.push_back(std::move(command));
+            }
+
+            bool empty() const { return children.empty(); }
+
+            void undo() override {
+                for (auto it = children.rbegin(); it != children.rend(); ++it) {
+                    (*it)->undo();
+                }
+            }
+
+            void redo() override {
+                for (auto& child : children) {
+                    child->redo();
+                }
+            }
+
+            std::string description() const override { return desc; }
+
+        private:
+            std::string desc;
+            std::vector<std::unique_ptr<UndoCommand>> children;
+        };
+
+        // ==================================================================
+        // Edit-state snapshots
+        // ==================================================================
+
+        ModelEditState ModelEditState::capture(const Model& model) {
+            ModelEditState s;
+            s.position = model.position;
+            s.rotation = model.rotation;
+            s.scale = model.scale;
+            s.visible = model.visible;
+            s.color = model.color;
+            s.shininess = model.shininess;
+            s.emissive = model.emissive;
+            s.metallicFactor = model.metallicFactor;
+            s.roughnessFactor = model.roughnessFactor;
+            s.F0 = model.F0;
+            s.normalScale = model.normalScale;
+            s.heightScale = model.heightScale;
+            s.diffuseReflectivity = model.diffuseReflectivity;
+            s.specularColor = model.specularColor;
+            s.specularDiffusion = model.specularDiffusion;
+            s.specularReflectivity = model.specularReflectivity;
+            s.refractiveIndex = model.refractiveIndex;
+            s.transparency = model.transparency;
+            s.materialType = model.materialType;
+            s.meshMaterials.reserve(model.getMeshes().size());
+            for (const auto& mesh : model.getMeshes()) {
+                MeshMaterialState m;
+                m.visible = mesh.visible;
+                m.color = mesh.color;
+                m.shininess = mesh.shininess;
+                m.emissive = mesh.emissive;
+                s.meshMaterials.push_back(m);
+            }
+            return s;
+        }
+
+        void ModelEditState::apply(Model& model) const {
+            model.position = position;
+            model.rotation = rotation;
+            model.scale = scale;
+            model.visible = visible;
+            model.color = color;
+            model.shininess = shininess;
+            model.emissive = emissive;
+            model.metallicFactor = metallicFactor;
+            model.roughnessFactor = roughnessFactor;
+            model.F0 = F0;
+            model.normalScale = normalScale;
+            model.heightScale = heightScale;
+            model.diffuseReflectivity = diffuseReflectivity;
+            model.specularColor = specularColor;
+            model.specularDiffusion = specularDiffusion;
+            model.specularReflectivity = specularReflectivity;
+            model.refractiveIndex = refractiveIndex;
+            model.transparency = transparency;
+            model.materialType = materialType;
+            // Mesh materials are restored only when the mesh count still
+            // matches; mesh add/remove is its own structural command.
+            auto& meshes = model.getMeshes();
+            if (meshMaterials.size() == meshes.size()) {
+                for (size_t i = 0; i < meshes.size(); i++) {
+                    meshes[i].visible = meshMaterials[i].visible;
+                    meshes[i].color = meshMaterials[i].color;
+                    meshes[i].shininess = meshMaterials[i].shininess;
+                    meshes[i].emissive = meshMaterials[i].emissive;
+                }
+            }
+        }
+
+        bool ModelEditState::operator==(const ModelEditState& other) const {
+            if (!(position == other.position && rotation == other.rotation &&
+                  scale == other.scale && visible == other.visible &&
+                  color == other.color && shininess == other.shininess &&
+                  emissive == other.emissive &&
+                  metallicFactor == other.metallicFactor &&
+                  roughnessFactor == other.roughnessFactor && F0 == other.F0 &&
+                  normalScale == other.normalScale &&
+                  heightScale == other.heightScale &&
+                  diffuseReflectivity == other.diffuseReflectivity &&
+                  specularColor == other.specularColor &&
+                  specularDiffusion == other.specularDiffusion &&
+                  specularReflectivity == other.specularReflectivity &&
+                  refractiveIndex == other.refractiveIndex &&
+                  transparency == other.transparency &&
+                  materialType == other.materialType &&
+                  meshMaterials.size() == other.meshMaterials.size()))
+                return false;
+            for (size_t i = 0; i < meshMaterials.size(); i++) {
+                const MeshMaterialState& a = meshMaterials[i];
+                const MeshMaterialState& b = other.meshMaterials[i];
+                if (!(a.visible == b.visible && a.color == b.color &&
+                      a.shininess == b.shininess && a.emissive == b.emissive))
+                    return false;
+            }
+            return true;
+        }
+
+        PointCloudEditState PointCloudEditState::capture(const PointCloud& pointCloud) {
+            PointCloudEditState s;
+            s.position = pointCloud.position;
+            s.rotation = pointCloud.rotation;
+            s.scale = pointCloud.scale;
+            s.visible = pointCloud.visible;
+            s.basePointSize = pointCloud.basePointSize;
+            return s;
+        }
+
+        void PointCloudEditState::apply(PointCloud& pointCloud) const {
+            pointCloud.position = position;
+            pointCloud.rotation = rotation;
+            pointCloud.scale = scale;
+            pointCloud.visible = visible;
+            pointCloud.basePointSize = basePointSize;
+        }
+
+        bool PointCloudEditState::operator==(const PointCloudEditState& other) const {
+            return position == other.position && rotation == other.rotation &&
+                   scale == other.scale && visible == other.visible &&
+                   basePointSize == other.basePointSize;
+        }
+
+        static bool lightEquals(const PointLight& a, const PointLight& b) {
+            return a.position == b.position && a.color == b.color &&
+                   a.intensity == b.intensity && a.linear == b.linear &&
+                   a.quadratic == b.quadratic && a.castShadows == b.castShadows;
+        }
+
+        static bool lightEquals(const SpotLight& a, const SpotLight& b) {
+            return a.position == b.position && a.direction == b.direction &&
+                   a.color == b.color && a.intensity == b.intensity &&
+                   a.innerCutOff == b.innerCutOff && a.outerCutOff == b.outerCutOff &&
+                   a.castShadows == b.castShadows;
+        }
+
+        static bool sunEquals(const Sun& a, const Sun& b) {
+            return a.direction == b.direction && a.color == b.color &&
+                   a.intensity == b.intensity && a.enabled == b.enabled;
+        }
+
+        // ==================================================================
+        // Property-edit records
+        // ==================================================================
+
+        void recordModelEdit(int index, const ModelEditState& before, const ModelEditState& after) {
+            if (before == after) return;
+            UndoManager::instance().record(std::make_unique<LambdaUndoCommand>(
+                "Edit model properties",
+                [index, before]() {
+                    if (index >= 0 && index < static_cast<int>(::currentScene.models.size()))
+                        before.apply(::currentScene.models[index]);
+                },
+                [index, after]() {
+                    if (index >= 0 && index < static_cast<int>(::currentScene.models.size()))
+                        after.apply(::currentScene.models[index]);
+                }));
+        }
+
+        void recordPointCloudEdit(int index, const PointCloudEditState& before, const PointCloudEditState& after) {
+            if (before == after) return;
+            UndoManager::instance().record(std::make_unique<LambdaUndoCommand>(
+                "Edit point cloud properties",
+                [index, before]() {
+                    if (index >= 0 && index < static_cast<int>(::currentScene.pointClouds.size()))
+                        before.apply(::currentScene.pointClouds[index]);
+                },
+                [index, after]() {
+                    if (index >= 0 && index < static_cast<int>(::currentScene.pointClouds.size()))
+                        after.apply(::currentScene.pointClouds[index]);
+                }));
+        }
+
+        void recordPointLightEdit(int index, const PointLight& before, const PointLight& after) {
+            if (lightEquals(before, after)) return;
+            UndoManager::instance().record(std::make_unique<LambdaUndoCommand>(
+                "Edit point light",
+                [index, before]() {
+                    if (index >= 0 && index < static_cast<int>(::pointLights.size()))
+                        ::pointLights[index] = before;
+                },
+                [index, after]() {
+                    if (index >= 0 && index < static_cast<int>(::pointLights.size()))
+                        ::pointLights[index] = after;
+                }));
+        }
+
+        void recordSpotLightEdit(int index, const SpotLight& before, const SpotLight& after) {
+            if (lightEquals(before, after)) return;
+            UndoManager::instance().record(std::make_unique<LambdaUndoCommand>(
+                "Edit spot light",
+                [index, before]() {
+                    if (index >= 0 && index < static_cast<int>(::spotLights.size()))
+                        ::spotLights[index] = before;
+                },
+                [index, after]() {
+                    if (index >= 0 && index < static_cast<int>(::spotLights.size()))
+                        ::spotLights[index] = after;
+                }));
+        }
+
+        void recordSunEdit(const Sun& before, const Sun& after) {
+            if (sunEquals(before, after)) return;
+            UndoManager::instance().record(std::make_unique<LambdaUndoCommand>(
+                "Edit sun light",
+                [before]() { ::sun = before; },
+                [after]() { ::sun = after; }));
+        }
+
+        // ==================================================================
+        // Viewport drag moves
+        // ==================================================================
+
+        void recordModelMoved(int index, const glm::vec3& before, const glm::vec3& after) {
+            if (before == after) return;
+            std::string name = (index >= 0 && index < static_cast<int>(::currentScene.models.size()))
+                                   ? ::currentScene.models[index].name
+                                   : "model";
+            UndoManager::instance().record(std::make_unique<LambdaUndoCommand>(
+                "Move '" + name + "'",
+                [index, before]() {
+                    if (index >= 0 && index < static_cast<int>(::currentScene.models.size()))
+                        ::currentScene.models[index].position = before;
+                },
+                [index, after]() {
+                    if (index >= 0 && index < static_cast<int>(::currentScene.models.size()))
+                        ::currentScene.models[index].position = after;
+                }));
+        }
+
+        void recordPointLightMoved(int index, const glm::vec3& before, const glm::vec3& after) {
+            if (before == after) return;
+            UndoManager::instance().record(std::make_unique<LambdaUndoCommand>(
+                "Move point light",
+                [index, before]() {
+                    if (index >= 0 && index < static_cast<int>(::pointLights.size()))
+                        ::pointLights[index].position = before;
+                },
+                [index, after]() {
+                    if (index >= 0 && index < static_cast<int>(::pointLights.size()))
+                        ::pointLights[index].position = after;
+                }));
+        }
+
+        void recordSpotLightMoved(int index, const glm::vec3& before, const glm::vec3& after) {
+            if (before == after) return;
+            UndoManager::instance().record(std::make_unique<LambdaUndoCommand>(
+                "Move spot light",
+                [index, before]() {
+                    if (index >= 0 && index < static_cast<int>(::spotLights.size()))
+                        ::spotLights[index].position = before;
+                },
+                [index, after]() {
+                    if (index >= 0 && index < static_cast<int>(::spotLights.size()))
+                        ::spotLights[index].position = after;
+                }));
+        }
+
+        // ==================================================================
+        // Structural edits
+        // ==================================================================
+
+        void deleteModel(int index) {
+            if (index < 0 || index >= static_cast<int>(::currentScene.models.size())) return;
+            std::string name = ::currentScene.models[index].name;
+            UndoManager::instance().record(std::make_unique<VectorItemCommand<Model>>(
+                &modelContainer, index, true, "Delete '" + name + "'"));
+        }
+
+        void deletePointCloud(int index) {
+            if (index < 0 || index >= static_cast<int>(::currentScene.pointClouds.size())) return;
+            std::string name = ::currentScene.pointClouds[index].name;
+            UndoManager::instance().record(std::make_unique<VectorItemCommand<PointCloud>>(
+                &pointCloudContainer, index, true, "Delete '" + name + "'"));
+        }
+
+        void deletePointLight(int index) {
+            if (index < 0 || index >= static_cast<int>(::pointLights.size())) return;
+            UndoManager::instance().record(std::make_unique<VectorItemCommand<PointLight>>(
+                &pointLightContainer, index, true, "Delete point light"));
+        }
+
+        void deleteSpotLight(int index) {
+            if (index < 0 || index >= static_cast<int>(::spotLights.size())) return;
+            UndoManager::instance().record(std::make_unique<VectorItemCommand<SpotLight>>(
+                &spotLightContainer, index, true, "Delete spot light"));
+        }
+
+        void deleteMesh(int modelIndex, int meshIndex) {
+            if (modelIndex < 0 || modelIndex >= static_cast<int>(::currentScene.models.size())) return;
+            auto& meshes = ::currentScene.models[modelIndex].getMeshes();
+            if (meshIndex < 0 || meshIndex >= static_cast<int>(meshes.size())) return;
+            UndoManager::instance().record(std::make_unique<DeleteMeshCommand>(modelIndex, meshIndex));
+        }
+
+        void deleteSceneGroup(std::vector<int> modelIndices,
+                              std::vector<int> pointCloudIndices,
+                              std::vector<int> pointLightIndices,
+                              std::vector<int> spotLightIndices) {
+            auto composite = std::make_unique<CompositeCommand>("Delete scene group");
+
+            // Erase from highest to lowest index so the remaining indices in
+            // each container stay valid while the group is taken apart.
+            auto addRemovals = [&composite](std::vector<int>& indices, auto containerGetter,
+                                            const char* what) {
+                using ItemType = typename std::remove_reference<decltype(containerGetter()[0])>::type;
+                std::sort(indices.rbegin(), indices.rend());
+                for (int index : indices) {
+                    if (index < 0 || index >= static_cast<int>(containerGetter().size())) continue;
+                    composite->add(std::make_unique<VectorItemCommand<ItemType>>(
+                        containerGetter, index, true, what));
+                }
+            };
+
+            addRemovals(modelIndices, &modelContainer, "Delete model");
+            addRemovals(pointCloudIndices, &pointCloudContainer, "Delete point cloud");
+            addRemovals(pointLightIndices, &pointLightContainer, "Delete point light");
+            addRemovals(spotLightIndices, &spotLightContainer, "Delete spot light");
+
+            if (!composite->empty()) {
+                UndoManager::instance().record(std::move(composite));
+            }
+        }
+
+        // ==================================================================
+        // Addition records
+        // ==================================================================
+
+        void recordModelAdded(int index) {
+            if (index < 0 || index >= static_cast<int>(::currentScene.models.size())) return;
+            std::string name = ::currentScene.models[index].name;
+            UndoManager::instance().record(std::make_unique<VectorItemCommand<Model>>(
+                &modelContainer, index, false, "Add '" + name + "'"));
+        }
+
+        void recordPointCloudAdded(int index) {
+            if (index < 0 || index >= static_cast<int>(::currentScene.pointClouds.size())) return;
+            std::string name = ::currentScene.pointClouds[index].name;
+            UndoManager::instance().record(std::make_unique<VectorItemCommand<PointCloud>>(
+                &pointCloudContainer, index, false, "Add '" + name + "'"));
+        }
+
+        void recordPointLightAdded(int index) {
+            if (index < 0 || index >= static_cast<int>(::pointLights.size())) return;
+            UndoManager::instance().record(std::make_unique<VectorItemCommand<PointLight>>(
+                &pointLightContainer, index, false, "Add point light"));
+        }
+
+        void recordSpotLightAdded(int index) {
+            if (index < 0 || index >= static_cast<int>(::spotLights.size())) return;
+            UndoManager::instance().record(std::make_unique<VectorItemCommand<SpotLight>>(
+                &spotLightContainer, index, false, "Add spot light"));
+        }
+
+    }
+
+}

--- a/StereoVista/src/Engine/ShortcutManager.cpp
+++ b/StereoVista/src/Engine/ShortcutManager.cpp
@@ -434,6 +434,11 @@ ShortcutProfile ShortcutManager::createDefaultProfile() {
   profile.setBinding(ShortcutAction::ResetCamera, KeyBinding(GLFW_KEY_HOME), 0);
   profile.setBinding(ShortcutAction::OpenMeasurementTool, KeyBinding(GLFW_KEY_M),
                      0);
+  profile.setBinding(ShortcutAction::Undo, KeyBinding(GLFW_KEY_Z, true), 0);
+  profile.setBinding(ShortcutAction::Redo, KeyBinding(GLFW_KEY_Y, true), 0);
+  profile.setBinding(ShortcutAction::Redo,
+                     KeyBinding(GLFW_KEY_Z, true, false, true),
+                     1); // Ctrl+Shift+Z
 
   // New actions start unbound - users can assign keys as needed
 
@@ -631,6 +636,12 @@ std::string ShortcutManager::getActionName(ShortcutAction action) {
   case ShortcutAction::DeleteObject:
     return "DeleteObject";
 
+  // Edit History
+  case ShortcutAction::Undo:
+    return "Undo";
+  case ShortcutAction::Redo:
+    return "Redo";
+
   default:
     return "Unknown";
   }
@@ -736,6 +747,12 @@ std::string ShortcutManager::getActionDescription(ShortcutAction action) {
   case ShortcutAction::DeleteObject:
     return "Delete Selected Object";
 
+  // Edit History
+  case ShortcutAction::Undo:
+    return "Undo Last Action";
+  case ShortcutAction::Redo:
+    return "Redo Last Undone Action";
+
   default:
     return "Unknown Action";
   }
@@ -796,6 +813,34 @@ bool ShortcutManager::loadFromFile(const std::string &filepath) {
     // If no profiles loaded, create default
     if (profiles.empty()) {
       profiles.push_back(createDefaultProfile());
+    }
+
+    // Backfill default bindings for actions added after this shortcuts file
+    // was written (e.g. Undo/Redo) so new features stay reachable. Default
+    // bindings that would conflict with the user's existing bindings are
+    // skipped.
+    ShortcutProfile defaults = createDefaultProfile();
+    for (auto &profile : profiles) {
+      for (const auto &[action, defaultBindings] : defaults.bindings) {
+        bool hasValidBinding = false;
+        for (const auto &binding : profile.getBindings(action)) {
+          if (binding.isValid()) {
+            hasValidBinding = true;
+            break;
+          }
+        }
+        if (hasValidBinding)
+          continue;
+
+        int slot = 0;
+        for (const auto &binding : defaultBindings) {
+          if (binding.isValid() && slot < 2 &&
+              !profile.findConflict(binding, action).has_value()) {
+            profile.setBinding(action, binding, slot);
+            slot++;
+          }
+        }
+      }
     }
 
     // Set active profile

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -1,5 +1,6 @@
 #include "Gui/Gui.h"
 #include "Core/Camera.h"
+#include "Core/UndoManager.h"
 #include "Core/Voxalizer.h"
 #include "Cursors/Base/CursorManager.h"
 #include "Engine/BVHDebug.h"
@@ -144,6 +145,52 @@ static int g_settingsCategory = SETTINGS_CAT_AI;
 // frame in renderGUI so the 3D viewport can be sized to the free area.
 float g_dockLeftWidth = 0.0f;
 float g_dockTopHeight = 0.0f;
+
+// ===========================================================================
+// Undo integration: per-panel edit gesture tracking
+// ===========================================================================
+
+// Records one undo entry per ImGui edit gesture (slider drag, color pick,
+// checkbox click, text input) instead of one per frame. A manipulation panel
+// calls update() after its widgets, passing the object state captured before
+// the widgets ran this frame (preFrame) and the state now (current). When a
+// gesture ends, record() is invoked once with the state from before the
+// gesture began and the final state; the record functions themselves discard
+// no-op edits, so spurious gestures (e.g. clicking a button) record nothing.
+template <typename State> struct PanelEditTracker {
+  bool editing = false;
+  int objectIndex = -1;
+  State preEdit{};
+
+  template <typename RecordFn>
+  void update(int index, const State &preFrame, const State &current,
+              RecordFn record) {
+    const bool activeNow = ImGui::IsAnyItemActive();
+    if (!editing) {
+      if (activeNow) {
+        editing = true;
+        objectIndex = index;
+        preEdit = preFrame;
+      }
+    } else if (!activeNow) {
+      if (objectIndex == index) {
+        record(index, preEdit, current);
+      }
+      editing = false;
+      objectIndex = -1;
+    } else if (objectIndex != index) {
+      // Selection changed mid-gesture - restart tracking on the new object.
+      objectIndex = index;
+      preEdit = preFrame;
+    }
+  }
+};
+
+static PanelEditTracker<Engine::Undo::ModelEditState> s_modelEditTracker;
+static PanelEditTracker<Engine::Undo::PointCloudEditState> s_pointCloudEditTracker;
+static PanelEditTracker<Engine::PointLight> s_pointLightEditTracker;
+static PanelEditTracker<Engine::SpotLight> s_spotLightEditTracker;
+static PanelEditTracker<Engine::Sun> s_sunEditTracker;
 
 // Draw a FontAwesome glyph inline using the dedicated icon font (the icon font
 // is always guaranteed to contain the glyph, unlike the merged regular font),
@@ -500,6 +547,10 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
   // Helper lambda to load and replace scene
   auto loadAndReplaceScene = [&](const std::string &sceneFile) {
     try {
+      // Recorded undo entries reference objects by index, which no longer
+      // match once a scene file replaces the containers
+      Engine::UndoManager::instance().clear();
+
       // Clear all existing objects
       currentScene.models.clear();
       currentScene.pointClouds.clear();
@@ -538,6 +589,9 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
   // Helper lambda to load and merge scene
   auto loadAndMergeScene = [&](const std::string &sceneFile) {
     try {
+      // Bulk merges are not tracked, so drop the index-based undo history
+      Engine::UndoManager::instance().clear();
+
       // Load new scene and merge with existing
       Engine::Scene newScene = Engine::loadScene(sceneFile, camera);
 
@@ -579,6 +633,7 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
 
   // Helper lambda to load scene (first load or based on preference)
   auto loadSceneWithPreference = [&](const std::string &sceneFile) {
+    Engine::UndoManager::instance().clear();
     currentScene = Engine::loadScene(sceneFile, camera);
     pointLights = currentScene.pointLights;
     for (auto &pl : pointLights) {
@@ -629,6 +684,8 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
                 newModel.startSpawnAnimation(targetScale, 1.1f);
               }
               currentScene.models.push_back(newModel);
+              Engine::Undo::recordModelAdded(
+                  static_cast<int>(currentScene.models.size()) - 1);
               currentSelectedIndex = currentScene.models.size() - 1;
               currentSelectedType = SelectedType::Model;
               updateSpaceMouseBounds();
@@ -677,6 +734,8 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
               auto clouds = Engine::PointCloudLoader::loadFromLASMultiple(lasFiles);
               for (auto& pc : clouds) {
                 currentScene.pointClouds.emplace_back(std::move(pc));
+                Engine::Undo::recordPointCloudAdded(
+                    static_cast<int>(currentScene.pointClouds.size()) - 1);
               }
               updateSpaceMouseBounds();
             }
@@ -693,6 +752,8 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
                     Engine::PointCloudLoader::loadPointCloudFile(filePath));
                 newPointCloud.filePath = filePath;
                 currentScene.pointClouds.emplace_back(std::move(newPointCloud));
+                Engine::Undo::recordPointCloudAdded(
+                    static_cast<int>(currentScene.pointClouds.size()) - 1);
                 updateSpaceMouseBounds();
               } else if (extension == ".pcb") {
                 Engine::PointCloud newPointCloud =
@@ -702,6 +763,8 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
                   newPointCloud.name =
                       std::filesystem::path(filePath).stem().string();
                   currentScene.pointClouds.emplace_back(std::move(newPointCloud));
+                  Engine::Undo::recordPointCloudAdded(
+                      static_cast<int>(currentScene.pointClouds.size()) - 1);
                   updateSpaceMouseBounds();
                 }
               } else if (extension == ".h5" || extension == ".hdf5" ||
@@ -713,6 +776,8 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
                   newPointCloud.name =
                       std::filesystem::path(filePath).stem().string();
                   currentScene.pointClouds.emplace_back(std::move(newPointCloud));
+                  Engine::Undo::recordPointCloudAdded(
+                      static_cast<int>(currentScene.pointClouds.size()) - 1);
                   updateSpaceMouseBounds();
                 }
               }
@@ -856,6 +921,49 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
       ImGui::EndPopup();
     }
 
+    // Edit Menu (undo/redo history)
+    if (ImGui::BeginMenu("Edit")) {
+      Engine::UndoManager &undoManager = Engine::UndoManager::instance();
+
+      // Show the active profile's binding next to the menu entry
+      auto bindingLabel = [](StereoVista::ShortcutAction action,
+                             const char *fallback) -> std::string {
+        const StereoVista::ShortcutProfile *profile =
+            shortcutManager.getActiveProfile();
+        if (profile) {
+          const auto &bindings = profile->getBindings(action);
+          if (!bindings.empty() && bindings[0].isValid()) {
+            return bindings[0].toString();
+          }
+        }
+        return fallback;
+      };
+
+      std::string undoLabel = "Undo";
+      if (undoManager.canUndo()) {
+        undoLabel += " " + undoManager.undoDescription();
+      }
+      if (ImGui::MenuItem(
+              undoLabel.c_str(),
+              bindingLabel(StereoVista::ShortcutAction::Undo, "Ctrl+Z").c_str(),
+              false, undoManager.canUndo())) {
+        undoManager.undo();
+      }
+
+      std::string redoLabel = "Redo";
+      if (undoManager.canRedo()) {
+        redoLabel += " " + undoManager.redoDescription();
+      }
+      if (ImGui::MenuItem(
+              redoLabel.c_str(),
+              bindingLabel(StereoVista::ShortcutAction::Redo, "Ctrl+Y").c_str(),
+              false, undoManager.canRedo())) {
+        undoManager.redo();
+      }
+
+      ImGui::EndMenu();
+    }
+
     // Create Menu
     if (ImGui::BeginMenu("Create")) {
       // Use non-collapsible headers instead of dropdowns
@@ -871,6 +979,8 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
           newCube.scale = targetScale;
         }
         currentScene.models.push_back(newCube);
+        Engine::Undo::recordModelAdded(
+            static_cast<int>(currentScene.models.size()) - 1);
         currentSelectedIndex = currentScene.models.size() - 1;
         currentSelectedType = SelectedType::Model;
         updateSpaceMouseBounds();
@@ -889,6 +999,8 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
           newSphere.scale = targetScale;
         }
         currentScene.models.push_back(newSphere);
+        Engine::Undo::recordModelAdded(
+            static_cast<int>(currentScene.models.size()) - 1);
         currentSelectedIndex = currentScene.models.size() - 1;
         currentSelectedType = SelectedType::Model;
         updateSpaceMouseBounds();
@@ -907,6 +1019,8 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
           newCylinder.scale = targetScale;
         }
         currentScene.models.push_back(newCylinder);
+        Engine::Undo::recordModelAdded(
+            static_cast<int>(currentScene.models.size()) - 1);
         currentSelectedIndex = currentScene.models.size() - 1;
         currentSelectedType = SelectedType::Model;
         updateSpaceMouseBounds();
@@ -925,6 +1039,8 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
           newPlane.scale = targetScale;
         }
         currentScene.models.push_back(newPlane);
+        Engine::Undo::recordModelAdded(
+            static_cast<int>(currentScene.models.size()) - 1);
         currentSelectedIndex = currentScene.models.size() - 1;
         currentSelectedType = SelectedType::Model;
         updateSpaceMouseBounds();
@@ -943,6 +1059,8 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
           newTorus.scale = targetScale;
         }
         currentScene.models.push_back(newTorus);
+        Engine::Undo::recordModelAdded(
+            static_cast<int>(currentScene.models.size()) - 1);
         currentSelectedIndex = currentScene.models.size() - 1;
         currentSelectedType = SelectedType::Model;
         updateSpaceMouseBounds();
@@ -962,6 +1080,8 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
         newPointLight.lightSpaceMatrix = glm::mat4(1.0f);
         newPointLight.castShadows = true; // default: cast shadows
         pointLights.push_back(newPointLight);
+        Engine::Undo::recordPointLightAdded(
+            static_cast<int>(pointLights.size()) - 1);
         currentSelectedIndex = pointLights.size() - 1;
         currentSelectedType = SelectedType::PointLight;
       }
@@ -976,6 +1096,8 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
         newSpotLight.outerCutOff = glm::cos(glm::radians(17.5f));
         newSpotLight.lightSpaceMatrix = glm::mat4(1.0f);
         spotLights.push_back(newSpotLight);
+        Engine::Undo::recordSpotLightAdded(
+            static_cast<int>(spotLights.size()) - 1);
         currentSelectedIndex = spotLights.size() - 1;
         currentSelectedType = SelectedType::SpotLight;
       }
@@ -1583,26 +1705,10 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
             spotLightsToDelete = sceneSpotLights[scenePath];
           }
 
-          // Sort in descending order to avoid index issues
-          std::sort(modelsToDelete.rbegin(), modelsToDelete.rend());
-          std::sort(pointCloudsToDelete.rbegin(), pointCloudsToDelete.rend());
-          std::sort(pointLightsToDelete.rbegin(), pointLightsToDelete.rend());
-          std::sort(spotLightsToDelete.rbegin(), spotLightsToDelete.rend());
-
-          // Delete objects
-          for (int idx : modelsToDelete) {
-            currentScene.models.erase(currentScene.models.begin() + idx);
-          }
-          for (int idx : pointCloudsToDelete) {
-            currentScene.pointClouds.erase(currentScene.pointClouds.begin() +
-                                           idx);
-          }
-          for (int idx : pointLightsToDelete) {
-            pointLights.erase(pointLights.begin() + idx);
-          }
-          for (int idx : spotLightsToDelete) {
-            spotLights.erase(spotLights.begin() + idx);
-          }
+          // Delete all objects in the group as a single undoable action
+          Engine::Undo::deleteSceneGroup(modelsToDelete, pointCloudsToDelete,
+                                         pointLightsToDelete,
+                                         spotLightsToDelete);
 
           // Mark voxelizer dirty if models were deleted
           if (!modelsToDelete.empty() && voxelizer) {
@@ -4034,6 +4140,8 @@ void renderSettingsWindow() {
           ImGui::NextColumn();
 
           displayAction(StereoVista::ShortcutAction::DeleteObject);
+          displayAction(StereoVista::ShortcutAction::Undo);
+          displayAction(StereoVista::ShortcutAction::Redo);
           displayAction(StereoVista::ShortcutAction::CenterView);
           displayAction(StereoVista::ShortcutAction::CycleLighting);
           displayAction(StereoVista::ShortcutAction::ToggleShadows);
@@ -4548,6 +4656,18 @@ void renderSettingsWindow() {
           ImGui::SetColumnWidth(2, 200);
 
           renderAction(StereoVista::ShortcutAction::DeleteObject);
+        }
+
+        // GROUP: Edit History
+        ImGui::Columns(1);
+        if (ImGui::CollapsingHeader("Edit History")) {
+          ImGui::Columns(3, "shortcutcolumns");
+          ImGui::SetColumnWidth(0, 250);
+          ImGui::SetColumnWidth(1, 200);
+          ImGui::SetColumnWidth(2, 200);
+
+          renderAction(StereoVista::ShortcutAction::Undo);
+          renderAction(StereoVista::ShortcutAction::Redo);
         }
 
         ImGui::Columns(1);
@@ -5617,6 +5737,8 @@ static void drawMeasurementLabels() {
 }
 
 void renderSunManipulationPanel() {
+  const Engine::Sun sunPreFrame = sun;
+
   DrawSectionHeader("Sun Light");
 
   ImGui::Checkbox("Enabled", &sun.enabled);
@@ -5641,10 +5763,19 @@ void renderSunManipulationPanel() {
 
   ImGui::Text("Direction Vector: (%.2f, %.2f, %.2f)", sun.direction.x,
               sun.direction.y, sun.direction.z);
+
+  s_sunEditTracker.update(0, sunPreFrame, sun,
+                          [](int, const Engine::Sun &before,
+                             const Engine::Sun &after) {
+                            Engine::Undo::recordSunEdit(before, after);
+                          });
 }
 
 void renderModelManipulationPanel(Engine::Model &model,
                                   Engine::Shader *shader) {
+  const Engine::Undo::ModelEditState modelStatePreFrame =
+      Engine::Undo::ModelEditState::capture(model);
+
   ImGui::Text("📦 %s", model.name.c_str());
   ImGui::Separator();
 
@@ -5789,6 +5920,16 @@ void renderModelManipulationPanel(Engine::Model &model,
     }
   }
 
+  // Record property edits made above as one undo entry per gesture. Must run
+  // before the delete handling below, which can invalidate `model`.
+  s_modelEditTracker.update(
+      currentSelectedIndex, modelStatePreFrame,
+      Engine::Undo::ModelEditState::capture(model),
+      [](int index, const Engine::Undo::ModelEditState &before,
+         const Engine::Undo::ModelEditState &after) {
+        Engine::Undo::recordModelEdit(index, before, after);
+      });
+
   ImGui::Spacing();
   ImGui::Separator();
   ImGui::Spacing();
@@ -5800,7 +5941,7 @@ void renderModelManipulationPanel(Engine::Model &model,
   if (ImGui::BeginPopupModal("Delete Model?", NULL,
                              ImGuiWindowFlags_AlwaysAutoResize)) {
     ImGui::Text("Delete '%s'?", model.name.c_str());
-    ImGui::Text("This cannot be undone!");
+    ImGui::TextDisabled("This can be undone with Ctrl+Z.");
     ImGui::Separator();
 
     if (ImGui::Button("Delete", ImVec2(120, 0))) {
@@ -5819,6 +5960,12 @@ void renderModelManipulationPanel(Engine::Model &model,
 void renderMeshManipulationPanel(Engine::Model &model, int meshIndex,
                                  Engine::Shader *shader) {
   auto &mesh = model.getMeshes()[meshIndex];
+
+  // Mesh materials are part of the model edit snapshot, so mesh-panel edits
+  // share the model edit tracker (only one of the two panels is open at a
+  // time).
+  const Engine::Undo::ModelEditState modelStatePreFrame =
+      Engine::Undo::ModelEditState::capture(model);
 
   ImGui::Text("📦 %s - Mesh %d", model.name.c_str(), meshIndex + 1);
   ImGui::Separator();
@@ -5937,6 +6084,14 @@ void renderMeshManipulationPanel(Engine::Model &model, int meshIndex,
     }
   }
 
+  s_modelEditTracker.update(
+      currentSelectedIndex, modelStatePreFrame,
+      Engine::Undo::ModelEditState::capture(model),
+      [](int index, const Engine::Undo::ModelEditState &before,
+         const Engine::Undo::ModelEditState &after) {
+        Engine::Undo::recordModelEdit(index, before, after);
+      });
+
   ImGui::Spacing();
   ImGui::Separator();
   ImGui::Spacing();
@@ -5952,11 +6107,11 @@ void renderMeshManipulationPanel(Engine::Model &model, int meshIndex,
   if (ImGui::BeginPopupModal("Delete Mesh?", NULL,
                              ImGuiWindowFlags_AlwaysAutoResize)) {
     ImGui::Text("Delete this mesh?");
-    ImGui::Text("This cannot be undone!");
+    ImGui::TextDisabled("This can be undone with Ctrl+Z.");
     ImGui::Separator();
 
     if (ImGui::Button("Delete", ImVec2(120, 0))) {
-      model.getMeshes().erase(model.getMeshes().begin() + meshIndex);
+      Engine::Undo::deleteMesh(currentSelectedIndex, meshIndex);
       currentSelectedMeshIndex = -1;
       ImGui::CloseCurrentPopup();
     }
@@ -5987,6 +6142,9 @@ void renderPointCloudManipulationPanel(Engine::PointCloud &pointCloud) {
     ImGui::TextDisabled("Point cloud is empty");
     return;
   }
+
+  const Engine::Undo::PointCloudEditState pointCloudStatePreFrame =
+      Engine::Undo::PointCloudEditState::capture(pointCloud);
 
   ImGui::Separator();
 
@@ -6092,6 +6250,14 @@ void renderPointCloudManipulationPanel(Engine::PointCloud &pointCloud) {
     }
   }
 
+  s_pointCloudEditTracker.update(
+      currentSelectedIndex, pointCloudStatePreFrame,
+      Engine::Undo::PointCloudEditState::capture(pointCloud),
+      [](int index, const Engine::Undo::PointCloudEditState &before,
+         const Engine::Undo::PointCloudEditState &after) {
+        Engine::Undo::recordPointCloudEdit(index, before, after);
+      });
+
   ImGui::Spacing();
   ImGui::Separator();
   ImGui::Spacing();
@@ -6103,7 +6269,7 @@ void renderPointCloudManipulationPanel(Engine::PointCloud &pointCloud) {
   if (ImGui::BeginPopupModal("Delete Point Cloud?", NULL,
                              ImGuiWindowFlags_AlwaysAutoResize)) {
     ImGui::Text("Delete '%s'?", pointCloud.name.c_str());
-    ImGui::Text("This cannot be undone!");
+    ImGui::TextDisabled("This can be undone with Ctrl+Z.");
     ImGui::Separator();
 
     if (ImGui::Button("Delete", ImVec2(120, 0))) {
@@ -6122,8 +6288,7 @@ void renderPointCloudManipulationPanel(Engine::PointCloud &pointCloud) {
 void deleteSelectedModel() {
   if (currentSelectedType == SelectedType::Model && currentSelectedIndex >= 0 &&
       currentSelectedIndex < currentScene.models.size()) {
-    currentScene.models.erase(currentScene.models.begin() +
-                              currentSelectedIndex);
+    Engine::Undo::deleteModel(currentSelectedIndex);
     currentSelectedIndex = -1;
     currentSelectedType = SelectedType::None;
     updateSpaceMouseBounds();
@@ -6139,11 +6304,9 @@ void deleteSelectedPointCloud() {
   if (currentSelectedType == SelectedType::PointCloud &&
       currentSelectedIndex >= 0 &&
       currentSelectedIndex < currentScene.pointClouds.size()) {
-    glDeleteVertexArrays(1,
-                         &currentScene.pointClouds[currentSelectedIndex].vao);
-    glDeleteBuffers(1, &currentScene.pointClouds[currentSelectedIndex].vbo);
-    currentScene.pointClouds.erase(currentScene.pointClouds.begin() +
-                                   currentSelectedIndex);
+    // The cloud (including its GL buffers) is kept alive by the undo entry
+    // and freed when the entry is discarded from the history
+    Engine::Undo::deletePointCloud(currentSelectedIndex);
     currentSelectedIndex = -1;
     currentSelectedType = SelectedType::None;
     updateSpaceMouseBounds();
@@ -6157,6 +6320,7 @@ void renderPointLightManipulationPanel() {
   }
 
   auto &light = pointLights[currentSelectedIndex];
+  const Engine::PointLight lightStatePreFrame = light;
 
   // Render icon and text with PushFont/PopFont approach
   if (g_Fonts.icons) {
@@ -6191,6 +6355,13 @@ void renderPointLightManipulationPanel() {
         "If enabled, this light renders a depth cubemap and casts shadows");
   }
 
+  s_pointLightEditTracker.update(
+      currentSelectedIndex, lightStatePreFrame, light,
+      [](int index, const Engine::PointLight &before,
+         const Engine::PointLight &after) {
+        Engine::Undo::recordPointLightEdit(index, before, after);
+      });
+
   ImGui::Spacing();
   ImGui::Separator();
   ImGui::Spacing();
@@ -6202,11 +6373,11 @@ void renderPointLightManipulationPanel() {
   if (ImGui::BeginPopupModal("Delete Light?", NULL,
                              ImGuiWindowFlags_AlwaysAutoResize)) {
     ImGui::Text("Delete this point light?");
-    ImGui::Text("This cannot be undone!");
+    ImGui::TextDisabled("This can be undone with Ctrl+Z.");
     ImGui::Separator();
 
     if (ImGui::Button("Delete", ImVec2(120, 0))) {
-      pointLights.erase(pointLights.begin() + currentSelectedIndex);
+      Engine::Undo::deletePointLight(currentSelectedIndex);
       currentSelectedIndex = -1;
       currentSelectedType = SelectedType::None;
       ImGui::CloseCurrentPopup();
@@ -6227,6 +6398,7 @@ void renderSpotLightManipulationPanel() {
   }
 
   auto &light = spotLights[currentSelectedIndex];
+  const Engine::SpotLight lightStatePreFrame = light;
 
   ImGui::Text("🔦 Spot Light %d", currentSelectedIndex + 1);
   ImGui::Separator();
@@ -6281,6 +6453,13 @@ void renderSpotLightManipulationPanel() {
         "Toggle whether this spot light should cast shadows (when supported)");
   }
 
+  s_spotLightEditTracker.update(
+      currentSelectedIndex, lightStatePreFrame, light,
+      [](int index, const Engine::SpotLight &before,
+         const Engine::SpotLight &after) {
+        Engine::Undo::recordSpotLightEdit(index, before, after);
+      });
+
   ImGui::Spacing();
   ImGui::Separator();
   ImGui::Spacing();
@@ -6292,11 +6471,11 @@ void renderSpotLightManipulationPanel() {
   if (ImGui::BeginPopupModal("Delete Light?", NULL,
                              ImGuiWindowFlags_AlwaysAutoResize)) {
     ImGui::Text("Delete this spot light?");
-    ImGui::Text("This cannot be undone!");
+    ImGui::TextDisabled("This can be undone with Ctrl+Z.");
     ImGui::Separator();
 
     if (ImGui::Button("Delete", ImVec2(120, 0))) {
-      spotLights.erase(spotLights.begin() + currentSelectedIndex);
+      Engine::Undo::deleteSpotLight(currentSelectedIndex);
       currentSelectedIndex = -1;
       currentSelectedType = SelectedType::None;
       ImGui::CloseCurrentPopup();

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -17,6 +17,7 @@
 #include "Core/CursorSyncState.h"
 #include "Core/CursorSynchronizer.h"
 #include "Core/SceneManager.h"
+#include "Core/UndoManager.h"
 #include "Core/Voxalizer.h"
 #include "Cursors/Base/CursorManager.h"
 #include "Cursors/CursorPresets.h"
@@ -2653,6 +2654,46 @@ int main() {
 
   voxelizer = new Engine::Voxelizer(128);
 
+  // ---- Initialize Undo/Redo ----
+  // After every undo/redo, resynchronize the systems that depend on scene
+  // structure and make sure the selection still points at a valid object.
+  UndoManager::instance().setSceneChangedCallback([]() {
+    if (voxelizer) {
+      voxelizer->markDirty();
+    }
+    updateSpaceMouseBounds();
+
+    int objectCount = -1;
+    switch (currentSelectedType) {
+    case SelectedType::Model:
+      objectCount = static_cast<int>(currentScene.models.size());
+      break;
+    case SelectedType::PointCloud:
+      objectCount = static_cast<int>(currentScene.pointClouds.size());
+      break;
+    case SelectedType::PointLight:
+      objectCount = static_cast<int>(pointLights.size());
+      break;
+    case SelectedType::SpotLight:
+      objectCount = static_cast<int>(spotLights.size());
+      break;
+    default:
+      break;
+    }
+    if (objectCount >= 0 &&
+        (currentSelectedIndex < 0 || currentSelectedIndex >= objectCount)) {
+      currentSelectedType = SelectedType::None;
+      currentSelectedIndex = -1;
+      currentSelectedMeshIndex = -1;
+    }
+    if (currentSelectedType == SelectedType::Model &&
+        currentSelectedMeshIndex >=
+            static_cast<int>(
+                currentScene.models[currentSelectedIndex].getMeshes().size())) {
+      currentSelectedMeshIndex = -1;
+    }
+  });
+
   // ---- Initialize Shadow Mapping Shader ----
   try {
     shadowMappingShader =
@@ -3897,6 +3938,10 @@ void cleanup() {
 
   // Clean up measurement tool GL resources while the context is still valid
   measurementTool.cleanup();
+
+  // Drop undo history while the context is still valid - undo entries for
+  // deleted objects own GL resources that are freed on destruction
+  UndoManager::instance().clear();
 
   // Clean up GUI before destroying window (ImGui needs valid OpenGL context)
   CleanupGUI();
@@ -6543,6 +6588,54 @@ void scroll_callback(GLFWwindow *window, double xoffset, double yoffset) {
   }
 }
 
+// ---- Drag-Move Undo Tracking ----
+// Captures the dragged object's position when a Ctrl/Alt+drag starts so the
+// whole drag is recorded as a single undo entry on mouse release.
+static bool dragUndoActive = false;
+static SelectedType dragUndoType = SelectedType::None;
+static int dragUndoIndex = -1;
+static glm::vec3 dragUndoStartPosition(0.0f);
+
+static void beginDragUndo() {
+  dragUndoActive = false;
+  dragUndoType = currentSelectedType;
+  dragUndoIndex = currentSelectedIndex;
+
+  if (dragUndoType == SelectedType::Model && dragUndoIndex >= 0 &&
+      dragUndoIndex < static_cast<int>(currentScene.models.size())) {
+    dragUndoStartPosition = currentScene.models[dragUndoIndex].position;
+    dragUndoActive = true;
+  } else if (dragUndoType == SelectedType::PointLight && dragUndoIndex >= 0 &&
+             dragUndoIndex < static_cast<int>(pointLights.size())) {
+    dragUndoStartPosition = pointLights[dragUndoIndex].position;
+    dragUndoActive = true;
+  } else if (dragUndoType == SelectedType::SpotLight && dragUndoIndex >= 0 &&
+             dragUndoIndex < static_cast<int>(spotLights.size())) {
+    dragUndoStartPosition = spotLights[dragUndoIndex].position;
+    dragUndoActive = true;
+  }
+}
+
+static void endDragUndo() {
+  if (!dragUndoActive)
+    return;
+  dragUndoActive = false;
+
+  if (dragUndoType == SelectedType::Model && dragUndoIndex >= 0 &&
+      dragUndoIndex < static_cast<int>(currentScene.models.size())) {
+    Undo::recordModelMoved(dragUndoIndex, dragUndoStartPosition,
+                           currentScene.models[dragUndoIndex].position);
+  } else if (dragUndoType == SelectedType::PointLight && dragUndoIndex >= 0 &&
+             dragUndoIndex < static_cast<int>(pointLights.size())) {
+    Undo::recordPointLightMoved(dragUndoIndex, dragUndoStartPosition,
+                                pointLights[dragUndoIndex].position);
+  } else if (dragUndoType == SelectedType::SpotLight && dragUndoIndex >= 0 &&
+             dragUndoIndex < static_cast<int>(spotLights.size())) {
+    Undo::recordSpotLightMoved(dragUndoIndex, dragUndoStartPosition,
+                               spotLights[dragUndoIndex].position);
+  }
+}
+
 void mouse_button_callback(GLFWwindow *window, int button, int action,
                            int mods) {
   if (ImGui::GetIO().WantCaptureMouse) {
@@ -6701,6 +6794,8 @@ void mouse_button_callback(GLFWwindow *window, int button, int action,
                 currentScene.models[closestModelIndex];
             duplicatedModel.name += "_Copy";
             currentScene.models.push_back(duplicatedModel);
+            Undo::recordModelAdded(
+                static_cast<int>(currentScene.models.size()) - 1);
 
             // Select the new duplicated model for moving
             currentSelectedIndex = currentScene.models.size() - 1;
@@ -6728,6 +6823,7 @@ void mouse_button_callback(GLFWwindow *window, int button, int action,
           if (ctrlPressed || altPressed) {
             selectionMode = true;
             isMovingModel = true;
+            beginDragUndo();
 
             // Calculate and store the grab point on the model
             // This is the world-space position where the ray intersects the
@@ -6762,6 +6858,7 @@ void mouse_button_callback(GLFWwindow *window, int button, int action,
           if (ctrlPressed || altPressed) {
             selectionMode = true;
             isMovingModel = true;
+            beginDragUndo();
           }
         } else if (closestSpotLightIndex != -1) {
           currentSelectedType = SelectedType::SpotLight;
@@ -6777,6 +6874,7 @@ void mouse_button_callback(GLFWwindow *window, int button, int action,
           if (ctrlPressed || altPressed) {
             selectionMode = true;
             isMovingModel = true;
+            beginDragUndo();
           }
         } else if (closestPointCloudIndex != -1) {
           currentSelectedType = SelectedType::PointCloud;
@@ -7046,6 +7144,11 @@ void mouse_button_callback(GLFWwindow *window, int button, int action,
             lastY = screenY;
           }
         }
+      }
+
+      // Record the completed drag as one undo entry
+      if (wasMovingModel) {
+        endDragUndo();
       }
 
       // Reset model grab point tracking
@@ -7643,9 +7746,8 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
                   << currentScene.models[currentSelectedIndex].name
                   << std::endl;
 
-        // Remove the selected model from the scene
-        currentScene.models.erase(currentScene.models.begin() +
-                                  currentSelectedIndex);
+        // Remove the selected model from the scene (undoable)
+        Undo::deleteModel(currentSelectedIndex);
 
         // Adjust selection indices after deletion
         if (currentScene.models.empty()) {
@@ -7667,6 +7769,24 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
                   << currentScene.models.size() << std::endl;
       } else {
         std::cout << "No model selected or invalid selection" << std::endl;
+      }
+      break;
+
+    // Edit History
+    case StereoVista::ShortcutAction::Undo:
+      // Let ImGui text fields keep their own Ctrl+Z handling
+      if (!ImGui::GetIO().WantTextInput) {
+        if (!UndoManager::instance().undo()) {
+          std::cout << "Nothing to undo" << std::endl;
+        }
+      }
+      break;
+
+    case StereoVista::ShortcutAction::Redo:
+      if (!ImGui::GetIO().WantTextInput) {
+        if (!UndoManager::instance().redo()) {
+          std::cout << "Nothing to redo" << std::endl;
+        }
       }
       break;
 


### PR DESCRIPTION
Adds a command-stack UndoManager (Ctrl+Z / Ctrl+Y, Edit menu) covering:

- Object add/delete for models, point clouds, point lights, spot lights,
  meshes, and whole scene groups. Deleted objects are moved into the undo
  entry (GPU resources stay alive) and moved back on undo; point cloud GL
  buffers are freed only when the entry leaves the history.
- Property edits in all manipulation panels (transform, materials, light
  parameters, sun). A gesture tracker records one undo entry per slider
  drag/color pick instead of one per frame.
- Viewport Ctrl+drag moves of models and lights, recorded as a single
  entry per drag; Alt+drag duplication records the added copy.

Undo/Redo are rebindable shortcut actions with defaults (Ctrl+Z, Ctrl+Y,
Ctrl+Shift+Z); loadFromFile now backfills default bindings for actions
missing from older shortcuts.json files. After every undo/redo the scene
callback re-marks the voxelizer, refreshes SpaceMouse bounds, and clamps
the selection. History is capped at 64 entries and cleared on scene load
and at shutdown while the GL context is still valid.

The delete confirmation dialogs no longer claim "This cannot be undone!".

https://claude.ai/code/session_01PXWxw7TSXF3UYi2xREycTD