### PR TITLE
Add renderer polish: color grading, perf overlay, toasts, dynamic title

### DIFF
--- a/StereoVista/assets/shaders/bloom/final.frag
+++ b/StereoVista/assets/shaders/bloom/final.frag
@@ -12,6 +12,14 @@ uniform float bloomIntensity;
 uniform float exposure;
 uniform int toneMapOperator; // 0=Reinhard, 1=ACES, 2=Uncharted2, 3=AgX, 4=Khronos PBR Neutral, 5=Tony McMapface
 
+// ---- Color grading (applied after tone mapping, before gamma) ----
+uniform float cgContrast;   // 1.0 = neutral
+uniform float cgSaturation; // 1.0 = neutral, 0.0 = grayscale
+uniform bool  enableVignette;
+uniform float vignetteIntensity; // corner darkening amount [0..1]
+uniform float vignetteRadius;    // distance (0=center, 1=corner) where falloff starts
+uniform float vignetteSoftness;  // falloff width
+
 // ---- Schütz Phase 1: Eye-Dome Lighting uniforms ----
 uniform sampler2D depthTexture;
 uniform bool  enableEDL;
@@ -237,8 +245,23 @@ void main()
         result = acesToneMapping(hdrColor, exposure); // Default to ACES (industry standard)
     }
     
+    // Color grading: saturation and contrast in tone-mapped [0,1] space.
+    // Defaults (1.0 / 1.0) leave the image untouched.
+    result = mix(vec3(luminance(result)), result, cgSaturation);
+    result = clamp(mix(vec3(0.5), result, cgContrast), 0.0, 1.0);
+
+    // Vignette: smooth radial darkening towards the corners
+    if (enableVignette) {
+        // Normalize distance so 0 = screen center, 1 = corner
+        float dist = length(TexCoords - 0.5) * 1.41421356;
+        float falloff = smoothstep(vignetteRadius,
+                                   vignetteRadius + max(vignetteSoftness, 1e-4),
+                                   dist);
+        result *= 1.0 - falloff * vignetteIntensity;
+    }
+
     // Gamma correction (sRGB conversion)
     result = linearToSRGB(result);
-    
+
     FragColor = vec4(result, 1.0);
 }

--- a/StereoVista/headers/Engine/BloomRenderer.h
+++ b/StereoVista/headers/Engine/BloomRenderer.h
@@ -21,6 +21,15 @@ struct BloomSettings {
   float fxaaSubpixel = 0.75f;       // sub-pixel aliasing removal [0..1]
   float fxaaEdgeThreshold = 0.166f; // relative edge threshold (~0.063..0.333)
 
+  // Color grading, applied in the final composite after tone mapping.
+  // Defaults are neutral (no visual change).
+  float contrast = 1.0f;           // 1 = neutral
+  float saturation = 1.0f;         // 1 = neutral, 0 = grayscale
+  bool vignetteEnabled = false;
+  float vignetteIntensity = 0.35f; // corner darkening amount [0..1]
+  float vignetteRadius = 0.55f;    // where falloff starts (0=center, 1=corner)
+  float vignetteSoftness = 0.45f;  // falloff width
+
   // Framebuffer objects
   GLuint hdrFBO = 0;
   GLuint bloomFBO[2] = {0, 0}; // Ping-pong framebuffers

--- a/StereoVista/headers/Gui/Gui.h
+++ b/StereoVista/headers/Gui/Gui.h
@@ -25,6 +25,22 @@ class Voxelizer;
 void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
                ImGuiWindowFlags windowFlags, Engine::Shader *shader);
 
+namespace GUI {
+
+// Toast notifications: transient, non-interactive status messages stacked at
+// the bottom-center of the window (e.g. "Scene saved", import failures).
+// Safe to call from anywhere after the ImGui context exists; calls made
+// before that are silently ignored.
+enum class ToastType { Success, Info, Warning, Error };
+void ShowToast(const std::string &message, ToastType type = ToastType::Info);
+
+// Reflect the loaded scene file in the OS window title (pass an empty string
+// to restore the plain application title). Preserves the mono-fallback
+// marker chosen at window creation.
+void UpdateWindowTitleForScene(const std::string &scenePath);
+
+} // namespace GUI
+
 // UI Windows
 void renderSettingsWindow();
 void renderCursorSettingsWindow();

--- a/StereoVista/headers/Gui/GuiTypes.h
+++ b/StereoVista/headers/Gui/GuiTypes.h
@@ -141,12 +141,21 @@ struct ApplicationPreferences {
     float exposure = 1.0f;
     float bloomThreshold = 1.0f;
     float bloomIntensity = 0.04f;
-    int toneMapOperator = 0; // 0=Reinhard, 1=ACES, 2=Filmic
+    // 0=Reinhard, 1=ACES, 2=Uncharted2, 3=AgX, 4=Khronos PBR Neutral,
+    // 5=Tony McMapface. ACES by default for a modern filmic look.
+    int toneMapOperator = 1;
     bool enableBloom = false;
     // FXAA post-process anti-aliasing (applied after tone mapping)
     bool enableFXAA = true;
     float fxaaSubpixel = 0.75f;       // sub-pixel aliasing removal [0..1]
     float fxaaEdgeThreshold = 0.166f; // edge threshold (~0.063 hi .. 0.333 lo)
+    // Color grading (applied after tone mapping; defaults are neutral)
+    float contrast = 1.0f;           // 1 = neutral
+    float saturation = 1.0f;         // 1 = neutral, 0 = grayscale
+    bool enableVignette = false;
+    float vignetteIntensity = 0.35f; // corner darkening amount [0..1]
+    float vignetteRadius = 0.55f;    // where falloff starts (0=center, 1=corner)
+    float vignetteSoftness = 0.45f;  // falloff width
   } hdrSettings;
 
   // SSAO settings

