### PR TITLE
Fix build error: rename ImGuiFonts::small to avoid Windows macro collision

### DIFF
--- a/StereoVista/headers/libs/imgui/imgui_style.cpp
+++ b/StereoVista/headers/libs/imgui/imgui_style.cpp
@@ -121,7 +121,7 @@ bool InitializeImGuiWithFonts(GLFWwindow *window, bool isDarkTheme) {
     smallConfig.SizePixels = smallSize;
     smallConfig.FontDataOwnedByAtlas =
         false; // CRITICAL: Do not free this memory as it is shared
-    g_Fonts.small = io.Fonts->AddFontFromMemoryTTF(
+    g_Fonts.smallFont = io.Fonts->AddFontFromMemoryTTF(
         (void *)g_Fonts.regular->ConfigData->FontData,
         g_Fonts.regular->ConfigData->FontDataSize, smallSize, &smallConfig);
   }
@@ -242,7 +242,7 @@ bool InitializeImGuiWithFonts(GLFWwindow *window, bool isDarkTheme) {
     g_Fonts.regular = io.Fonts->AddFontDefault();
     g_Fonts.bold = g_Fonts.regular;
     g_Fonts.header = g_Fonts.regular;
-    g_Fonts.small = g_Fonts.regular;
+    g_Fonts.smallFont = g_Fonts.regular;
     g_Fonts.mono = g_Fonts.regular;
   }
 
@@ -342,7 +342,7 @@ void RebuildImGuiFontAtlas(bool isDarkTheme) {
   g_Fonts.regular = nullptr;
   g_Fonts.bold = nullptr;
   g_Fonts.header = nullptr;
-  g_Fonts.small = nullptr;
+  g_Fonts.smallFont = nullptr;
   g_Fonts.mono = nullptr;
   g_Fonts.icons = nullptr;
 
@@ -433,7 +433,7 @@ void RebuildImGuiFontAtlas(bool isDarkTheme) {
 
   // Load small font
   if (loadedRegularFontPath) {
-    g_Fonts.small = io.Fonts->AddFontFromFileTTF(loadedRegularFontPath,
+    g_Fonts.smallFont = io.Fonts->AddFontFromFileTTF(loadedRegularFontPath,
                                                  smallSize, &fontConfig);
   }
 
@@ -540,7 +540,7 @@ void RebuildImGuiFontAtlas(bool isDarkTheme) {
     g_Fonts.regular = io.Fonts->AddFontDefault();
     g_Fonts.bold = g_Fonts.regular;
     g_Fonts.header = g_Fonts.regular;
-    g_Fonts.small = g_Fonts.regular;
+    g_Fonts.smallFont = g_Fonts.regular;
     g_Fonts.mono = g_Fonts.regular;
   }
 

--- a/StereoVista/headers/libs/imgui/imgui_sytle.h
+++ b/StereoVista/headers/libs/imgui/imgui_sytle.h
@@ -22,7 +22,7 @@ struct ImGuiFonts {
     ImFont* regular = nullptr;
     ImFont* bold = nullptr;
     ImFont* header = nullptr;
-    ImFont* small = nullptr;
+    ImFont* smallFont = nullptr;
     ImFont* mono = nullptr;
     ImFont* icons = nullptr;
 };

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -721,8 +721,8 @@ static void renderPerformanceOverlay() {
     points += pc.totalPointCount;
   }
 
-  if (g_Fonts.small)
-    ImGui::PushFont(g_Fonts.small);
+  if (g_Fonts.smallFont)
+    ImGui::PushFont(g_Fonts.smallFont);
   char countBuffer[32];
   if (triangles > 0 || !currentScene.models.empty()) {
     formatCount(countBuffer, sizeof(countBuffer), triangles);
@@ -735,7 +735,7 @@ static void renderPerformanceOverlay() {
                         currentScene.pointClouds.size(), countBuffer);
   }
   ImGui::TextDisabled("%s", gpuName);
-  if (g_Fonts.small)
+  if (g_Fonts.smallFont)
     ImGui::PopFont();
 
   ImGui::End();


### PR DESCRIPTION
The 'small' member of ImGuiFonts collided with the Windows '#define small
char' macro (pulled in via windows.h), causing C2059 syntax errors in
GUI.cpp where g_Fonts.small expanded to g_Fonts.char. Renamed the member
to smallFont and updated all usages.

https://claude.ai/code/session_01581TWSFt6MwuJ1Ew3736we