--- a/StereoVista/headers/Gui/GuiTypes.h
+++ b/StereoVista/headers/Gui/GuiTypes.h
@@ -110,6 +110,10 @@ struct ApplicationPreferences {
   std::string currentPresetName = "Sphere";
   float cameraSpeedFactor = 1.0f;
   bool showFPS = true;
+  // Sync buffer swaps to the display refresh rate (eliminates tearing at the
+  // cost of capping the frame rate). Off by default to preserve the
+  // historical uncapped behavior.
+  bool vsyncEnabled = false;
   bool show3DCursor = true;
   // Keep the 3D cursor at the last valid depth when the mouse is over the
   // background instead of switching to the Windows cursor (helps with sparse

--- a/StereoVista/src/Engine/BloomRenderer.cpp
+++ b/StereoVista/src/Engine/BloomRenderer.cpp
@@ -593,6 +593,16 @@ void BloomRenderer::applyBloom(GLuint sceneTexture,
     m_settings.finalShader->setFloat("exposure", settings.exposure);
     m_settings.finalShader->setInt("toneMapOperator", settings.toneMapOperator);
 
+    // Color grading
+    m_settings.finalShader->setFloat("cgContrast", settings.contrast);
+    m_settings.finalShader->setFloat("cgSaturation", settings.saturation);
+    m_settings.finalShader->setBool("enableVignette", settings.vignetteEnabled);
+    m_settings.finalShader->setFloat("vignetteIntensity",
+                                     settings.vignetteIntensity);
+    m_settings.finalShader->setFloat("vignetteRadius", settings.vignetteRadius);
+    m_settings.finalShader->setFloat("vignetteSoftness",
+                                     settings.vignetteSoftness);
+
     renderQuad();
 
     // Unbind textures to avoid state issues

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -117,6 +117,9 @@ extern GUI::CursorPreview3D cursorPreview3D;
 // Shortcut manager
 extern StereoVista::ShortcutManager shortcutManager;
 
+// Files dropped onto the window (queued by the GLFW drop callback in main.cpp)
+extern std::vector<std::string> g_droppedFiles;
+
 // External function declarations
 extern void savePreferences();
 extern void updateSkybox();
@@ -739,6 +742,152 @@ static void renderPerformanceOverlay() {
   ImGui::PopStyleVar();
 }
 
+// ---------------------------------------------------------------------------
+// Empty-scene hint: a subtle centered prompt shown while nothing is loaded
+// ---------------------------------------------------------------------------
+static void renderEmptySceneHint() {
+  if (!currentScene.models.empty() || !currentScene.pointClouds.empty())
+    return;
+
+  // Center over the 3D viewport (falls back to the window center before the
+  // viewport rectangle is first published)
+  float centerX = windowWidth * 0.5f;
+  float centerY = windowHeight * 0.5f;
+  if (g_viewportWidth > 0 && g_viewportHeight > 0) {
+    centerX = g_viewportX + g_viewportWidth * 0.5f;
+    centerY = g_viewportTopInset + g_viewportHeight * 0.5f;
+  }
+
+  auto centeredText = [](const char *text) {
+    float textWidth = ImGui::CalcTextSize(text).x;
+    float indent = (ImGui::GetWindowSize().x -
+                    ImGui::GetStyle().WindowPadding.x * 2.0f - textWidth) *
+                   0.5f;
+    if (indent > 0.0f) {
+      ImGui::SetCursorPosX(ImGui::GetStyle().WindowPadding.x + indent);
+    }
+    ImGui::TextDisabled("%s", text);
+  };
+
+  ImGui::SetNextWindowPos(ImVec2(centerX, centerY), ImGuiCond_Always,
+                          ImVec2(0.5f, 0.5f));
+  ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.75f);
+  ImGui::Begin("EmptySceneHint", nullptr,
+               ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs |
+                   ImGuiWindowFlags_AlwaysAutoResize |
+                   ImGuiWindowFlags_NoSavedSettings |
+                   ImGuiWindowFlags_NoFocusOnAppearing |
+                   ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoBackground);
+
+  if (g_Fonts.icons) {
+    ImGui::PushFont(g_Fonts.icons);
+    centeredText(ICON_FA_CUBE);
+    ImGui::PopFont();
+    ImGui::Spacing();
+  }
+  if (g_Fonts.header)
+    ImGui::PushFont(g_Fonts.header);
+  centeredText("Scene is empty");
+  if (g_Fonts.header)
+    ImGui::PopFont();
+  ImGui::Spacing();
+  centeredText("Drag & drop 3D models, point clouds or scene files here");
+  centeredText("or use File > Import");
+
+  ImGui::End();
+  ImGui::PopStyleVar();
+}
+
+// ---------------------------------------------------------------------------
+// File import helpers shared by the File menu and window drag-and-drop
+// ---------------------------------------------------------------------------
+
+// Imports a single 3D model file into the scene and selects it.
+static void importModelFile(const std::string &filePath) {
+  try {
+    Engine::Model newModel = *Engine::loadModel(filePath);
+    glm::vec3 targetScale = newModel.scale;
+    if (preferences.enableSpawnAnimation) {
+      newModel.startSpawnAnimation(targetScale, 1.1f);
+    }
+    currentScene.models.push_back(newModel);
+    Engine::Undo::recordModelAdded(
+        static_cast<int>(currentScene.models.size()) - 1);
+    currentSelectedIndex = currentScene.models.size() - 1;
+    currentSelectedType = SelectedType::Model;
+    updateSpaceMouseBounds();
+
+    // Mark voxelizer dirty for re-voxelization
+    if (voxelizer) {
+      voxelizer->markDirty();
+    }
+
+    GUI::ShowToast("Model imported: " +
+                       std::filesystem::path(filePath).filename().string(),
+                   GUI::ToastType::Success);
+  } catch (const std::exception &e) {
+    std::cerr << "Failed to load model: " << e.what() << std::endl;
+    GUI::ShowToast(std::string("Failed to import model: ") + e.what(),
+                   GUI::ToastType::Error);
+  }
+}
+
+// Imports a single point cloud file of any supported format except LAS/LAZ
+// (those are loaded in batches via importLASFiles so tiles share a global
+// center).
+static void importPointCloudFile(const std::string &filePath) {
+  std::string extension = std::filesystem::path(filePath).extension().string();
+  std::transform(extension.begin(), extension.end(), extension.begin(),
+                 ::tolower);
+
+  if (extension == ".txt" || extension == ".xyz" || extension == ".ply") {
+    Engine::PointCloud newPointCloud =
+        std::move(Engine::PointCloudLoader::loadPointCloudFile(filePath));
+    newPointCloud.filePath = filePath;
+    currentScene.pointClouds.emplace_back(std::move(newPointCloud));
+    Engine::Undo::recordPointCloudAdded(
+        static_cast<int>(currentScene.pointClouds.size()) - 1);
+    updateSpaceMouseBounds();
+  } else if (extension == ".pcb") {
+    Engine::PointCloud newPointCloud =
+        std::move(Engine::PointCloudLoader::loadFromBinary(filePath));
+    if (newPointCloud.isLoaded()) {
+      newPointCloud.filePath = filePath;
+      newPointCloud.name = std::filesystem::path(filePath).stem().string();
+      currentScene.pointClouds.emplace_back(std::move(newPointCloud));
+      Engine::Undo::recordPointCloudAdded(
+          static_cast<int>(currentScene.pointClouds.size()) - 1);
+      updateSpaceMouseBounds();
+    }
+  } else if (extension == ".h5" || extension == ".hdf5" ||
+             extension == ".f5") {
+    Engine::PointCloud newPointCloud =
+        std::move(Engine::PointCloudLoader::loadPointCloudFile(filePath));
+    if (newPointCloud.isLoaded()) {
+      newPointCloud.filePath = filePath;
+      newPointCloud.name = std::filesystem::path(filePath).stem().string();
+      currentScene.pointClouds.emplace_back(std::move(newPointCloud));
+      Engine::Undo::recordPointCloudAdded(
+          static_cast<int>(currentScene.pointClouds.size()) - 1);
+      updateSpaceMouseBounds();
+    }
+  }
+}
+
+// Imports LAS/LAZ tiles together so they share a global center and remain
+// correctly positioned relative to each other.
+static void importLASFiles(const std::vector<std::string> &lasFiles) {
+  if (lasFiles.empty())
+    return;
+  auto clouds = Engine::PointCloudLoader::loadFromLASMultiple(lasFiles);
+  for (auto &pc : clouds) {
+    currentScene.pointClouds.emplace_back(std::move(pc));
+    Engine::Undo::recordPointCloudAdded(
+        static_cast<int>(currentScene.pointClouds.size()) - 1);
+  }
+  updateSpaceMouseBounds();
+}
+
 void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
                ImGuiWindowFlags windowFlags, Engine::Shader *shader) {
   if (!isLeftEye) {
@@ -754,9 +903,16 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
   ImGui::NewFrame();
 
   if (!showGui) {
+    // Files dropped while the GUI is hidden: bring the GUI back so the
+    // import (and any scene-load dialog) runs on the next frame.
+    if (!g_droppedFiles.empty()) {
+      showGui = true;
+    }
+
     // GUI hidden: the viewport fills the whole window.
     g_dockLeftWidth = 0.0f;
     g_dockTopHeight = 0.0f;
+    renderEmptySceneHint();
     if (showFPS) {
       renderPerformanceOverlay();
     }
@@ -905,6 +1061,70 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
                    GUI::ToastType::Success);
   };
 
+  // Import any files dropped onto the window (queued by the GLFW drop
+  // callback). Scene files follow the same replace/merge/ask flow as
+  // File > Load Scene; models and point clouds import directly.
+  if (!g_droppedFiles.empty()) {
+    std::vector<std::string> droppedFiles;
+    droppedFiles.swap(g_droppedFiles);
+
+    std::vector<std::string> lasFiles;
+    size_t cloudCountBefore = currentScene.pointClouds.size();
+
+    for (const auto &filePath : droppedFiles) {
+      std::string ext = std::filesystem::path(filePath).extension().string();
+      std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+
+      if (ext == ".scene") {
+        bool hasExistingObjects = !currentScene.models.empty() ||
+                                  !currentScene.pointClouds.empty() ||
+                                  !pointLights.empty() || !spotLights.empty();
+        if (!hasExistingObjects) {
+          try {
+            loadSceneWithPreference(filePath);
+          } catch (const std::exception &e) {
+            std::cerr << "Failed to load scene: " << e.what() << std::endl;
+            GUI::ShowToast(std::string("Failed to load scene: ") + e.what(),
+                           GUI::ToastType::Error);
+          }
+        } else if (preferences.sceneLoadingBehavior ==
+                   GUI::SCENE_LOAD_ALWAYS_REPLACE) {
+          loadAndReplaceScene(filePath);
+        } else if (preferences.sceneLoadingBehavior ==
+                   GUI::SCENE_LOAD_ALWAYS_MERGE) {
+          loadAndMergeScene(filePath);
+        } else {
+          pendingSceneToLoad = filePath;
+          showLoadSceneDialog = true;
+        }
+      } else if (ext == ".obj" || ext == ".fbx" || ext == ".3ds" ||
+                 ext == ".gltf" || ext == ".glb") {
+        importModelFile(filePath);
+      } else if (ext == ".las" || ext == ".laz") {
+        lasFiles.push_back(filePath);
+      } else if (ext == ".txt" || ext == ".xyz" || ext == ".ply" ||
+                 ext == ".pcb" || ext == ".h5" || ext == ".hdf5" ||
+                 ext == ".f5") {
+        importPointCloudFile(filePath);
+      } else {
+        GUI::ShowToast("Unsupported file type: " +
+                           std::filesystem::path(filePath).filename().string(),
+                       GUI::ToastType::Warning);
+      }
+    }
+
+    importLASFiles(lasFiles);
+
+    size_t cloudsImported =
+        currentScene.pointClouds.size() - cloudCountBefore;
+    if (cloudsImported > 0) {
+      GUI::ShowToast("Imported " + std::to_string(cloudsImported) +
+                         (cloudsImported == 1 ? " point cloud"
+                                              : " point clouds"),
+                     GUI::ToastType::Success);
+    }
+  }
+
   if (ImGui::BeginMainMenuBar()) {
     // File Menu
     if (ImGui::BeginMenu("File")) {
@@ -925,35 +1145,7 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
                   .result();
 
           if (!selection.empty()) {
-            std::string filePath = selection[0];
-            try {
-              Engine::Model newModel = *Engine::loadModel(filePath);
-              glm::vec3 targetScale = newModel.scale;
-              if (preferences.enableSpawnAnimation) {
-                newModel.startSpawnAnimation(targetScale, 1.1f);
-              }
-              currentScene.models.push_back(newModel);
-              Engine::Undo::recordModelAdded(
-                  static_cast<int>(currentScene.models.size()) - 1);
-              currentSelectedIndex = currentScene.models.size() - 1;
-              currentSelectedType = SelectedType::Model;
-              updateSpaceMouseBounds();
-
-              // Mark voxelizer dirty for re-voxelization
-              if (voxelizer) {
-                voxelizer->markDirty();
-              }
-
-              GUI::ShowToast(
-                  "Model imported: " +
-                      std::filesystem::path(filePath).filename().string(),
-                  GUI::ToastType::Success);
-            } catch (const std::exception &e) {
-              std::cerr << "Failed to load model: " << e.what() << std::endl;
-              GUI::ShowToast(std::string("Failed to import model: ") +
-                                 e.what(),
-                             GUI::ToastType::Error);
-            }
+            importModelFile(selection[0]);
           }
         }
 
@@ -989,57 +1181,10 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
               else otherFiles.push_back(path);
             }
 
-            if (!lasFiles.empty()) {
-              auto clouds = Engine::PointCloudLoader::loadFromLASMultiple(lasFiles);
-              for (auto& pc : clouds) {
-                currentScene.pointClouds.emplace_back(std::move(pc));
-                Engine::Undo::recordPointCloudAdded(
-                    static_cast<int>(currentScene.pointClouds.size()) - 1);
-              }
-              updateSpaceMouseBounds();
-            }
+            importLASFiles(lasFiles);
 
             for (const auto& filePath : otherFiles) {
-              std::string extension =
-                  std::filesystem::path(filePath).extension().string();
-              std::transform(extension.begin(), extension.end(),
-                             extension.begin(), ::tolower);
-
-              if (extension == ".txt" || extension == ".xyz" ||
-                  extension == ".ply") {
-                Engine::PointCloud newPointCloud = std::move(
-                    Engine::PointCloudLoader::loadPointCloudFile(filePath));
-                newPointCloud.filePath = filePath;
-                currentScene.pointClouds.emplace_back(std::move(newPointCloud));
-                Engine::Undo::recordPointCloudAdded(
-                    static_cast<int>(currentScene.pointClouds.size()) - 1);
-                updateSpaceMouseBounds();
-              } else if (extension == ".pcb") {
-                Engine::PointCloud newPointCloud =
-                    std::move(Engine::PointCloudLoader::loadFromBinary(filePath));
-                if (newPointCloud.isLoaded()) {
-                  newPointCloud.filePath = filePath;
-                  newPointCloud.name =
-                      std::filesystem::path(filePath).stem().string();
-                  currentScene.pointClouds.emplace_back(std::move(newPointCloud));
-                  Engine::Undo::recordPointCloudAdded(
-                      static_cast<int>(currentScene.pointClouds.size()) - 1);
-                  updateSpaceMouseBounds();
-                }
-              } else if (extension == ".h5" || extension == ".hdf5" ||
-                         extension == ".f5") {
-                Engine::PointCloud newPointCloud = std::move(
-                    Engine::PointCloudLoader::loadPointCloudFile(filePath));
-                if (newPointCloud.isLoaded()) {
-                  newPointCloud.filePath = filePath;
-                  newPointCloud.name =
-                      std::filesystem::path(filePath).stem().string();
-                  currentScene.pointClouds.emplace_back(std::move(newPointCloud));
-                  Engine::Undo::recordPointCloudAdded(
-                      static_cast<int>(currentScene.pointClouds.size()) - 1);
-                  updateSpaceMouseBounds();
-                }
-              }
+              importPointCloudFile(filePath);
             }
 
             size_t cloudsImported =
@@ -2218,6 +2363,9 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
   // Screen-space measurement labels (distances/angles/coordinates) projected
   // from the world-space measurement overlay
   drawMeasurementLabels();
+
+  // Centered hint while nothing is loaded yet
+  renderEmptySceneHint();
 
   // Performance overlay (bottom-right corner)
   if (showFPS) {
@@ -3795,6 +3943,14 @@ void renderSettingsWindow() {
       ImGui::SameLine();
       DrawHelpMarker("Shows/hides the performance overlay (FPS, frame-time "
                      "graph and scene statistics) in the bottom-right corner");
+
+      if (ImGui::Checkbox("VSync", &preferences.vsyncEnabled)) {
+        glfwSwapInterval(preferences.vsyncEnabled ? 1 : 0);
+        settingsChanged = true;
+      }
+      ImGui::SameLine();
+      DrawHelpMarker("Synchronizes rendering with the display refresh rate. "
+                     "Eliminates tearing but caps the frame rate.");
 
       if (ImGui::Checkbox("Show GUI", &showGui)) {
         settingsChanged = true;

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -14,6 +14,7 @@
 #include "imgui/IconsFontAwesome5.h"
 #include "imgui/imgui_sytle.h"
 #include "libs/portable-file-dialogs.h"
+#include <algorithm>
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
@@ -41,6 +42,7 @@ extern Camera camera;
 extern bool showGui;
 extern bool showFPS;
 extern bool isDarkTheme;
+extern bool isStereoWindow;
 extern bool showInfoWindow;
 extern bool showSettingsWindow;
 extern bool show3DCursor;
@@ -503,6 +505,240 @@ void CleanupGUI() {
   // ImGui::DestroyContext();
 }
 
+// ---------------------------------------------------------------------------
+// Toast notifications
+// ---------------------------------------------------------------------------
+
+namespace {
+
+struct ToastMessage {
+  std::string text;
+  GUI::ToastType type;
+  double createdAt;
+};
+
+std::vector<ToastMessage> g_toasts;
+
+constexpr double kToastLifetime = 4.0; // seconds on screen
+constexpr double kToastFadeIn = 0.15;
+constexpr double kToastFadeOut = 0.4;
+
+} // namespace
+
+void GUI::ShowToast(const std::string &message, GUI::ToastType type) {
+  if (ImGui::GetCurrentContext() == nullptr)
+    return;
+  // Keep the stack short; the oldest message gives way to new ones
+  if (g_toasts.size() >= 4)
+    g_toasts.erase(g_toasts.begin());
+  g_toasts.push_back({message, type, ImGui::GetTime()});
+}
+
+void GUI::UpdateWindowTitleForScene(const std::string &scenePath) {
+  std::string title = "StereoVista";
+  if (!scenePath.empty()) {
+    std::string stem = std::filesystem::path(scenePath).stem().string();
+    if (!stem.empty()) {
+      title = stem + " - StereoVista";
+    }
+  }
+  if (!isStereoWindow) {
+    title += " (Monoviewer)";
+  }
+  if (Engine::Window::nativeWindow) {
+    glfwSetWindowTitle(Engine::Window::nativeWindow, title.c_str());
+  }
+}
+
+// Draws the active toasts stacked above the bottom edge, newest at the
+// bottom. Called every frame from renderGUI (in both the visible and the
+// hidden-GUI paths).
+static void renderToasts() {
+  if (g_toasts.empty())
+    return;
+
+  double now = ImGui::GetTime();
+  g_toasts.erase(std::remove_if(g_toasts.begin(), g_toasts.end(),
+                                [now](const ToastMessage &t) {
+                                  return now - t.createdAt > kToastLifetime;
+                                }),
+                 g_toasts.end());
+
+  float scale = g_GuiScale.currentScale;
+  float y = windowHeight - 24.0f * scale;
+
+  for (int i = static_cast<int>(g_toasts.size()) - 1; i >= 0; --i) {
+    const ToastMessage &toast = g_toasts[i];
+    double age = now - toast.createdAt;
+
+    // Fade in quickly, hold, then fade out
+    float alpha = 1.0f;
+    if (age < kToastFadeIn) {
+      alpha = static_cast<float>(age / kToastFadeIn);
+    } else if (age > kToastLifetime - kToastFadeOut) {
+      alpha = static_cast<float>((kToastLifetime - age) / kToastFadeOut);
+    }
+    alpha = std::clamp(alpha, 0.0f, 1.0f);
+
+    const char *icon = ICON_FA_INFO_CIRCLE;
+    ImVec4 accent = g_StyleColors.info;
+    switch (toast.type) {
+    case GUI::ToastType::Success:
+      icon = ICON_FA_CHECK_CIRCLE;
+      accent = g_StyleColors.success;
+      break;
+    case GUI::ToastType::Warning:
+      icon = ICON_FA_EXCLAMATION_TRIANGLE;
+      accent = g_StyleColors.warning;
+      break;
+    case GUI::ToastType::Error:
+      icon = ICON_FA_EXCLAMATION_CIRCLE;
+      accent = g_StyleColors.danger;
+      break;
+    default:
+      break;
+    }
+
+    ImGui::SetNextWindowPos(ImVec2(windowWidth * 0.5f, y), ImGuiCond_Always,
+                            ImVec2(0.5f, 1.0f));
+    ImGui::SetNextWindowBgAlpha(0.92f);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 8.0f * scale);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
+                        ImVec2(14.0f * scale, 10.0f * scale));
+    ImGui::PushStyleVar(ImGuiStyleVar_Alpha, alpha);
+
+    char windowName[32];
+    snprintf(windowName, sizeof(windowName), "##toast%d", i);
+    ImGui::Begin(windowName, nullptr,
+                 ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs |
+                     ImGuiWindowFlags_AlwaysAutoResize |
+                     ImGuiWindowFlags_NoSavedSettings |
+                     ImGuiWindowFlags_NoFocusOnAppearing |
+                     ImGuiWindowFlags_NoNav);
+
+    if (g_Fonts.icons) {
+      ImGui::PushFont(g_Fonts.icons);
+      ImGui::TextColored(accent, "%s", icon);
+      ImGui::PopFont();
+      ImGui::SameLine();
+    }
+    ImGui::TextUnformatted(toast.text.c_str());
+
+    y -= ImGui::GetWindowSize().y + 8.0f * scale;
+    ImGui::End();
+    ImGui::PopStyleVar(3);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Performance overlay: FPS, frame time, a frame-time graph and scene
+// statistics in a translucent click-through widget (bottom-right corner).
+// ---------------------------------------------------------------------------
+
+// Formats large counts compactly ("950", "12.4K", "1.2M")
+static void formatCount(char *buffer, size_t bufferSize, size_t count) {
+  if (count >= 1000000) {
+    snprintf(buffer, bufferSize, "%.1fM", count / 1000000.0);
+  } else if (count >= 10000) {
+    snprintf(buffer, bufferSize, "%.1fK", count / 1000.0);
+  } else {
+    snprintf(buffer, bufferSize, "%zu", count);
+  }
+}
+
+static void renderPerformanceOverlay() {
+  ImGuiIO &io = ImGui::GetIO();
+  float scale = g_GuiScale.currentScale;
+
+  // Rolling frame-time history (~2 s at 60 fps)
+  static float frameTimes[120] = {};
+  static int frameTimeOffset = 0;
+  frameTimes[frameTimeOffset] = io.DeltaTime * 1000.0f;
+  frameTimeOffset = (frameTimeOffset + 1) % IM_ARRAYSIZE(frameTimes);
+
+  // GPU name (driver-owned string, valid for the lifetime of the GL context)
+  static const char *gpuName = nullptr;
+  if (gpuName == nullptr) {
+    const GLubyte *renderer = glGetString(GL_RENDERER);
+    gpuName =
+        renderer ? reinterpret_cast<const char *>(renderer) : "Unknown GPU";
+  }
+
+  float fps = io.Framerate;
+  float frameMs = fps > 0.0f ? 1000.0f / fps : 0.0f;
+
+  ImGui::SetNextWindowPos(
+      ImVec2(windowWidth - 12.0f * scale, windowHeight - 12.0f * scale),
+      ImGuiCond_Always, ImVec2(1.0f, 1.0f));
+  ImGui::SetNextWindowBgAlpha(0.6f);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 8.0f * scale);
+  ImGui::Begin("PerformanceOverlay", nullptr,
+               ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs |
+                   ImGuiWindowFlags_AlwaysAutoResize |
+                   ImGuiWindowFlags_NoSavedSettings |
+                   ImGuiWindowFlags_NoFocusOnAppearing |
+                   ImGuiWindowFlags_NoNav);
+
+  // FPS readout colored by performance budget (green >= 59, yellow >= 29)
+  ImVec4 fpsColor = fps >= 59.0f   ? g_StyleColors.success
+                    : fps >= 29.0f ? g_StyleColors.warning
+                                   : g_StyleColors.danger;
+  if (g_Fonts.header)
+    ImGui::PushFont(g_Fonts.header);
+  ImGui::TextColored(fpsColor, "%.0f", fps);
+  if (g_Fonts.header)
+    ImGui::PopFont();
+  ImGui::SameLine();
+  ImGui::Text("FPS");
+  ImGui::SameLine();
+  ImGui::TextDisabled("%.2f ms", frameMs);
+
+  // Frame-time graph. The scale floors at the 30 fps budget so a steady
+  // 60 fps draws as a calm low line and spikes stand out.
+  float graphMax = 33.3f;
+  for (float t : frameTimes) {
+    if (t > graphMax)
+      graphMax = t;
+  }
+  ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.0f, 0.0f, 0.0f, 0.25f));
+  ImGui::PlotLines("##frametimes", frameTimes, IM_ARRAYSIZE(frameTimes),
+                   frameTimeOffset, nullptr, 0.0f, graphMax,
+                   ImVec2(180.0f * scale, 40.0f * scale));
+  ImGui::PopStyleColor();
+
+  // Scene statistics
+  size_t triangles = 0;
+  for (const auto &model : currentScene.models) {
+    for (const auto &mesh : model.getMeshes()) {
+      triangles += mesh.indices.size() / 3;
+    }
+  }
+  size_t points = 0;
+  for (const auto &pc : currentScene.pointClouds) {
+    points += pc.totalPointCount;
+  }
+
+  if (g_Fonts.small)
+    ImGui::PushFont(g_Fonts.small);
+  char countBuffer[32];
+  if (triangles > 0 || !currentScene.models.empty()) {
+    formatCount(countBuffer, sizeof(countBuffer), triangles);
+    ImGui::TextDisabled("%zu models | %s tris", currentScene.models.size(),
+                        countBuffer);
+  }
+  if (points > 0 || !currentScene.pointClouds.empty()) {
+    formatCount(countBuffer, sizeof(countBuffer), points);
+    ImGui::TextDisabled("%zu clouds | %s pts",
+                        currentScene.pointClouds.size(), countBuffer);
+  }
+  ImGui::TextDisabled("%s", gpuName);
+  if (g_Fonts.small)
+    ImGui::PopFont();
+
+  ImGui::End();
+  ImGui::PopStyleVar();
+}
+
 void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
                ImGuiWindowFlags windowFlags, Engine::Shader *shader) {
   if (!isLeftEye) {
@@ -522,14 +758,9 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
     g_dockLeftWidth = 0.0f;
     g_dockTopHeight = 0.0f;
     if (showFPS) {
-      ImGui::SetNextWindowPos(ImVec2(windowWidth - 120, windowHeight - 60));
-      ImGui::Begin("FPS Counter", nullptr,
-                   ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs |
-                       ImGuiWindowFlags_AlwaysAutoResize |
-                       ImGuiWindowFlags_NoBackground);
-      ImGui::Text("FPS: %.1f", ImGui::GetIO().Framerate);
-      ImGui::End();
+      renderPerformanceOverlay();
     }
+    renderToasts();
     ImGui::Render();
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
     return;
@@ -581,8 +812,15 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
       if (voxelizer) {
         voxelizer->markDirty();
       }
+
+      GUI::UpdateWindowTitleForScene(sceneFile);
+      GUI::ShowToast("Scene loaded: " +
+                         std::filesystem::path(sceneFile).filename().string(),
+                     GUI::ToastType::Success);
     } catch (const std::exception &e) {
       std::cerr << "Failed to load scene: " << e.what() << std::endl;
+      GUI::ShowToast(std::string("Failed to load scene: ") + e.what(),
+                     GUI::ToastType::Error);
     }
   };
 
@@ -626,8 +864,14 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
       if (voxelizer) {
         voxelizer->markDirty();
       }
+
+      GUI::ShowToast("Scene merged: " +
+                         std::filesystem::path(sceneFile).filename().string(),
+                     GUI::ToastType::Success);
     } catch (const std::exception &e) {
       std::cerr << "Failed to load scene: " << e.what() << std::endl;
+      GUI::ShowToast(std::string("Failed to merge scene: ") + e.what(),
+                     GUI::ToastType::Error);
     }
   };
 
@@ -654,6 +898,11 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
     if (voxelizer) {
       voxelizer->markDirty();
     }
+
+    GUI::UpdateWindowTitleForScene(sceneFile);
+    GUI::ShowToast("Scene loaded: " +
+                       std::filesystem::path(sceneFile).filename().string(),
+                   GUI::ToastType::Success);
   };
 
   if (ImGui::BeginMainMenuBar()) {
@@ -694,8 +943,16 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
               if (voxelizer) {
                 voxelizer->markDirty();
               }
+
+              GUI::ShowToast(
+                  "Model imported: " +
+                      std::filesystem::path(filePath).filename().string(),
+                  GUI::ToastType::Success);
             } catch (const std::exception &e) {
               std::cerr << "Failed to load model: " << e.what() << std::endl;
+              GUI::ShowToast(std::string("Failed to import model: ") +
+                                 e.what(),
+                             GUI::ToastType::Error);
             }
           }
         }
@@ -719,6 +976,8 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
                   .result();
 
           if (!selection.empty()) {
+            size_t cloudCountBefore = currentScene.pointClouds.size();
+
             // Separate LAS/LAZ tiles from other formats.  Multiple LAS/LAZ
             // files are loaded together so they share a global centre and
             // remain correctly positioned relative to each other.
@@ -782,6 +1041,18 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
                 }
               }
             }
+
+            size_t cloudsImported =
+                currentScene.pointClouds.size() - cloudCountBefore;
+            if (cloudsImported > 0) {
+              GUI::ShowToast("Imported " + std::to_string(cloudsImported) +
+                                 (cloudsImported == 1 ? " point cloud"
+                                                      : " point clouds"),
+                             GUI::ToastType::Success);
+            } else {
+              GUI::ShowToast("No point clouds could be imported",
+                             GUI::ToastType::Warning);
+            }
           }
         }
         ImGui::EndMenu();
@@ -830,6 +1101,8 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
               loadSceneWithPreference(selection[0]);
             } catch (const std::exception &e) {
               std::cerr << "Failed to load scene: " << e.what() << std::endl;
+              GUI::ShowToast(std::string("Failed to load scene: ") + e.what(),
+                             GUI::ToastType::Error);
             }
           }
         }
@@ -845,8 +1118,15 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
             currentScene.pointLights = pointLights;
             currentScene.spotLights = spotLights;
             Engine::saveScene(destination, currentScene, camera);
+            GUI::UpdateWindowTitleForScene(destination);
+            GUI::ShowToast(
+                "Scene saved: " +
+                    std::filesystem::path(destination).filename().string(),
+                GUI::ToastType::Success);
           } catch (const std::exception &e) {
             std::cerr << "Failed to save scene: " << e.what() << std::endl;
+            GUI::ShowToast(std::string("Failed to save scene: ") + e.what(),
+                           GUI::ToastType::Error);
           }
         }
       }
@@ -1108,7 +1388,7 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
     // View Menu
     if (ImGui::BeginMenu("View")) {
       ImGui::MenuItem("Show GUI", "G", &showGui);
-      ImGui::MenuItem("Show FPS Counter", nullptr, &showFPS);
+      ImGui::MenuItem("Show Performance Overlay", nullptr, &showFPS);
       ImGui::MenuItem("Wireframe Mode", nullptr, &camera.wireframe);
 
       ImGui::Separator();
@@ -1939,16 +2219,13 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
   // from the world-space measurement overlay
   drawMeasurementLabels();
 
-  // FPS Counter (always in top-right corner)
+  // Performance overlay (bottom-right corner)
   if (showFPS) {
-    ImGui::SetNextWindowPos(ImVec2(windowWidth - 120, windowHeight - 60));
-    ImGui::Begin("FPS", nullptr,
-                 ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs |
-                     ImGuiWindowFlags_AlwaysAutoResize |
-                     ImGuiWindowFlags_NoBackground);
-    ImGui::Text("FPS: %.1f", ImGui::GetIO().Framerate);
-    ImGui::End();
+    renderPerformanceOverlay();
   }
+
+  // Transient status notifications (bottom-center)
+  renderToasts();
 
   ImGui::Render();
   ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
@@ -2399,6 +2676,71 @@ void renderSettingsWindow() {
             ImGui::SameLine();
             DrawHelpMarker("Minimum contrast treated as an edge. Lower = more "
                            "edges smoothed (higher quality, slower).");
+          }
+
+          ImGui::Spacing();
+          DrawSectionHeader("Color Grading");
+
+          if (ImGui::SliderFloat("Contrast",
+                                 &preferences.hdrSettings.contrast, 0.5f, 1.5f,
+                                 "%.2f")) {
+            settingsChanged = true;
+          }
+          ImGui::SameLine();
+          DrawHelpMarker("Image contrast around mid-gray. 1.00 = neutral.");
+
+          if (ImGui::SliderFloat("Saturation",
+                                 &preferences.hdrSettings.saturation, 0.0f,
+                                 2.0f, "%.2f")) {
+            settingsChanged = true;
+          }
+          ImGui::SameLine();
+          DrawHelpMarker(
+              "Color intensity. 1.00 = neutral, 0.00 = grayscale.");
+
+          if (ImGui::Checkbox("Vignette",
+                              &preferences.hdrSettings.enableVignette)) {
+            settingsChanged = true;
+          }
+          ImGui::SameLine();
+          DrawHelpMarker("Subtle darkening towards the screen corners that "
+                         "draws the eye to the center of the frame.");
+
+          if (preferences.hdrSettings.enableVignette) {
+            if (ImGui::SliderFloat("Vignette Intensity",
+                                   &preferences.hdrSettings.vignetteIntensity,
+                                   0.0f, 1.0f, "%.2f")) {
+              settingsChanged = true;
+            }
+            ImGui::SameLine();
+            DrawHelpMarker("How dark the corners get.");
+
+            if (ImGui::SliderFloat("Vignette Radius",
+                                   &preferences.hdrSettings.vignetteRadius,
+                                   0.0f, 1.0f, "%.2f")) {
+              settingsChanged = true;
+            }
+            ImGui::SameLine();
+            DrawHelpMarker("Where the darkening starts. 0 = screen center, "
+                           "1 = corners only.");
+
+            if (ImGui::SliderFloat("Vignette Softness",
+                                   &preferences.hdrSettings.vignetteSoftness,
+                                   0.05f, 1.0f, "%.2f")) {
+              settingsChanged = true;
+            }
+            ImGui::SameLine();
+            DrawHelpMarker("Width of the falloff. Higher = smoother blend.");
+          }
+
+          if (ImGui::Button("Reset Color Grading")) {
+            preferences.hdrSettings.contrast = 1.0f;
+            preferences.hdrSettings.saturation = 1.0f;
+            preferences.hdrSettings.enableVignette = false;
+            preferences.hdrSettings.vignetteIntensity = 0.35f;
+            preferences.hdrSettings.vignetteRadius = 0.55f;
+            preferences.hdrSettings.vignetteSoftness = 0.45f;
+            settingsChanged = true;
           }
         }
 
@@ -3446,12 +3788,13 @@ void renderSettingsWindow() {
       DrawHelpMarker(
           "Switches between light and dark color themes for the interface");
 
-      if (ImGui::Checkbox("Show FPS", &showFPS)) {
+      if (ImGui::Checkbox("Show Performance Overlay", &showFPS)) {
         preferences.showFPS = showFPS;
         settingsChanged = true;
       }
       ImGui::SameLine();
-      DrawHelpMarker("Shows/hides the FPS counter in the top-right corner");
+      DrawHelpMarker("Shows/hides the performance overlay (FPS, frame-time "
+                     "graph and scene statistics) in the bottom-right corner");
 
       if (ImGui::Checkbox("Show GUI", &showGui)) {
         settingsChanged = true;

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -1689,6 +1689,12 @@ void savePreferences() {
   j["hdr"]["enableFXAA"] = preferences.hdrSettings.enableFXAA;
   j["hdr"]["fxaaSubpixel"] = preferences.hdrSettings.fxaaSubpixel;
   j["hdr"]["fxaaEdgeThreshold"] = preferences.hdrSettings.fxaaEdgeThreshold;
+  j["hdr"]["contrast"] = preferences.hdrSettings.contrast;
+  j["hdr"]["saturation"] = preferences.hdrSettings.saturation;
+  j["hdr"]["enableVignette"] = preferences.hdrSettings.enableVignette;
+  j["hdr"]["vignetteIntensity"] = preferences.hdrSettings.vignetteIntensity;
+  j["hdr"]["vignetteRadius"] = preferences.hdrSettings.vignetteRadius;
+  j["hdr"]["vignetteSoftness"] = preferences.hdrSettings.vignetteSoftness;
 
   // Save SSAO settings
   j["ssao"]["enabled"] = preferences.ssaoSettings.enabled;
@@ -2214,7 +2220,7 @@ void loadPreferences() {
       preferences.hdrSettings.bloomIntensity =
           j["hdr"].value("bloomIntensity", 0.04f);
       preferences.hdrSettings.toneMapOperator =
-          j["hdr"].value("toneMapOperator", 0);
+          j["hdr"].value("toneMapOperator", 1);
       preferences.hdrSettings.enableBloom =
           j["hdr"].value("enableBloom", false);
       preferences.hdrSettings.enableFXAA =
@@ -2223,6 +2229,16 @@ void loadPreferences() {
           j["hdr"].value("fxaaSubpixel", 0.75f);
       preferences.hdrSettings.fxaaEdgeThreshold =
           j["hdr"].value("fxaaEdgeThreshold", 0.166f);
+      preferences.hdrSettings.contrast = j["hdr"].value("contrast", 1.0f);
+      preferences.hdrSettings.saturation = j["hdr"].value("saturation", 1.0f);
+      preferences.hdrSettings.enableVignette =
+          j["hdr"].value("enableVignette", false);
+      preferences.hdrSettings.vignetteIntensity =
+          j["hdr"].value("vignetteIntensity", 0.35f);
+      preferences.hdrSettings.vignetteRadius =
+          j["hdr"].value("vignetteRadius", 0.55f);
+      preferences.hdrSettings.vignetteSoftness =
+          j["hdr"].value("vignetteSoftness", 0.45f);
     }
 
     // SSAO settings
@@ -2950,6 +2966,13 @@ int main() {
       }
       currentModelIndex = currentScene.models.empty() ? -1 : 0;
       updateSpaceMouseBounds();
+      GUI::UpdateWindowTitleForScene(preferences.startupScenePath);
+      GUI::ShowToast(
+          "Scene loaded: " +
+              std::filesystem::path(preferences.startupScenePath)
+                  .filename()
+                  .string(),
+          GUI::ToastType::Success);
       std::cout << "Startup scene loaded successfully" << std::endl;
     } catch (const std::exception &e) {
       std::cerr << "Failed to load startup scene '"
@@ -3691,6 +3714,14 @@ int main() {
       bloomSettings.fxaaSubpixel = preferences.hdrSettings.fxaaSubpixel;
       bloomSettings.fxaaEdgeThreshold =
           preferences.hdrSettings.fxaaEdgeThreshold;
+      bloomSettings.contrast = preferences.hdrSettings.contrast;
+      bloomSettings.saturation = preferences.hdrSettings.saturation;
+      bloomSettings.vignetteEnabled = preferences.hdrSettings.enableVignette;
+      bloomSettings.vignetteIntensity =
+          preferences.hdrSettings.vignetteIntensity;
+      bloomSettings.vignetteRadius = preferences.hdrSettings.vignetteRadius;
+      bloomSettings.vignetteSoftness =
+          preferences.hdrSettings.vignetteSoftness;
 
       // Set SSAO texture for final composition
       if (ssaoRenderer && ssaoRenderer->isInitialized() &&

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -77,6 +77,7 @@ void mouse_button_callback(GLFWwindow *window, int button, int action,
 void mouse_callback(GLFWwindow *window, double xpos, double ypos);
 void framebuffer_size_callback(GLFWwindow *window, int width, int height);
 void cursor_enter_callback(GLFWwindow *window, int entered);
+void drop_callback(GLFWwindow *window, int count, const char **paths);
 
 // ---- Rendering Functions ----
 void renderEye(GLenum drawBuffer, const glm::mat4 &projection,
@@ -292,6 +293,11 @@ int windowWidth = 1920;
 int windowHeight = 1080;
 bool isStereoWindow = false;
 
+// ---- Drag & Drop ----
+// Files dropped onto the window, queued by drop_callback and imported by the
+// GUI on the next frame (where the scene-load dialog and import flow live).
+std::vector<std::string> g_droppedFiles;
+
 // ---- 3D Viewport (free area not covered by the docked GUI panels) ----
 // The scene renders into this sub-rectangle of the window instead of the whole
 // window, so it no longer draws behind the left Scene Hierarchy panel or the
@@ -494,6 +500,14 @@ void cursor_enter_callback(GLFWwindow *window, int entered) {
     cursorManager.getSphereCursor()->setPositionValid(false);
     cursorManager.getFragmentCursor()->setPositionValid(false);
     cursorManager.getPlaneCursor()->setPositionValid(false);
+  }
+}
+
+void drop_callback(GLFWwindow *window, int count, const char **paths) {
+  // Queue only; the import runs inside the GUI frame so dropped scene files
+  // can go through the regular replace/merge/ask flow.
+  for (int i = 0; i < count; i++) {
+    g_droppedFiles.push_back(paths[i]);
   }
 }
 
@@ -1563,6 +1577,7 @@ void savePreferences() {
   // UI preferences
   j["ui"]["darkTheme"] = preferences.isDarkTheme;
   j["ui"]["showFPS"] = preferences.showFPS;
+  j["ui"]["vsync"] = preferences.vsyncEnabled;
   j["ui"]["show3DCursor"] = preferences.show3DCursor;
   j["ui"]["cursorKeepLastDepthOnBackground"] =
       preferences.cursorKeepLastDepthOnBackground;
@@ -2016,6 +2031,7 @@ void loadPreferences() {
     if (j.contains("ui")) {
       preferences.isDarkTheme = j["ui"].value("darkTheme", true);
       preferences.showFPS = j["ui"].value("showFPS", true);
+      preferences.vsyncEnabled = j["ui"].value("vsync", false);
       preferences.show3DCursor = j["ui"].value("show3DCursor", true);
       preferences.cursorKeepLastDepthOnBackground =
           j["ui"].value("cursorKeepLastDepthOnBackground", false);
@@ -2667,6 +2683,7 @@ int main() {
   glfwSetMouseButtonCallback(window, mouse_button_callback);
   glfwSetWindowFocusCallback(window, window_focus_callback);
   glfwSetCursorEnterCallback(window, cursor_enter_callback);
+  glfwSetDropCallback(window, drop_callback);
 
   voxelizer = new Engine::Voxelizer(128);
 
@@ -3124,7 +3141,7 @@ int main() {
   // ---- OpenGL Settings ----
   glEnable(GL_DEPTH_TEST);
   glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
-  glfwSwapInterval(0); // Enable vsync
+  glfwSwapInterval(preferences.vsyncEnabled ? 1 : 0);
 
   // ---- Main Loop ----
   while (!glfwWindowShouldClose(window)) {
@@ -7345,6 +7362,14 @@ void mouse_callback(GLFWwindow *window, double xposIn, double yposIn) {
   // No need for an 'else' here, if not captured, we just don't accumulate.
 }
 
+// Reports a shortcut-driven toggle through both the console and a GUI toast,
+// so keyboard changes are visible without watching the console.
+static void reportToggle(const char *name, bool enabled) {
+  std::cout << name << " " << (enabled ? "enabled" : "disabled") << std::endl;
+  GUI::ShowToast(std::string(name) + (enabled ? " enabled" : " disabled"),
+                 GUI::ToastType::Info);
+}
+
 void key_callback(GLFWwindow *window, int key, int scancode, int action,
                   int mods) {
   // Note: This handles special keys like GUI toggle, lighting mode changes
@@ -7435,21 +7460,27 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
       // Update preferences
       preferences.lightingMode = currentLightingMode;
       savePreferences();
+
+      GUI::ShowToast(
+          std::string("Lighting mode: ") +
+              (currentLightingMode == GUI::LIGHTING_SHADOW_MAPPING
+                   ? "Shadow Mapping"
+                   : currentLightingMode == GUI::LIGHTING_VOXEL_CONE_TRACING
+                         ? "Voxel Cone Tracing"
+                         : "Radiance"),
+          GUI::ToastType::Info);
       break;
 
     case StereoVista::ShortcutAction::ToggleShadows:
       enableShadows = !enableShadows;
-      std::cout << "Shadows " << (enableShadows ? "enabled" : "disabled")
-                << std::endl;
+      reportToggle("Shadows", enableShadows);
       preferences.enableShadows = enableShadows;
       savePreferences();
       break;
 
     case StereoVista::ShortcutAction::ToggleVoxelViz:
       voxelizer->showDebugVisualization = !voxelizer->showDebugVisualization;
-      std::cout << "Voxel visualization "
-                << (voxelizer->showDebugVisualization ? "enabled" : "disabled")
-                << std::endl;
+      reportToggle("Voxel visualization", voxelizer->showDebugVisualization);
       break;
 
     case StereoVista::ShortcutAction::CenterView: {
@@ -7495,44 +7526,35 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
     // View/Display Controls
     case StereoVista::ShortcutAction::ToggleFPS:
       showFPS = !showFPS;
-      std::cout << "FPS counter " << (showFPS ? "enabled" : "disabled")
-                << std::endl;
+      reportToggle("Performance overlay", showFPS);
       break;
 
     case StereoVista::ShortcutAction::ToggleWireframe:
       camera.wireframe = !camera.wireframe;
-      std::cout << "Wireframe mode "
-                << (camera.wireframe ? "enabled" : "disabled") << std::endl;
+      reportToggle("Wireframe mode", camera.wireframe);
       break;
 
     case StereoVista::ShortcutAction::ToggleRadar:
       preferences.radarEnabled = !preferences.radarEnabled;
-      std::cout << "Radar "
-                << (preferences.radarEnabled ? "enabled" : "disabled")
-                << std::endl;
+      reportToggle("Radar", preferences.radarEnabled);
       savePreferences();
       break;
 
     case StereoVista::ShortcutAction::ToggleZeroPlane:
       preferences.showZeroPlane = !preferences.showZeroPlane;
-      std::cout << "Zero plane "
-                << (preferences.showZeroPlane ? "enabled" : "disabled")
-                << std::endl;
+      reportToggle("Zero plane", preferences.showZeroPlane);
       savePreferences();
       break;
 
     // Camera Controls
     case StereoVista::ShortcutAction::ToggleZoomToCursor:
       camera.zoomToCursor = !camera.zoomToCursor;
-      std::cout << "Zoom to cursor "
-                << (camera.zoomToCursor ? "enabled" : "disabled") << std::endl;
+      reportToggle("Zoom to cursor", camera.zoomToCursor);
       break;
 
     case StereoVista::ShortcutAction::ToggleOrbitAroundCursor:
       camera.orbitAroundCursor = !camera.orbitAroundCursor;
-      std::cout << "Orbit around cursor "
-                << (camera.orbitAroundCursor ? "enabled" : "disabled")
-                << std::endl;
+      reportToggle("Orbit around cursor", camera.orbitAroundCursor);
       break;
 
     case StereoVista::ShortcutAction::ToggleSpaceMouseMode:
@@ -7547,46 +7569,34 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
     // Lighting
     case StereoVista::ShortcutAction::ToggleHDR:
       preferences.hdrSettings.enabled = !preferences.hdrSettings.enabled;
-      std::cout << "HDR "
-                << (preferences.hdrSettings.enabled ? "enabled" : "disabled")
-                << std::endl;
+      reportToggle("HDR", preferences.hdrSettings.enabled);
       savePreferences();
       break;
 
     case StereoVista::ShortcutAction::ToggleBloom:
       preferences.hdrSettings.enableBloom =
           !preferences.hdrSettings.enableBloom;
-      std::cout << "Bloom "
-                << (preferences.hdrSettings.enableBloom ? "enabled"
-                                                        : "disabled")
-                << std::endl;
+      reportToggle("Bloom", preferences.hdrSettings.enableBloom);
       savePreferences();
       break;
 
     case StereoVista::ShortcutAction::TogglePCSS:
       preferences.shadowSettings.enablePCSS =
           !preferences.shadowSettings.enablePCSS;
-      std::cout << "PCSS (soft shadows) "
-                << (preferences.shadowSettings.enablePCSS ? "enabled"
-                                                          : "disabled")
-                << std::endl;
+      reportToggle("PCSS (soft shadows)", preferences.shadowSettings.enablePCSS);
       savePreferences();
       break;
 
     case StereoVista::ShortcutAction::ToggleSunLight:
       sun.enabled = !sun.enabled;
-      std::cout << "Sun light " << (sun.enabled ? "enabled" : "disabled")
-                << std::endl;
+      reportToggle("Sun light", sun.enabled);
       break;
 
     // Materials & Rendering
     case StereoVista::ShortcutAction::TogglePBR:
       preferences.materialSettings.enablePBR =
           !preferences.materialSettings.enablePBR;
-      std::cout << "PBR materials "
-                << (preferences.materialSettings.enablePBR ? "enabled"
-                                                           : "disabled")
-                << std::endl;
+      reportToggle("PBR materials", preferences.materialSettings.enablePBR);
       savePreferences();
       break;
 
@@ -7594,38 +7604,29 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
     case StereoVista::ShortcutAction::ToggleVCTIndirectDiffuse:
       preferences.vctSettings.indirectDiffuseLight =
           !preferences.vctSettings.indirectDiffuseLight;
-      std::cout << "VCT indirect diffuse "
-                << (preferences.vctSettings.indirectDiffuseLight ? "enabled"
-                                                                 : "disabled")
-                << std::endl;
+      reportToggle("VCT indirect diffuse",
+                   preferences.vctSettings.indirectDiffuseLight);
       savePreferences();
       break;
 
     case StereoVista::ShortcutAction::ToggleVCTIndirectSpecular:
       preferences.vctSettings.indirectSpecularLight =
           !preferences.vctSettings.indirectSpecularLight;
-      std::cout << "VCT indirect specular "
-                << (preferences.vctSettings.indirectSpecularLight ? "enabled"
-                                                                  : "disabled")
-                << std::endl;
+      reportToggle("VCT indirect specular",
+                   preferences.vctSettings.indirectSpecularLight);
       savePreferences();
       break;
 
     case StereoVista::ShortcutAction::ToggleVCTDirectLight:
       preferences.vctSettings.directLight =
           !preferences.vctSettings.directLight;
-      std::cout << "VCT direct lighting "
-                << (preferences.vctSettings.directLight ? "enabled"
-                                                        : "disabled")
-                << std::endl;
+      reportToggle("VCT direct lighting", preferences.vctSettings.directLight);
       savePreferences();
       break;
 
     case StereoVista::ShortcutAction::ToggleVCTSoftShadows:
       preferences.vctSettings.shadows = !preferences.vctSettings.shadows;
-      std::cout << "VCT soft shadows "
-                << (preferences.vctSettings.shadows ? "enabled" : "disabled")
-                << std::endl;
+      reportToggle("VCT soft shadows", preferences.vctSettings.shadows);
       savePreferences();
       break;
 
@@ -7635,10 +7636,7 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
           !preferences.radianceSettings.enableRaytracing;
       radianceSettings.enableRaytracing =
           preferences.radianceSettings.enableRaytracing;
-      std::cout << "Raytracing "
-                << (preferences.radianceSettings.enableRaytracing ? "enabled"
-                                                                  : "disabled")
-                << std::endl;
+      reportToggle("Raytracing", preferences.radianceSettings.enableRaytracing);
       savePreferences();
       break;
 
@@ -7647,11 +7645,8 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
           !preferences.radianceSettings.enableIndirectLighting;
       radianceSettings.enableIndirectLighting =
           preferences.radianceSettings.enableIndirectLighting;
-      std::cout << "Indirect lighting "
-                << (preferences.radianceSettings.enableIndirectLighting
-                        ? "enabled"
-                        : "disabled")
-                << std::endl;
+      reportToggle("Indirect lighting",
+                   preferences.radianceSettings.enableIndirectLighting);
       savePreferences();
       break;
 
@@ -7660,11 +7655,8 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
           !preferences.radianceSettings.enableEmissiveLighting;
       radianceSettings.enableEmissiveLighting =
           preferences.radianceSettings.enableEmissiveLighting;
-      std::cout << "Emissive lighting "
-                << (preferences.radianceSettings.enableEmissiveLighting
-                        ? "enabled"
-                        : "disabled")
-                << std::endl;
+      reportToggle("Emissive lighting",
+                   preferences.radianceSettings.enableEmissiveLighting);
       savePreferences();
       break;
 
@@ -7673,10 +7665,7 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
           !preferences.radianceSettings.enableBVH;
       radianceSettings.enableBVH = preferences.radianceSettings.enableBVH;
       enableBVH = preferences.radianceSettings.enableBVH;
-      std::cout << "BVH acceleration "
-                << (preferences.radianceSettings.enableBVH ? "enabled"
-                                                           : "disabled")
-                << std::endl;
+      reportToggle("BVH acceleration", preferences.radianceSettings.enableBVH);
       savePreferences();
       break;
 
@@ -7685,8 +7674,10 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
         ddgiVolume->clear();
         std::cout << "DDGI probes reset - will reconverge over the next frames"
                   << std::endl;
+        GUI::ShowToast("DDGI probes reset", GUI::ToastType::Info);
       } else {
         std::cout << "DDGI volume not initialized" << std::endl;
+        GUI::ShowToast("DDGI volume not initialized", GUI::ToastType::Warning);
       }
       break;
 


### PR DESCRIPTION
User-facing polish to make the application feel like a modern renderer:

- Color grading in the final post-process pass: contrast, saturation and
  a configurable vignette (intensity/radius/softness), applied after tone
  mapping with neutral defaults. Exposed under Settings > HDR Rendering >
  Color Grading and persisted in preferences.json.
- Replaced the plain FPS text with a performance overlay: color-coded FPS,
  frame time, a rolling 120-frame frame-time graph, scene statistics
  (models/triangles, clouds/points) and the GPU name, in a translucent
  click-through widget styled to match the theme.
- Toast notification system (success/info/warning/error) with fade in/out,
  shown for scene load/save/merge, model and point cloud imports, and
  their failure paths (previously console-only).
- Window title now reflects the loaded scene file, preserving the mono
  fallback marker.
- New installs default to ACES filmic tone mapping instead of Reinhard.

https://claude.ai/code/session_017dxG8ziMqdM8vzsFA22a5M