### PR TITLE
Add cursor-integrated transform gizmo (move/rotate/scale)

### DIFF
--- a/StereoVista/StereoVista.vcxproj
+++ b/StereoVista/StereoVista.vcxproj
@@ -216,6 +216,7 @@ IF %ERRORLEVEL% LEQ 7 SET ERRORLEVEL=0</Command>
     <ClCompile Include="src\Gui\GUI.cpp" />
     <ClCompile Include="src\Tools\BrushTool.cpp" />
     <ClCompile Include="src\Tools\MeasurementTool.cpp" />
+    <ClCompile Include="src\Tools\TransformGizmo.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="headers\core.h" />
@@ -242,6 +243,7 @@ IF %ERRORLEVEL% LEQ 7 SET ERRORLEVEL=0</Command>
     <ClInclude Include="headers\Camera.h" />
     <ClInclude Include="headers\Tools\BrushTool.h" />
     <ClInclude Include="headers\Tools\MeasurementTool.h" />
+    <ClInclude Include="headers\Tools\TransformGizmo.h" />
     <ClInclude Include="headers\libs\assimp\aabb.h" />
     <ClInclude Include="headers\libs\assimp\ai_assert.h" />
     <ClInclude Include="headers\libs\assimp\anim.h" />

--- a/StereoVista/StereoVista.vcxproj.filters
+++ b/StereoVista/StereoVista.vcxproj.filters
@@ -129,6 +129,9 @@
     <ClCompile Include="src\Tools\MeasurementTool.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Tools\TransformGizmo.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\Engine\DDGIVolume.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -483,6 +486,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="headers\Tools\MeasurementTool.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="headers\Tools\TransformGizmo.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="headers\Loaders\ModelLoader.h">

--- a/StereoVista/assets/shaders/core/fragmentShader.glsl
+++ b/StereoVista/assets/shaders/core/fragmentShader.glsl
@@ -155,6 +155,8 @@ uniform float emissiveIntensity;
 // Lighting configuration
 uniform int lightingMode;
 uniform bool enableShadows;
+// Unlit view mode: output albedo/base color directly, skipping lighting/GI.
+uniform bool unlitMode;
 
 #define MAX_LIGHTS 16
 uniform PointLight lights[MAX_LIGHTS];
@@ -1894,8 +1896,21 @@ void main() {
     } else {
         baseColor = material.objectColor;
     }
-    
-    float specularStrength = material.hasSpecularMap ? 
+
+    // Unlit view mode: output the albedo directly and skip all lighting,
+    // shadows and GI. Reuses the same HDR-vs-direct output convention as the
+    // lit tail (radar pass is left to its own dedicated path below).
+    if (unlitMode && radarBrightness <= 0.0) {
+        if (hdrSettings.enabled) {
+            FragColor = vec4(baseColor, 1.0); // linear; post does tonemap+gamma
+        } else {
+            FragColor = vec4(pow(baseColor, vec3(1.0 / 2.2)), 1.0);
+        }
+        BrightColor = vec4(0.0, 0.0, 0.0, 1.0);
+        return;
+    }
+
+    float specularStrength = material.hasSpecularMap ?
                            texture(material.textures[1], fs_in.TexCoords).r : 0.2;
     
     // Calculate enhanced normal with improved TBN and multi-layer support

--- a/StereoVista/headers/Engine/ShortcutManager.h
+++ b/StereoVista/headers/Engine/ShortcutManager.h
@@ -34,7 +34,8 @@ enum class ShortcutAction {
   ToggleSunLight, // Toggle sun/directional light
 
   // Materials & Rendering
-  TogglePBR, // Toggle PBR materials
+  TogglePBR,   // Toggle PBR materials
+  ToggleUnlit, // Toggle unlit (albedo-only) view shading
 
   // VCT (Voxel Cone Tracing)
   ToggleVoxelViz,            // V - Toggle voxel visualization

--- a/StereoVista/headers/Engine/ShortcutManager.h
+++ b/StereoVista/headers/Engine/ShortcutManager.h
@@ -70,6 +70,12 @@ enum class ShortcutAction {
   // Object Manipulation
   DeleteObject, // Delete - Delete selected object
 
+  // Transform Gizmo
+  GizmoModeMove,    // 1 - Gizmo translate mode
+  GizmoModeRotate,  // 2 - Gizmo rotate mode
+  GizmoModeScale,   // 3 - Gizmo scale mode
+  GizmoToggleSpace, // 4 - Toggle gizmo world/local space
+
   // Edit History
   Undo, // Ctrl+Z - Undo last action
   Redo, // Ctrl+Y - Redo last undone action

--- a/StereoVista/headers/Tools/TransformGizmo.h
+++ b/StereoVista/headers/Tools/TransformGizmo.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include "Engine/Core.h"
+#include <glm/glm.hpp>
+
+namespace Tools {
+
+    // Interactive transform gizmo that integrates with the 3D cursor / selection
+    // system. When an object is selected the gizmo anchors at the object's pivot
+    // and lets the user translate / rotate / scale it with constrained handles,
+    // while the existing Ctrl/Alt body-drag free-move stays untouched.
+    //
+    // The gizmo is bound to a target each frame via setTarget(): a position
+    // (always), an optional Euler-rotation (degrees, X-Y-Z order to match the
+    // model matrix convention) and an optional non-uniform scale. Lights pass
+    // only a position, which automatically restricts the gizmo to translation.
+    //
+    // Rendering mirrors MeasurementTool: a self-contained world-space overlay
+    // drawn once per eye with that eye's matrices, using embedded shaders so the
+    // tool has no asset-file dependency. Hit-testing is fully analytic, so it
+    // needs no GL context and can run inside the input callbacks.
+    class TransformGizmo {
+    public:
+        enum class Mode { Translate, Rotate, Scale };
+        enum class Space { World, Local };
+
+        // Individual interactive parts of the gizmo.
+        enum class Handle {
+            None,
+            AxisX, AxisY, AxisZ,        // single-axis translate / scale shafts
+            PlaneXY, PlaneYZ, PlaneZX,  // two-axis translate quads
+            RingX, RingY, RingZ,        // rotation rings
+            ScaleUniform,               // centre box: uniform scale
+            ScreenMove                  // centre box: view-plane translate
+        };
+
+        TransformGizmo() = default;
+        ~TransformGizmo() = default;
+
+        void cleanup();
+
+        // ── Target binding ──────────────────────────────────────────────────
+        // rotationEulerDeg / scale may be null (e.g. lights); the corresponding
+        // modes are then unavailable and fall back to translation.
+        void setTarget(glm::vec3* position, glm::vec3* rotationEulerDeg,
+                       glm::vec3* scale);
+        void clearTarget();
+        bool hasTarget() const { return m_position != nullptr; }
+        bool canRotate() const { return m_rotation != nullptr; }
+        bool canScale()  const { return m_scale != nullptr; }
+
+        // ── Configuration ───────────────────────────────────────────────────
+        bool  enabled = true;        // master on/off (GUI toggle)
+        Space space = Space::World;  // world / local for translate & rotate
+        bool  snapEnabled = false;   // persistent snapping (Shift = momentary)
+        float snapTranslate = 0.25f; // world units
+        float snapRotateDeg = 15.0f; // degrees
+        float snapScale = 0.1f;      // scale increments
+        float screenSize = 0.14f;    // on-screen constant size (fraction of dist)
+
+        Mode mode() const { return m_mode; }
+        void setMode(Mode m);
+        void cycleMode();            // Translate -> Rotate -> Scale -> Translate
+        void toggleSpace() { space = (space == Space::World) ? Space::Local
+                                                             : Space::World; }
+
+        // The mode actually used this frame (falls back to Translate when the
+        // target can't rotate/scale).
+        Mode effectiveMode() const;
+
+        // ── Interaction ─────────────────────────────────────────────────────
+        // Update the hovered handle for highlighting (call when not dragging).
+        Handle updateHover(const glm::vec3& rayOrigin, const glm::vec3& rayDir,
+                           const glm::vec3& cameraPos);
+
+        // Return the handle under the ray, or Handle::None. Pure query.
+        Handle hitTest(const glm::vec3& rayOrigin, const glm::vec3& rayDir,
+                       const glm::vec3& cameraPos) const;
+
+        // Begin / update / end a drag on the given handle. updateDrag writes the
+        // new transform straight into the bound target pointers.
+        bool beginDrag(Handle handle, const glm::vec3& rayOrigin,
+                       const glm::vec3& rayDir, const glm::vec3& cameraPos);
+        void updateDrag(const glm::vec3& rayOrigin, const glm::vec3& rayDir,
+                        const glm::vec3& cameraPos, bool snapHeld);
+        void endDrag();
+        bool isDragging() const { return m_activeHandle != Handle::None; }
+        Handle activeHandle() const { return m_activeHandle; }
+
+        // ── Rendering ───────────────────────────────────────────────────────
+        // World-space overlay; call once per eye with that eye's matrices.
+        void render(const glm::mat4& projection, const glm::mat4& view,
+                    const glm::vec3& cameraPos);
+
+    private:
+        // Target transform (borrowed, owned by the scene).
+        glm::vec3* m_position = nullptr;
+        glm::vec3* m_rotation = nullptr; // Euler degrees (X-Y-Z), may be null
+        glm::vec3* m_scale = nullptr;    // may be null
+
+        Mode   m_mode = Mode::Translate;
+        Handle m_hover = Handle::None;
+        Handle m_activeHandle = Handle::None;
+
+        // Geometry size at the pivot for the current camera distance.
+        float gizmoScale(const glm::vec3& cameraPos) const;
+        // Unit basis used for axis handles. translate/rotate honour `space`;
+        // scale is always object-local. Returns world-space axes.
+        void computeAxes(glm::vec3 outAxes[3], Mode forMode) const;
+        glm::mat3 rotationMatrix() const; // from Euler degrees (identity if none)
+
+        // Drag state captured at beginDrag.
+        glm::vec3 m_startPos = glm::vec3(0.0f);
+        glm::vec3 m_startScale = glm::vec3(1.0f);
+        glm::mat3 m_startRot = glm::mat3(1.0f);
+        glm::vec3 m_dragAxis = glm::vec3(0.0f);        // world axis / ring normal
+        glm::vec3 m_dragPlaneNormal = glm::vec3(0.0f);
+        glm::vec3 m_dragStartHit = glm::vec3(0.0f);
+        glm::vec3 m_planeU = glm::vec3(0.0f);          // ring tangent basis
+        glm::vec3 m_planeV = glm::vec3(0.0f);
+        float m_startProj = 0.0f;                      // axis-drag reference
+        float m_startAngle = 0.0f;                     // ring-drag reference
+        float m_lastAngle = 0.0f;                      // ring continuity tracking
+        int   m_turnCount = 0;                         // ring full-turn counter
+        float m_startRadius = 1.0f;                    // uniform-scale reference
+        float m_gizmoScaleAtDrag = 1.0f;
+        int   m_dragAxisIndex = -1;                    // 0/1/2 for scale
+
+        // ── GL resources (lazy, embedded shaders) ──────────────────────────
+        bool   m_initialized = false;
+        void   ensureInit();
+        void   drawMesh(unsigned int vao, int count, unsigned int prim,
+                        const glm::mat4& mvp, const glm::vec4& color, float alpha);
+
+        unsigned int m_program = 0;
+        int m_uMVP = -1, m_uColor = -1, m_uAlpha = -1;
+
+        unsigned int m_cylVAO = 0, m_cylVBO = 0; int m_cylCount = 0;   // +Y unit
+        unsigned int m_coneVAO = 0, m_coneVBO = 0; int m_coneCount = 0; // +Y unit
+        unsigned int m_cubeVAO = 0, m_cubeVBO = 0; int m_cubeCount = 0; // centred
+        unsigned int m_ringVAO = 0, m_ringVBO = 0; int m_ringCount = 0; // XY loop
+        unsigned int m_quadVAO = 0, m_quadVBO = 0; int m_quadCount = 0; // XY quad
+    };
+
+} // namespace Tools

--- a/StereoVista/src/Engine/ShortcutManager.cpp
+++ b/StereoVista/src/Engine/ShortcutManager.cpp
@@ -440,6 +440,12 @@ ShortcutProfile ShortcutManager::createDefaultProfile() {
                      KeyBinding(GLFW_KEY_Z, true, false, true),
                      1); // Ctrl+Shift+Z
 
+  // Transform gizmo (active while an object is selected)
+  profile.setBinding(ShortcutAction::GizmoModeMove, KeyBinding(GLFW_KEY_1), 0);
+  profile.setBinding(ShortcutAction::GizmoModeRotate, KeyBinding(GLFW_KEY_2), 0);
+  profile.setBinding(ShortcutAction::GizmoModeScale, KeyBinding(GLFW_KEY_3), 0);
+  profile.setBinding(ShortcutAction::GizmoToggleSpace, KeyBinding(GLFW_KEY_4), 0);
+
   // New actions start unbound - users can assign keys as needed
 
   return profile;
@@ -642,6 +648,16 @@ std::string ShortcutManager::getActionName(ShortcutAction action) {
   case ShortcutAction::Redo:
     return "Redo";
 
+  // Transform Gizmo
+  case ShortcutAction::GizmoModeMove:
+    return "GizmoModeMove";
+  case ShortcutAction::GizmoModeRotate:
+    return "GizmoModeRotate";
+  case ShortcutAction::GizmoModeScale:
+    return "GizmoModeScale";
+  case ShortcutAction::GizmoToggleSpace:
+    return "GizmoToggleSpace";
+
   default:
     return "Unknown";
   }
@@ -752,6 +768,16 @@ std::string ShortcutManager::getActionDescription(ShortcutAction action) {
     return "Undo Last Action";
   case ShortcutAction::Redo:
     return "Redo Last Undone Action";
+
+  // Transform Gizmo
+  case ShortcutAction::GizmoModeMove:
+    return "Gizmo: Move Mode";
+  case ShortcutAction::GizmoModeRotate:
+    return "Gizmo: Rotate Mode";
+  case ShortcutAction::GizmoModeScale:
+    return "Gizmo: Scale Mode";
+  case ShortcutAction::GizmoToggleSpace:
+    return "Gizmo: Toggle World/Local Space";
 
   default:
     return "Unknown Action";

--- a/StereoVista/src/Engine/ShortcutManager.cpp
+++ b/StereoVista/src/Engine/ShortcutManager.cpp
@@ -440,6 +440,9 @@ ShortcutProfile ShortcutManager::createDefaultProfile() {
                      KeyBinding(GLFW_KEY_Z, true, false, true),
                      1); // Ctrl+Shift+Z
 
+  // View shading
+  profile.setBinding(ShortcutAction::ToggleUnlit, KeyBinding(GLFW_KEY_U), 0);
+
   // Transform gizmo (active while an object is selected)
   profile.setBinding(ShortcutAction::GizmoModeMove, KeyBinding(GLFW_KEY_1), 0);
   profile.setBinding(ShortcutAction::GizmoModeRotate, KeyBinding(GLFW_KEY_2), 0);
@@ -585,6 +588,8 @@ std::string ShortcutManager::getActionName(ShortcutAction action) {
   // Materials & Rendering
   case ShortcutAction::TogglePBR:
     return "TogglePBR";
+  case ShortcutAction::ToggleUnlit:
+    return "ToggleUnlit";
 
   // VCT
   case ShortcutAction::ToggleVoxelViz:
@@ -706,6 +711,8 @@ std::string ShortcutManager::getActionDescription(ShortcutAction action) {
   // Materials & Rendering
   case ShortcutAction::TogglePBR:
     return "Toggle PBR Materials";
+  case ShortcutAction::ToggleUnlit:
+    return "Toggle Unlit (Albedo) Shading";
 
   // VCT
   case ShortcutAction::ToggleVoxelViz:

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -225,6 +225,84 @@ static void renderGizmoViewportToolbar() {
   ImGui::PopStyleVar(3);
 }
 
+extern bool g_unlitMode;
+
+// Floating "View" toolbar in the top-left of the viewport. Always available
+// (these are global view-shading toggles, independent of selection). Surfaces
+// the rebindable shortcut keys as tooltips.
+static void renderViewModeToolbar() {
+  using SA = StereoVista::ShortcutAction;
+  if (g_viewportWidth <= 0 || g_viewportHeight <= 0)
+    return;
+
+  auto keyFor = [&](SA a) -> std::string {
+    const StereoVista::ShortcutProfile *prof = shortcutManager.getActiveProfile();
+    if (!prof)
+      return "";
+    const std::vector<StereoVista::KeyBinding> &b = prof->getBindings(a);
+    if (b.empty() || b[0].isEmpty())
+      return "";
+    return b[0].toString();
+  };
+
+  const float scale = g_GuiScale.currentScale;
+  const float margin = 12.0f * scale;
+  ImGui::SetNextWindowPos(
+      ImVec2(g_viewportX + margin, g_viewportTopInset + margin),
+      ImGuiCond_Always, ImVec2(0.0f, 0.0f));
+  ImGui::SetNextWindowBgAlpha(0.78f);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 10.0f * scale);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
+                      ImVec2(6.0f * scale, 6.0f * scale));
+  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.0f * scale);
+
+  ImGuiWindowFlags flags =
+      ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
+      ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar |
+      ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_AlwaysAutoResize |
+      ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoFocusOnAppearing |
+      ImGuiWindowFlags_NoSavedSettings;
+
+  if (ImGui::Begin("##ViewModeToolbar", nullptr, flags)) {
+    const ImVec4 accent = ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive);
+    const ImVec2 btn(0.0f, 26.0f * scale);
+
+    auto toggleBtn = [&](const char *label, bool active, const char *tip,
+                         SA act) {
+      if (active)
+        ImGui::PushStyleColor(ImGuiCol_Button, accent);
+      bool clicked = ImGui::Button(label, btn);
+      if (active)
+        ImGui::PopStyleColor();
+      if (ImGui::IsItemHovered()) {
+        std::string k = keyFor(act);
+        if (k.empty())
+          ImGui::SetTooltip("%s", tip);
+        else
+          ImGui::SetTooltip("%s  [%s]", tip, k.c_str());
+      }
+      return clicked;
+    };
+
+    // Shading: Lit / Unlit (mutually exclusive)
+    if (toggleBtn("Lit", !g_unlitMode, "Lit shading", SA::ToggleUnlit))
+      g_unlitMode = false;
+    ImGui::SameLine();
+    if (toggleBtn("Unlit", g_unlitMode, "Unlit (albedo-only) shading",
+                  SA::ToggleUnlit))
+      g_unlitMode = true;
+    ImGui::SameLine();
+    ImGui::TextUnformatted("|");
+    ImGui::SameLine();
+    // Wireframe overlay toggle (independent of shading)
+    if (toggleBtn("Wireframe", camera.wireframe, "Wireframe (triangle edges)",
+                  SA::ToggleWireframe))
+      camera.wireframe = !camera.wireframe;
+  }
+  ImGui::End();
+  ImGui::PopStyleVar(3);
+}
+
 extern GUI::LightingMode currentLightingMode;
 extern bool enableShadows;
 extern GUI::VCTSettings vctSettings;
@@ -2519,7 +2597,9 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
   // from the world-space measurement overlay
   drawMeasurementLabels();
 
-  // Floating transform-gizmo mode toolbar (top-right of the viewport)
+  // Floating view-mode toolbar (top-left) and transform-gizmo toolbar
+  // (top-right) of the viewport
+  renderViewModeToolbar();
   renderGizmoViewportToolbar();
 
   // Centered hint while nothing is loaded yet

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -119,7 +119,9 @@ static void DrawTransformGizmoControls(bool canRotateScale) {
   }
   ImGui::DragFloat("Gizmo Size", &transformGizmo.screenSize, 0.005f, 0.04f,
                    0.5f, "%.3f");
-  ImGui::TextDisabled("Keys: 1 Move  2 Rotate  3 Scale  4 World/Local");
+  ImGui::TextDisabled(
+      "Default keys: 1 Move  2 Rotate  3 Scale  4 World/Local");
+  ImGui::TextDisabled("(rebindable in Settings > Shortcuts)");
   ImGui::TextDisabled("Hold Shift while dragging to snap");
 }
 
@@ -129,6 +131,99 @@ extern int g_viewportTopInset;
 extern int g_viewportWidth;
 extern int g_viewportHeight;
 extern float aspectRatio;
+extern StereoVista::ShortcutManager shortcutManager;
+
+// Floating mode toolbar drawn as a small rounded bubble in the top-right of the
+// 3D viewport while an object is selected. Mirrors the gizmo's current mode and
+// shows the (rebindable) shortcut keys as tooltips.
+static void renderGizmoViewportToolbar() {
+  using G = Tools::TransformGizmo;
+  using SA = StereoVista::ShortcutAction;
+  if (!transformGizmo.enabled || !transformGizmo.hasTarget())
+    return;
+  if (g_viewportWidth <= 0 || g_viewportHeight <= 0)
+    return;
+
+  auto keyFor = [&](SA a) -> std::string {
+    const StereoVista::ShortcutProfile *prof = shortcutManager.getActiveProfile();
+    if (!prof)
+      return "";
+    const std::vector<StereoVista::KeyBinding> &b = prof->getBindings(a);
+    if (b.empty() || b[0].isEmpty())
+      return "";
+    return b[0].toString();
+  };
+
+  const float scale = g_GuiScale.currentScale;
+  const float margin = 12.0f * scale;
+  ImGui::SetNextWindowPos(
+      ImVec2(g_viewportX + g_viewportWidth - margin, g_viewportTopInset + margin),
+      ImGuiCond_Always, ImVec2(1.0f, 0.0f));
+  ImGui::SetNextWindowBgAlpha(0.78f);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 10.0f * scale);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
+                      ImVec2(6.0f * scale, 6.0f * scale));
+  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.0f * scale);
+
+  ImGuiWindowFlags flags =
+      ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
+      ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar |
+      ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_AlwaysAutoResize |
+      ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoFocusOnAppearing |
+      ImGuiWindowFlags_NoSavedSettings;
+
+  if (ImGui::Begin("##GizmoToolbar", nullptr, flags)) {
+    const ImVec4 accent = ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive);
+    const ImVec2 btn(0.0f, 26.0f * scale);
+
+    auto modeBtn = [&](const char *label, G::Mode m, bool enabledBtn, SA act) {
+      bool active = (transformGizmo.mode() == m);
+      if (active)
+        ImGui::PushStyleColor(ImGuiCol_Button, accent);
+      if (!enabledBtn)
+        ImGui::BeginDisabled();
+      if (ImGui::Button(label, btn))
+        transformGizmo.setMode(m);
+      if (!enabledBtn)
+        ImGui::EndDisabled();
+      if (active)
+        ImGui::PopStyleColor();
+      if (ImGui::IsItemHovered()) {
+        std::string k = keyFor(act);
+        ImGui::SetTooltip("%s%s%s", label, k.empty() ? "" : "  [",
+                          k.empty() ? "" : (k + "]").c_str());
+      }
+    };
+
+    bool rs = transformGizmo.canRotate(); // rotate/scale availability
+    modeBtn("Move", G::Mode::Translate, true, SA::GizmoModeMove);
+    ImGui::SameLine();
+    modeBtn("Rotate", G::Mode::Rotate, rs, SA::GizmoModeRotate);
+    ImGui::SameLine();
+    modeBtn("Scale", G::Mode::Scale, transformGizmo.canScale(),
+            SA::GizmoModeScale);
+    ImGui::SameLine();
+    ImGui::TextUnformatted("|");
+    ImGui::SameLine();
+    bool world = (transformGizmo.space == G::Space::World);
+    if (ImGui::Button(world ? "World" : "Local", btn))
+      transformGizmo.toggleSpace();
+    if (ImGui::IsItemHovered()) {
+      std::string k = keyFor(SA::GizmoToggleSpace);
+      ImGui::SetTooltip("Transform space%s%s%s",
+                        k.empty() ? "" : "  [", k.empty() ? "" : k.c_str(),
+                        k.empty() ? "" : "]");
+    }
+    ImGui::SameLine();
+    if (ImGui::SmallButton(transformGizmo.snapEnabled ? "Snap:On" : "Snap:Off"))
+      transformGizmo.snapEnabled = !transformGizmo.snapEnabled;
+    if (ImGui::IsItemHovered())
+      ImGui::SetTooltip("Toggle snapping (hold Shift while dragging for "
+                        "momentary snap)");
+  }
+  ImGui::End();
+  ImGui::PopStyleVar(3);
+}
 
 extern GUI::LightingMode currentLightingMode;
 extern bool enableShadows;
@@ -2423,6 +2518,9 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
   // Screen-space measurement labels (distances/angles/coordinates) projected
   // from the world-space measurement overlay
   drawMeasurementLabels();
+
+  // Floating transform-gizmo mode toolbar (top-right of the viewport)
+  renderGizmoViewportToolbar();
 
   // Centered hint while nothing is loaded yet
   renderEmptySceneHint();

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -11,6 +11,7 @@
 #include "Gui/GuiTypes.h"
 #include "Tools/BrushTool.h"
 #include "Tools/MeasurementTool.h"
+#include "Tools/TransformGizmo.h"
 #include "imgui/IconsFontAwesome5.h"
 #include "imgui/imgui_sytle.h"
 #include "libs/portable-file-dialogs.h"
@@ -69,6 +70,58 @@ extern Tools::BrushTool brushTool;
 // Measurement tool
 extern Tools::MeasurementTool measurementTool;
 extern bool showMeasurementToolWindow;
+
+// Transform gizmo
+extern Tools::TransformGizmo transformGizmo;
+
+// Shared transform-gizmo controls (mode / space / snap), drawn inside the
+// Transform panel of any selectable object.
+static void DrawTransformGizmoControls(bool canRotateScale) {
+  using G = Tools::TransformGizmo;
+  ImGui::Spacing();
+  ImGui::Checkbox("Show Gizmo", &transformGizmo.enabled);
+  if (!transformGizmo.enabled)
+    return;
+
+  G::Mode mode = transformGizmo.mode();
+  auto modeButton = [&](const char *label, G::Mode m, bool enabledBtn) {
+    if (!enabledBtn)
+      ImGui::BeginDisabled();
+    bool active = (mode == m);
+    if (active)
+      ImGui::PushStyleColor(ImGuiCol_Button,
+                            ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive));
+    if (ImGui::Button(label))
+      transformGizmo.setMode(m);
+    if (active)
+      ImGui::PopStyleColor();
+    if (!enabledBtn)
+      ImGui::EndDisabled();
+  };
+  modeButton("Move", G::Mode::Translate, true);
+  ImGui::SameLine();
+  modeButton("Rotate", G::Mode::Rotate, canRotateScale);
+  ImGui::SameLine();
+  modeButton("Scale", G::Mode::Scale, canRotateScale);
+  ImGui::SameLine();
+  bool world = (transformGizmo.space == G::Space::World);
+  if (ImGui::Button(world ? "World" : "Local"))
+    transformGizmo.toggleSpace();
+
+  ImGui::Checkbox("Snap", &transformGizmo.snapEnabled);
+  if (transformGizmo.snapEnabled) {
+    ImGui::DragFloat("Move Snap", &transformGizmo.snapTranslate, 0.01f, 0.001f,
+                     10.0f, "%.3f");
+    ImGui::DragFloat("Rotate Snap", &transformGizmo.snapRotateDeg, 0.5f, 1.0f,
+                     90.0f, "%.0f°");
+    ImGui::DragFloat("Scale Snap", &transformGizmo.snapScale, 0.01f, 0.001f,
+                     10.0f, "%.3f");
+  }
+  ImGui::DragFloat("Gizmo Size", &transformGizmo.screenSize, 0.005f, 0.04f,
+                   0.5f, "%.3f");
+  ImGui::TextDisabled("Keys: 1 Move  2 Rotate  3 Scale  4 World/Local");
+  ImGui::TextDisabled("Hold Shift while dragging to snap");
+}
 
 // 3D viewport rectangle (window pixels) — used to project measurement labels
 extern int g_viewportX;
@@ -6298,6 +6351,8 @@ void renderModelManipulationPanel(Engine::Model &model,
     if (transformChanged) {
       updateSpaceMouseBounds();
     }
+
+    DrawTransformGizmoControls(/*canRotateScale=*/true);
   }
 
   if (ImGui::CollapsingHeader("Material", ImGuiTreeNodeFlags_DefaultOpen)) {
@@ -6667,6 +6722,8 @@ void renderPointCloudManipulationPanel(Engine::PointCloud &pointCloud) {
     if (transformChanged) {
       updateSpaceMouseBounds();
     }
+
+    DrawTransformGizmoControls(/*canRotateScale=*/true);
   }
 
   if (ImGui::CollapsingHeader("Display Settings",
@@ -6842,6 +6899,7 @@ void renderPointLightManipulationPanel() {
 
   if (ImGui::CollapsingHeader("Transform", ImGuiTreeNodeFlags_DefaultOpen)) {
     ImGui::DragFloat3("Position", glm::value_ptr(light.position), 0.1f);
+    DrawTransformGizmoControls(/*canRotateScale=*/false);
   }
 
   if (ImGui::CollapsingHeader("Light Properties",
@@ -6919,6 +6977,7 @@ void renderSpotLightManipulationPanel() {
     }
     ImGui::SameLine();
     DrawHelpMarker("Make direction vector unit length");
+    DrawTransformGizmoControls(/*canRotateScale=*/false);
   }
 
   if (ImGui::CollapsingHeader("Light Properties",

--- a/StereoVista/src/Tools/TransformGizmo.cpp
+++ b/StereoVista/src/Tools/TransformGizmo.cpp
@@ -1,0 +1,664 @@
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef GLM_ENABLE_EXPERIMENTAL
+#define GLM_ENABLE_EXPERIMENTAL
+#endif
+#include "Tools/TransformGizmo.h"
+
+#include <glm/gtc/constants.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/type_ptr.hpp>
+#include <glm/gtx/quaternion.hpp>     // glm::rotation, glm::toMat4
+#include <glm/gtx/euler_angles.hpp>   // eulerAngleXYZ, extractEulerAngleXYZ
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+namespace Tools {
+
+// ── Geometry constants (fractions of the screen-constant gizmo size) ────────
+namespace {
+constexpr float SHAFT_LEN   = 0.80f;
+constexpr float SHAFT_R     = 0.018f;
+constexpr float TIP_LEN     = 0.18f;
+constexpr float TIP_R       = 0.055f;
+constexpr float AXIS_PICK_R = 0.10f;  // forgiving radial pick distance
+constexpr float AXIS_MIN_T  = 0.13f;  // ignore picks near the centre handle
+constexpr float PLANE_OFF   = 0.34f;
+constexpr float PLANE_HALF  = 0.12f;
+constexpr float RING_R      = 0.92f;
+constexpr float RING_PICK   = 0.07f;
+constexpr float SCALE_TIP   = 0.085f; // cube half-extent at shaft end
+constexpr float CENTER_HALF = 0.11f;
+
+const glm::vec3 kAxisColor[3] = {
+    glm::vec3(0.91f, 0.27f, 0.30f),   // X red
+    glm::vec3(0.45f, 0.82f, 0.27f),   // Y green
+    glm::vec3(0.27f, 0.50f, 0.95f),   // Z blue
+};
+const glm::vec3 kHighlight(1.0f, 0.85f, 0.16f);
+const glm::vec3 kCenterColor(0.85f, 0.85f, 0.88f);
+
+// Closest points between a ray (o,d) and an infinite line (p,a). Returns the
+// ray parameter and line parameter; `a` and `d` are assumed unit-length.
+void closestRayLine(const glm::vec3& o, const glm::vec3& d, const glm::vec3& p,
+                    const glm::vec3& a, float& sRay, float& tLine) {
+    glm::vec3 r = o - p;
+    float dd = glm::dot(d, d);
+    float aa = glm::dot(a, a);
+    float da = glm::dot(d, a);
+    float dr = glm::dot(d, r);
+    float ar = glm::dot(a, r);
+    float denom = dd * aa - da * da;
+    if (std::fabs(denom) < 1e-7f) { sRay = 0.0f; tLine = 0.0f; return; }
+    sRay  = (da * ar - aa * dr) / denom;
+    tLine = (dd * ar - da * dr) / denom;
+}
+
+// Ray/plane intersection. Returns false when (near) parallel or behind.
+bool rayPlane(const glm::vec3& o, const glm::vec3& d, const glm::vec3& p,
+              const glm::vec3& n, glm::vec3& hit, float& t) {
+    float denom = glm::dot(d, n);
+    if (std::fabs(denom) < 1e-6f) return false;
+    t = glm::dot(p - o, n) / denom;
+    if (t <= 0.0f) return false;
+    hit = o + d * t;
+    return true;
+}
+
+// Two unit vectors orthogonal to n (for ring tangent space).
+void planeBasis(const glm::vec3& n, glm::vec3& u, glm::vec3& v) {
+    glm::vec3 ref = (std::fabs(n.x) < 0.9f) ? glm::vec3(1, 0, 0)
+                                            : glm::vec3(0, 1, 0);
+    u = glm::normalize(glm::cross(ref, n));
+    v = glm::normalize(glm::cross(n, u));
+}
+
+unsigned int compileShader(unsigned int type, const char* src) {
+    unsigned int s = glCreateShader(type);
+    glShaderSource(s, 1, &src, nullptr);
+    glCompileShader(s);
+    int ok = 0;
+    glGetShaderiv(s, GL_COMPILE_STATUS, &ok);
+    if (!ok) {
+        char log[512];
+        glGetShaderInfoLog(s, 512, nullptr, log);
+        std::cerr << "[TransformGizmo] shader compile error: " << log << std::endl;
+    }
+    return s;
+}
+} // namespace
+
+// ── Embedded overlay shader ─────────────────────────────────────────────────
+static const char* kVertSrc = R"(
+#version 330 core
+layout (location = 0) in vec3 aPos;
+uniform mat4 uMVP;
+void main() { gl_Position = uMVP * vec4(aPos, 1.0); }
+)";
+
+static const char* kFragSrc = R"(
+#version 330 core
+out vec4 FragColor;
+uniform vec3 uColor;
+uniform float uAlpha;
+void main() { FragColor = vec4(uColor, uAlpha); }
+)";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Target binding & configuration
+// ────────────────────────────────────────────────────────────────────────────
+void TransformGizmo::setTarget(glm::vec3* position, glm::vec3* rotationEulerDeg,
+                               glm::vec3* scale) {
+    m_position = position;
+    m_rotation = rotationEulerDeg;
+    m_scale = scale;
+}
+
+void TransformGizmo::clearTarget() {
+    if (isDragging()) return; // don't drop a live drag
+    m_position = nullptr;
+    m_rotation = nullptr;
+    m_scale = nullptr;
+    m_hover = Handle::None;
+}
+
+void TransformGizmo::setMode(Mode m) { m_mode = m; }
+
+void TransformGizmo::cycleMode() {
+    m_mode = (m_mode == Mode::Translate) ? Mode::Rotate
+           : (m_mode == Mode::Rotate)    ? Mode::Scale
+                                         : Mode::Translate;
+}
+
+TransformGizmo::Mode TransformGizmo::effectiveMode() const {
+    if (m_mode == Mode::Rotate && !canRotate()) return Mode::Translate;
+    if (m_mode == Mode::Scale && !canScale())   return Mode::Translate;
+    return m_mode;
+}
+
+glm::mat3 TransformGizmo::rotationMatrix() const {
+    if (!m_rotation) return glm::mat3(1.0f);
+    return glm::mat3(glm::eulerAngleXYZ(glm::radians(m_rotation->x),
+                                        glm::radians(m_rotation->y),
+                                        glm::radians(m_rotation->z)));
+}
+
+void TransformGizmo::computeAxes(glm::vec3 outAxes[3], Mode forMode) const {
+    bool local = (forMode == Mode::Scale) ||
+                 (space == Space::Local && m_rotation != nullptr);
+    if (local) {
+        glm::mat3 R = rotationMatrix();
+        outAxes[0] = glm::normalize(R[0]);
+        outAxes[1] = glm::normalize(R[1]);
+        outAxes[2] = glm::normalize(R[2]);
+    } else {
+        outAxes[0] = glm::vec3(1, 0, 0);
+        outAxes[1] = glm::vec3(0, 1, 0);
+        outAxes[2] = glm::vec3(0, 0, 1);
+    }
+}
+
+float TransformGizmo::gizmoScale(const glm::vec3& cameraPos) const {
+    if (!m_position) return 1.0f;
+    float dist = glm::distance(cameraPos, *m_position);
+    return std::max(dist * screenSize, 1e-3f);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Hit testing
+// ────────────────────────────────────────────────────────────────────────────
+TransformGizmo::Handle
+TransformGizmo::hitTest(const glm::vec3& o, const glm::vec3& d,
+                        const glm::vec3& cameraPos) const {
+    if (!enabled || !hasTarget()) return Handle::None;
+
+    const glm::vec3 pivot = *m_position;
+    const float s = gizmoScale(cameraPos);
+    const Mode m = effectiveMode();
+    glm::vec3 axes[3];
+    computeAxes(axes, m);
+
+    Handle best = Handle::None;
+    float bestDepth = std::numeric_limits<float>::max();
+    auto consider = [&](Handle h, float depth) {
+        if (depth > 0.0f && depth < bestDepth) { bestDepth = depth; best = h; }
+    };
+
+    if (m == Mode::Rotate) {
+        const Handle ringH[3] = {Handle::RingX, Handle::RingY, Handle::RingZ};
+        for (int i = 0; i < 3; ++i) {
+            glm::vec3 hit; float t;
+            if (!rayPlane(o, d, pivot, axes[i], hit, t)) continue;
+            float radial = glm::length(hit - pivot);
+            if (std::fabs(radial - RING_R * s) < RING_PICK * s) consider(ringH[i], t);
+        }
+        return best;
+    }
+
+    // Translate & Scale share single-axis shafts.
+    const Handle axisH[3] = {Handle::AxisX, Handle::AxisY, Handle::AxisZ};
+    const float axisLen = (m == Mode::Scale ? SHAFT_LEN + SCALE_TIP
+                                            : SHAFT_LEN + TIP_LEN) * s;
+    for (int i = 0; i < 3; ++i) {
+        float sRay, tLine;
+        closestRayLine(o, d, pivot, axes[i], sRay, tLine);
+        if (sRay <= 0.0f) continue;
+        if (tLine < AXIS_MIN_T * s || tLine > axisLen) continue;
+        glm::vec3 pRay = o + d * sRay;
+        glm::vec3 pAxis = pivot + axes[i] * tLine;
+        if (glm::length(pRay - pAxis) < AXIS_PICK_R * s) consider(axisH[i], sRay);
+    }
+
+    if (m == Mode::Translate) {
+        // Two-axis plane quads.
+        const Handle planeH[3] = {Handle::PlaneYZ, Handle::PlaneZX, Handle::PlaneXY};
+        const int ai[3] = {1, 2, 0};
+        const int aj[3] = {2, 0, 1};
+        const int nk[3] = {0, 1, 2};
+        for (int k = 0; k < 3; ++k) {
+            glm::vec3 hit; float t;
+            if (!rayPlane(o, d, pivot, axes[nk[k]], hit, t)) continue;
+            float u = glm::dot(hit - pivot, axes[ai[k]]);
+            float v = glm::dot(hit - pivot, axes[aj[k]]);
+            float lo = (PLANE_OFF - PLANE_HALF) * s;
+            float hi = (PLANE_OFF + PLANE_HALF) * s;
+            if (u > lo && u < hi && v > lo && v < hi) consider(planeH[k], t);
+        }
+    }
+
+    // Centre handle (sphere pick).
+    {
+        glm::vec3 oc = o - pivot;
+        float r = CENTER_HALF * 1.35f * s;
+        float b = glm::dot(oc, d);
+        float c = glm::dot(oc, oc) - r * r;
+        float disc = b * b - c;
+        if (disc >= 0.0f) {
+            float t = -b - std::sqrt(disc);
+            if (t > 0.0f) {
+                if (m == Mode::Scale) consider(Handle::ScaleUniform, t);
+                else if (m == Mode::Translate) consider(Handle::ScreenMove, t);
+            }
+        }
+    }
+
+    return best;
+}
+
+TransformGizmo::Handle
+TransformGizmo::updateHover(const glm::vec3& o, const glm::vec3& d,
+                            const glm::vec3& cameraPos) {
+    if (isDragging()) return m_activeHandle;
+    m_hover = hitTest(o, d, cameraPos);
+    return m_hover;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Drag lifecycle
+// ────────────────────────────────────────────────────────────────────────────
+bool TransformGizmo::beginDrag(Handle handle, const glm::vec3& o,
+                               const glm::vec3& d, const glm::vec3& cameraPos) {
+    if (!hasTarget() || handle == Handle::None) return false;
+
+    const glm::vec3 pivot = *m_position;
+    m_startPos = pivot;
+    m_startScale = m_scale ? *m_scale : glm::vec3(1.0f);
+    m_startRot = rotationMatrix();
+    m_gizmoScaleAtDrag = gizmoScale(cameraPos);
+    const Mode m = effectiveMode();
+    glm::vec3 axes[3];
+    computeAxes(axes, m);
+
+    auto axisIndex = [](Handle h) {
+        switch (h) {
+        case Handle::AxisX: case Handle::RingX: return 0;
+        case Handle::AxisY: case Handle::RingY: return 1;
+        case Handle::AxisZ: case Handle::RingZ: return 2;
+        default: return -1;
+        }
+    };
+
+    switch (handle) {
+    case Handle::AxisX: case Handle::AxisY: case Handle::AxisZ: {
+        int idx = axisIndex(handle);
+        m_dragAxisIndex = idx;
+        m_dragAxis = axes[idx];
+        float sRay, tLine;
+        closestRayLine(o, d, pivot, m_dragAxis, sRay, tLine);
+        m_startProj = tLine;
+        break;
+    }
+    case Handle::PlaneYZ: case Handle::PlaneZX: case Handle::PlaneXY: {
+        int nk = (handle == Handle::PlaneYZ) ? 0
+               : (handle == Handle::PlaneZX) ? 1 : 2;
+        m_dragPlaneNormal = axes[nk];
+        float t;
+        if (!rayPlane(o, d, pivot, m_dragPlaneNormal, m_dragStartHit, t))
+            m_dragStartHit = pivot;
+        break;
+    }
+    case Handle::RingX: case Handle::RingY: case Handle::RingZ: {
+        int idx = axisIndex(handle);
+        m_dragAxis = axes[idx];
+        planeBasis(m_dragAxis, m_planeU, m_planeV);
+        glm::vec3 hit; float t;
+        if (rayPlane(o, d, pivot, m_dragAxis, hit, t)) {
+            glm::vec3 v = glm::normalize(hit - pivot);
+            m_startAngle = std::atan2(glm::dot(v, m_planeV), glm::dot(v, m_planeU));
+        } else {
+            m_startAngle = 0.0f;
+        }
+        m_lastAngle = m_startAngle;
+        m_turnCount = 0;
+        break;
+    }
+    case Handle::ScreenMove: {
+        m_dragPlaneNormal = glm::normalize(cameraPos - pivot);
+        float t;
+        if (!rayPlane(o, d, pivot, m_dragPlaneNormal, m_dragStartHit, t))
+            m_dragStartHit = pivot;
+        break;
+    }
+    case Handle::ScaleUniform: {
+        m_dragPlaneNormal = glm::normalize(cameraPos - pivot);
+        glm::vec3 hit; float t;
+        if (rayPlane(o, d, pivot, m_dragPlaneNormal, hit, t))
+            m_startRadius = std::max(glm::length(hit - pivot), 1e-4f);
+        else
+            m_startRadius = m_gizmoScaleAtDrag;
+        break;
+    }
+    default:
+        return false;
+    }
+
+    m_activeHandle = handle;
+    return true;
+}
+
+void TransformGizmo::updateDrag(const glm::vec3& o, const glm::vec3& d,
+                                const glm::vec3& cameraPos, bool snapHeld) {
+    if (!isDragging() || !hasTarget()) return;
+    const bool snap = snapEnabled || snapHeld;
+    const glm::vec3 pivot = m_startPos;
+
+    switch (m_activeHandle) {
+    case Handle::AxisX: case Handle::AxisY: case Handle::AxisZ: {
+        float sRay, tLine;
+        closestRayLine(o, d, pivot, m_dragAxis, sRay, tLine);
+        float delta = tLine - m_startProj;
+        if (effectiveMode() == Mode::Scale && m_scale) {
+            float factor = 1.0f + delta / m_gizmoScaleAtDrag;
+            factor = std::max(factor, 0.01f);
+            float val = m_startScale[m_dragAxisIndex] * factor;
+            if (snap) val = std::max(snapScale,
+                                     std::round(val / snapScale) * snapScale);
+            (*m_scale)[m_dragAxisIndex] = val;
+        } else {
+            if (snap) delta = std::round(delta / snapTranslate) * snapTranslate;
+            *m_position = m_startPos + m_dragAxis * delta;
+        }
+        break;
+    }
+    case Handle::PlaneYZ: case Handle::PlaneZX: case Handle::PlaneXY:
+    case Handle::ScreenMove: {
+        glm::vec3 hit; float t;
+        if (rayPlane(o, d, pivot, m_dragPlaneNormal, hit, t)) {
+            glm::vec3 delta = hit - m_dragStartHit;
+            if (snap) {
+                delta.x = std::round(delta.x / snapTranslate) * snapTranslate;
+                delta.y = std::round(delta.y / snapTranslate) * snapTranslate;
+                delta.z = std::round(delta.z / snapTranslate) * snapTranslate;
+            }
+            *m_position = m_startPos + delta;
+        }
+        break;
+    }
+    case Handle::RingX: case Handle::RingY: case Handle::RingZ: {
+        if (!m_rotation) break;
+        glm::vec3 hit; float t;
+        if (!rayPlane(o, d, pivot, m_dragAxis, hit, t)) break;
+        glm::vec3 v = glm::normalize(hit - pivot);
+        float ang = std::atan2(glm::dot(v, m_planeV), glm::dot(v, m_planeU));
+        // Track full turns for continuous multi-revolution dragging.
+        if (ang - m_lastAngle > glm::pi<float>()) m_turnCount--;
+        else if (ang - m_lastAngle < -glm::pi<float>()) m_turnCount++;
+        m_lastAngle = ang;
+        float delta = (ang + m_turnCount * glm::two_pi<float>()) - m_startAngle;
+        if (snap) {
+            float step = glm::radians(snapRotateDeg);
+            delta = std::round(delta / step) * step;
+        }
+        glm::mat3 deltaRot =
+            glm::mat3(glm::rotate(glm::mat4(1.0f), delta, m_dragAxis));
+        glm::mat3 R = deltaRot * m_startRot;
+        float ex, ey, ez;
+        glm::extractEulerAngleXYZ(glm::mat4(R), ex, ey, ez);
+        *m_rotation = glm::degrees(glm::vec3(ex, ey, ez));
+        break;
+    }
+    case Handle::ScaleUniform: {
+        if (!m_scale) break;
+        glm::vec3 hit; float t;
+        if (rayPlane(o, d, pivot, m_dragPlaneNormal, hit, t)) {
+            float factor = std::max(glm::length(hit - pivot) / m_startRadius, 0.01f);
+            glm::vec3 ns = m_startScale * factor;
+            if (snap) {
+                ns.x = std::max(snapScale, std::round(ns.x / snapScale) * snapScale);
+                ns.y = std::max(snapScale, std::round(ns.y / snapScale) * snapScale);
+                ns.z = std::max(snapScale, std::round(ns.z / snapScale) * snapScale);
+            }
+            *m_scale = ns;
+        }
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+void TransformGizmo::endDrag() {
+    m_activeHandle = Handle::None;
+    m_dragAxisIndex = -1;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Rendering
+// ────────────────────────────────────────────────────────────────────────────
+void TransformGizmo::ensureInit() {
+    if (m_initialized) return;
+    m_initialized = true;
+
+    // Program.
+    unsigned int vs = compileShader(GL_VERTEX_SHADER, kVertSrc);
+    unsigned int fs = compileShader(GL_FRAGMENT_SHADER, kFragSrc);
+    m_program = glCreateProgram();
+    glAttachShader(m_program, vs);
+    glAttachShader(m_program, fs);
+    glLinkProgram(m_program);
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+    m_uMVP = glGetUniformLocation(m_program, "uMVP");
+    m_uColor = glGetUniformLocation(m_program, "uColor");
+    m_uAlpha = glGetUniformLocation(m_program, "uAlpha");
+
+    auto upload = [](unsigned int& vao, unsigned int& vbo,
+                     const std::vector<float>& verts) {
+        glGenVertexArrays(1, &vao);
+        glGenBuffers(1, &vbo);
+        glBindVertexArray(vao);
+        glBindBuffer(GL_ARRAY_BUFFER, vbo);
+        glBufferData(GL_ARRAY_BUFFER, verts.size() * sizeof(float),
+                     verts.data(), GL_STATIC_DRAW);
+        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float),
+                              (void*)0);
+        glEnableVertexAttribArray(0);
+        glBindVertexArray(0);
+    };
+
+    const int SEG = 20;
+    const float TAU = glm::two_pi<float>();
+
+    // Cylinder +Y, radius 1, y in [0,1] (side only).
+    {
+        std::vector<float> v;
+        for (int i = 0; i < SEG; ++i) {
+            float a0 = TAU * i / SEG, a1 = TAU * (i + 1) / SEG;
+            glm::vec3 b0(std::cos(a0), 0, std::sin(a0));
+            glm::vec3 b1(std::cos(a1), 0, std::sin(a1));
+            glm::vec3 t0 = b0 + glm::vec3(0, 1, 0);
+            glm::vec3 t1 = b1 + glm::vec3(0, 1, 0);
+            glm::vec3 tri[6] = {b0, b1, t1, b0, t1, t0};
+            for (auto& p : tri) { v.push_back(p.x); v.push_back(p.y); v.push_back(p.z); }
+        }
+        m_cylCount = (int)v.size() / 3;
+        upload(m_cylVAO, m_cylVBO, v);
+    }
+    // Cone +Y, base radius 1 at y=0, apex y=1 (+ base cap).
+    {
+        std::vector<float> v;
+        glm::vec3 apex(0, 1, 0), center(0, 0, 0);
+        for (int i = 0; i < SEG; ++i) {
+            float a0 = TAU * i / SEG, a1 = TAU * (i + 1) / SEG;
+            glm::vec3 b0(std::cos(a0), 0, std::sin(a0));
+            glm::vec3 b1(std::cos(a1), 0, std::sin(a1));
+            glm::vec3 side[3] = {b0, b1, apex};
+            for (auto& p : side) { v.push_back(p.x); v.push_back(p.y); v.push_back(p.z); }
+            glm::vec3 cap[3] = {center, b1, b0};
+            for (auto& p : cap) { v.push_back(p.x); v.push_back(p.y); v.push_back(p.z); }
+        }
+        m_coneCount = (int)v.size() / 3;
+        upload(m_coneVAO, m_coneVBO, v);
+    }
+    // Cube centred, side 1.
+    {
+        const float h = 0.5f;
+        glm::vec3 c[8] = {
+            {-h,-h,-h},{ h,-h,-h},{ h, h,-h},{-h, h,-h},
+            {-h,-h, h},{ h,-h, h},{ h, h, h},{-h, h, h}};
+        int faces[6][4] = {{0,1,2,3},{5,4,7,6},{4,0,3,7},
+                           {1,5,6,2},{3,2,6,7},{4,5,1,0}};
+        std::vector<float> v;
+        for (auto& f : faces) {
+            glm::vec3 q[6] = {c[f[0]], c[f[1]], c[f[2]],
+                              c[f[0]], c[f[2]], c[f[3]]};
+            for (auto& p : q) { v.push_back(p.x); v.push_back(p.y); v.push_back(p.z); }
+        }
+        m_cubeCount = (int)v.size() / 3;
+        upload(m_cubeVAO, m_cubeVBO, v);
+    }
+    // Ring: unit circle line loop in XY (normal +Z).
+    {
+        const int RSEG = 64;
+        std::vector<float> v;
+        for (int i = 0; i < RSEG; ++i) {
+            float a = TAU * i / RSEG;
+            v.push_back(std::cos(a)); v.push_back(std::sin(a)); v.push_back(0.0f);
+        }
+        m_ringCount = (int)v.size() / 3;
+        upload(m_ringVAO, m_ringVBO, v);
+    }
+    // Quad: XY plane, corners +/-1 (two triangles).
+    {
+        glm::vec3 q[6] = {{-1,-1,0},{1,-1,0},{1,1,0},{-1,-1,0},{1,1,0},{-1,1,0}};
+        std::vector<float> v;
+        for (auto& p : q) { v.push_back(p.x); v.push_back(p.y); v.push_back(p.z); }
+        m_quadCount = (int)v.size() / 3;
+        upload(m_quadVAO, m_quadVBO, v);
+    }
+}
+
+void TransformGizmo::drawMesh(unsigned int vao, int count, unsigned int prim,
+                              const glm::mat4& mvp, const glm::vec4& color,
+                              float alpha) {
+    glUniformMatrix4fv(m_uMVP, 1, GL_FALSE, glm::value_ptr(mvp));
+    glUniform3f(m_uColor, color.r, color.g, color.b);
+    glUniform1f(m_uAlpha, alpha);
+    glBindVertexArray(vao);
+    glDrawArrays(prim, 0, count);
+}
+
+void TransformGizmo::render(const glm::mat4& projection, const glm::mat4& view,
+                            const glm::vec3& cameraPos) {
+    if (!enabled || !hasTarget()) return;
+    ensureInit();
+
+    const glm::vec3 pivot = *m_position;
+    const float s = gizmoScale(cameraPos);
+    const Mode m = effectiveMode();
+    const glm::mat4 viewProj = projection * view;
+    glm::vec3 axes[3];
+    computeAxes(axes, m);
+
+    // Overlay state: always-on-top, blended, no culling. Capture prior state so
+    // we don't leak it into subsequent same-eye overlay draws.
+    GLboolean depthWasOn = glIsEnabled(GL_DEPTH_TEST);
+    GLboolean cullWasOn = glIsEnabled(GL_CULL_FACE);
+    GLboolean blendWasOn = glIsEnabled(GL_BLEND);
+    glDisable(GL_DEPTH_TEST);
+    glDisable(GL_CULL_FACE);
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+    glUseProgram(m_program);
+
+    auto colorFor = [&](Handle h, const glm::vec3& base) {
+        bool active = (m_activeHandle == h);
+        bool hovered = (m_activeHandle == Handle::None && m_hover == h);
+        return (active || hovered) ? kHighlight : base;
+    };
+    auto alignY = [](const glm::vec3& a) {
+        return glm::toMat4(glm::rotation(glm::vec3(0, 1, 0), a));
+    };
+
+    const Handle axisH[3] = {Handle::AxisX, Handle::AxisY, Handle::AxisZ};
+    const Handle ringH[3] = {Handle::RingX, Handle::RingY, Handle::RingZ};
+
+    if (m == Mode::Rotate) {
+        for (int i = 0; i < 3; ++i) {
+            glm::mat4 model = glm::translate(glm::mat4(1.0f), pivot) *
+                              glm::toMat4(glm::rotation(glm::vec3(0, 0, 1), axes[i])) *
+                              glm::scale(glm::mat4(1.0f), glm::vec3(RING_R * s));
+            glLineWidth(3.0f);
+            drawMesh(m_ringVAO, m_ringCount, GL_LINE_LOOP, viewProj * model,
+                     glm::vec4(colorFor(ringH[i], kAxisColor[i]), 1.0f), 1.0f);
+        }
+    } else {
+        // Axis shafts + tips (translate cones / scale cubes).
+        for (int i = 0; i < 3; ++i) {
+            glm::vec3 col = colorFor(axisH[i], kAxisColor[i]);
+            glm::mat4 R = alignY(axes[i]);
+            glm::mat4 shaft = glm::translate(glm::mat4(1.0f), pivot) * R *
+                              glm::scale(glm::mat4(1.0f),
+                                         glm::vec3(SHAFT_R * s, SHAFT_LEN * s, SHAFT_R * s));
+            drawMesh(m_cylVAO, m_cylCount, GL_TRIANGLES, viewProj * shaft,
+                     glm::vec4(col, 1.0f), 1.0f);
+
+            glm::vec3 tipPos = pivot + axes[i] * (SHAFT_LEN * s);
+            if (m == Mode::Scale) {
+                glm::mat4 tip = glm::translate(glm::mat4(1.0f), tipPos) *
+                                glm::scale(glm::mat4(1.0f), glm::vec3(SCALE_TIP * 2.0f * s));
+                drawMesh(m_cubeVAO, m_cubeCount, GL_TRIANGLES, viewProj * tip,
+                         glm::vec4(col, 1.0f), 1.0f);
+            } else {
+                glm::mat4 tip = glm::translate(glm::mat4(1.0f), tipPos) * R *
+                                glm::scale(glm::mat4(1.0f),
+                                           glm::vec3(TIP_R * s, TIP_LEN * s, TIP_R * s));
+                drawMesh(m_coneVAO, m_coneCount, GL_TRIANGLES, viewProj * tip,
+                         glm::vec4(col, 1.0f), 1.0f);
+            }
+        }
+
+        if (m == Mode::Translate) {
+            // Two-axis plane quads (coloured by their normal axis).
+            const Handle planeH[3] = {Handle::PlaneYZ, Handle::PlaneZX, Handle::PlaneXY};
+            const int ai[3] = {1, 2, 0}, aj[3] = {2, 0, 1}, nk[3] = {0, 1, 2};
+            for (int k = 0; k < 3; ++k) {
+                glm::vec3 center = pivot +
+                    (axes[ai[k]] + axes[aj[k]]) * (PLANE_OFF * s);
+                glm::mat4 basis(1.0f);
+                basis[0] = glm::vec4(axes[ai[k]], 0.0f);
+                basis[1] = glm::vec4(axes[aj[k]], 0.0f);
+                basis[2] = glm::vec4(axes[nk[k]], 0.0f);
+                glm::mat4 model = glm::translate(glm::mat4(1.0f), center) * basis *
+                                  glm::scale(glm::mat4(1.0f), glm::vec3(PLANE_HALF * s));
+                glm::vec3 col = colorFor(planeH[k], kAxisColor[nk[k]]);
+                drawMesh(m_quadVAO, m_quadCount, GL_TRIANGLES, viewProj * model,
+                         glm::vec4(col, 1.0f), 0.35f);
+            }
+        }
+
+        // Centre handle.
+        Handle centreH = (m == Mode::Scale) ? Handle::ScaleUniform
+                                            : Handle::ScreenMove;
+        glm::mat4 cube = glm::translate(glm::mat4(1.0f), pivot) *
+                         glm::scale(glm::mat4(1.0f), glm::vec3(CENTER_HALF * 2.0f * s));
+        drawMesh(m_cubeVAO, m_cubeCount, GL_TRIANGLES, viewProj * cube,
+                 glm::vec4(colorFor(centreH, kCenterColor), 1.0f), 1.0f);
+    }
+
+    glBindVertexArray(0);
+    glUseProgram(0);
+    glLineWidth(1.0f);
+    if (depthWasOn) glEnable(GL_DEPTH_TEST);
+    if (cullWasOn) glEnable(GL_CULL_FACE);
+    if (!blendWasOn) glDisable(GL_BLEND);
+}
+
+void TransformGizmo::cleanup() {
+    if (!m_initialized) return;
+    if (m_program) glDeleteProgram(m_program);
+    unsigned int vaos[] = {m_cylVAO, m_coneVAO, m_cubeVAO, m_ringVAO, m_quadVAO};
+    unsigned int vbos[] = {m_cylVBO, m_coneVBO, m_cubeVBO, m_ringVBO, m_quadVBO};
+    glDeleteVertexArrays(5, vaos);
+    glDeleteBuffers(5, vbos);
+    m_program = 0;
+    m_initialized = false;
+}
+
+} // namespace Tools

--- a/StereoVista/src/Tools/TransformGizmo.cpp
+++ b/StereoVista/src/Tools/TransformGizmo.cpp
@@ -327,10 +327,13 @@ bool TransformGizmo::beginDrag(Handle handle, const glm::vec3& o,
     case Handle::ScaleUniform: {
         m_dragPlaneNormal = glm::normalize(cameraPos - pivot);
         glm::vec3 hit; float t;
-        if (rayPlane(o, d, pivot, m_dragPlaneNormal, hit, t))
-            m_startRadius = std::max(glm::length(hit - pivot), 1e-4f);
-        else
-            m_startRadius = m_gizmoScaleAtDrag;
+        // Store the start distance from the pivot; the update uses an additive
+        // factor so the response is stable even when the grab starts near the
+        // centre (no division by a tiny radius).
+        m_startRadius =
+            rayPlane(o, d, pivot, m_dragPlaneNormal, hit, t)
+                ? glm::length(hit - pivot)
+                : 0.0f;
         break;
     }
     default:
@@ -406,7 +409,9 @@ void TransformGizmo::updateDrag(const glm::vec3& o, const glm::vec3& d,
         if (!m_scale) break;
         glm::vec3 hit; float t;
         if (rayPlane(o, d, pivot, m_dragPlaneNormal, hit, t)) {
-            float factor = std::max(glm::length(hit - pivot) / m_startRadius, 0.01f);
+            float len = glm::length(hit - pivot);
+            float factor = std::max(
+                0.01f, 1.0f + (len - m_startRadius) / m_gizmoScaleAtDrag);
             glm::vec3 ns = m_startScale * factor;
             if (snap) {
                 ns.x = std::max(snapScale, std::round(ns.x / snapScale) * snapScale);

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -6878,6 +6878,9 @@ void mouse_button_callback(GLFWwindow *window, int button, int action,
       // drag and consume the click. This works with or without modifiers, so a
       // plain click on an axis/ring/plane manipulates the object while a click
       // on empty space still orbits and Ctrl/Alt body-drag still free-moves.
+      // Re-bind first so the target pointer reflects the current selection even
+      // if a scene container was reallocated since the last frame.
+      bindGizmoTargetToSelection();
       if (transformGizmo.enabled && transformGizmo.hasTarget()) {
         glm::vec3 gRayOrigin, gRayDir, gRayNear, gRayFar;
         calculateMouseRay(lastX, lastY, gRayOrigin, gRayDir, gRayNear, gRayFar,
@@ -7614,37 +7617,6 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
     }
   }
 
-  // Transform gizmo mode switching (only when an object is selected and the
-  // user isn't typing). 1=Move, 2=Rotate, 3=Scale, 4=toggle World/Local.
-  if (transformGizmo.enabled && transformGizmo.hasTarget() &&
-      !ImGui::GetIO().WantTextInput && !(mods & GLFW_MOD_CONTROL) &&
-      !(mods & GLFW_MOD_ALT)) {
-    switch (key) {
-    case GLFW_KEY_1:
-      transformGizmo.setMode(Tools::TransformGizmo::Mode::Translate);
-      GUI::ShowToast("Gizmo: Move", GUI::ToastType::Info);
-      return;
-    case GLFW_KEY_2:
-      transformGizmo.setMode(Tools::TransformGizmo::Mode::Rotate);
-      GUI::ShowToast("Gizmo: Rotate", GUI::ToastType::Info);
-      return;
-    case GLFW_KEY_3:
-      transformGizmo.setMode(Tools::TransformGizmo::Mode::Scale);
-      GUI::ShowToast("Gizmo: Scale", GUI::ToastType::Info);
-      return;
-    case GLFW_KEY_4:
-      transformGizmo.toggleSpace();
-      GUI::ShowToast(transformGizmo.space ==
-                             Tools::TransformGizmo::Space::World
-                         ? "Gizmo: World space"
-                         : "Gizmo: Local space",
-                     GUI::ToastType::Info);
-      return;
-    default:
-      break;
-    }
-  }
-
   // Check if this key press matches any shortcut action
   auto actionOpt = shortcutManager.getActionForKey(key, mods);
 
@@ -8040,6 +8012,38 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
         if (!UndoManager::instance().redo()) {
           std::cout << "Nothing to redo" << std::endl;
         }
+      }
+      break;
+
+    // Transform gizmo mode/space. Switching mode is a persistent setting even
+    // with nothing selected; it takes visible effect once an object is picked.
+    // Guarded so digits typed into numeric fields don't switch modes.
+    case StereoVista::ShortcutAction::GizmoModeMove:
+      if (!ImGui::GetIO().WantTextInput) {
+        transformGizmo.setMode(Tools::TransformGizmo::Mode::Translate);
+        GUI::ShowToast("Gizmo: Move", GUI::ToastType::Info);
+      }
+      break;
+    case StereoVista::ShortcutAction::GizmoModeRotate:
+      if (!ImGui::GetIO().WantTextInput) {
+        transformGizmo.setMode(Tools::TransformGizmo::Mode::Rotate);
+        GUI::ShowToast("Gizmo: Rotate", GUI::ToastType::Info);
+      }
+      break;
+    case StereoVista::ShortcutAction::GizmoModeScale:
+      if (!ImGui::GetIO().WantTextInput) {
+        transformGizmo.setMode(Tools::TransformGizmo::Mode::Scale);
+        GUI::ShowToast("Gizmo: Scale", GUI::ToastType::Info);
+      }
+      break;
+    case StereoVista::ShortcutAction::GizmoToggleSpace:
+      if (!ImGui::GetIO().WantTextInput) {
+        transformGizmo.toggleSpace();
+        GUI::ShowToast(transformGizmo.space ==
+                               Tools::TransformGizmo::Space::World
+                           ? "Gizmo: World space"
+                           : "Gizmo: Local space",
+                       GUI::ToastType::Info);
       }
       break;
 

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -394,6 +394,9 @@ Engine::SSAORenderer *ssaoRenderer = nullptr;
 
 GUI::LightingMode currentLightingMode = GUI::LIGHTING_SHADOW_MAPPING;
 bool enableShadows = true;
+// Unlit view mode (albedo only): a view-shading toggle independent of the
+// lighting mode, used by the View toolbar and the ToggleUnlit shortcut.
+bool g_unlitMode = false;
 
 GUI::VCTSettings vctSettings;
 GUI::ApplicationPreferences::RadianceSettings radianceSettings;
@@ -3702,8 +3705,10 @@ int main() {
       rightView = glm::lookAt(rightEyePos, rightEyePos + frontVec, upVec);
     }
     // ---- Update Scene State ----
-    // Set wireframe mode before rendering
-    glPolygonMode(GL_FRONT_AND_BACK, camera.wireframe ? GL_LINE : GL_FILL);
+    // Wireframe is applied per-draw (only around the model geometry pass inside
+    // renderEye) so GL_LINE never leaks into the full-screen post-process /
+    // composite passes — that leak is what broke wireframe under HDR.
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 
     // Reset cursor position calculation flag at start of frame
     cursorManager.resetFrameCalculationFlag();
@@ -3725,6 +3730,12 @@ int main() {
       activeShader = voxelConeTracingShader;
     } else if (currentLightingMode == GUI::LIGHTING_SHADOW_MAPPING &&
                shadowMappingShader) {
+      activeShader = shadowMappingShader;
+    }
+
+    // Unlit view mode outputs albedo only; force the shadow-mapping shader
+    // (the only one carrying the unlit path) regardless of lighting mode.
+    if (g_unlitMode && shadowMappingShader) {
       activeShader = shadowMappingShader;
     }
 
@@ -4193,7 +4204,7 @@ void renderEye(GLenum drawBuffer, const glm::mat4 &projection,
     glDisable(GL_POLYGON_OFFSET_FILL);
 
     // Restore wireframe mode if it was enabled
-    glPolygonMode(GL_FRONT_AND_BACK, camera.wireframe ? GL_LINE : GL_FILL);
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL); // wireframe is applied per-draw
   }
 
   // 2.5. Point shadow mapping pass for all point lights. Like the sun shadow
@@ -4259,7 +4270,7 @@ void renderEye(GLenum drawBuffer, const glm::mat4 &projection,
     }
 
     // Restore wireframe mode if it was enabled
-    glPolygonMode(GL_FRONT_AND_BACK, camera.wireframe ? GL_LINE : GL_FILL);
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL); // wireframe is applied per-draw
   }
 
   // 2.7. SSAO geometry pass - render view-space positions and normals
@@ -4324,7 +4335,7 @@ void renderEye(GLenum drawBuffer, const glm::mat4 &projection,
     glEnable(GL_DEPTH_TEST);
 
     // Restore wireframe mode if it was enabled
-    glPolygonMode(GL_FRONT_AND_BACK, camera.wireframe ? GL_LINE : GL_FILL);
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL); // wireframe is applied per-draw
   }
 
   // 3. Regular rendering pass
@@ -4378,6 +4389,9 @@ void renderEye(GLenum drawBuffer, const glm::mat4 &projection,
   // Set lighting mode uniforms - this is always needed
   shader->setInt("lightingMode", static_cast<int>(currentLightingMode));
   shader->setBool("enableShadows", enableShadows);
+  // Unlit view mode (albedo only). Harmless no-op on shaders lacking the
+  // uniform; only the shadow-mapping shader implements the unlit path.
+  shader->setBool("unlitMode", g_unlitMode);
 
   // Set HDR settings uniforms
   shader->setBool("hdrSettings.enabled", preferences.hdrSettings.enabled);
@@ -5128,8 +5142,15 @@ void renderEye(GLenum drawBuffer, const glm::mat4 &projection,
   // regenerating them.
   g_sharedPassesDone = true;
 
-  // Render scene - cache buffers still bound, fragment shader can read them
+  // Render scene - cache buffers still bound, fragment shader can read them.
+  // Wireframe is scoped to the model pass only: the skybox stays solid and,
+  // crucially, GL_LINE is reset before the post-process/composite passes so it
+  // can't turn the full-screen HDR quads into stray lines.
+  if (camera.wireframe)
+    glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
   renderModels(shader, projection * view);
+  if (camera.wireframe)
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
   renderSkybox(projection, view, shader);
   renderPointClouds(shader, view, projection);
 
@@ -7735,6 +7756,11 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
     case StereoVista::ShortcutAction::ToggleWireframe:
       camera.wireframe = !camera.wireframe;
       reportToggle("Wireframe mode", camera.wireframe);
+      break;
+
+    case StereoVista::ShortcutAction::ToggleUnlit:
+      g_unlitMode = !g_unlitMode;
+      reportToggle("Unlit shading", g_unlitMode);
       break;
 
     case StereoVista::ShortcutAction::ToggleRadar:

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -32,6 +32,7 @@
 #include "Loaders/PointCloudLoader.h"
 #include "Tools/BrushTool.h"
 #include "Tools/MeasurementTool.h"
+#include "Tools/TransformGizmo.h"
 
 
 // ---- GUI and Dialog ----
@@ -136,6 +137,12 @@ bool rayIntersectsModel(const glm::vec3 &rayOrigin,
 // ---- Preferences Functions ----
 void savePreferences();
 void printCursorSyncDiagnostics();
+
+// ---- Transform Gizmo glue (defined alongside the input callbacks) ----
+static void bindGizmoTargetToSelection();
+static void beginGizmoDrag(Tools::TransformGizmo::Handle handle,
+                           const glm::vec3 &rayOrigin, const glm::vec3 &rayDir);
+static void finishGizmoDrag();
 #pragma endregion
 
 // ---- Global Variables ----
@@ -286,6 +293,20 @@ Tools::BrushTool brushTool;
 
 // ---- Measurement Tool ----
 Tools::MeasurementTool measurementTool;
+
+// ---- Transform Gizmo ----
+// Visual translate/rotate/scale gizmo anchored at the selected object's pivot.
+// Coexists with the legacy Ctrl/Alt body-drag free-move (which is preserved):
+// clicking a gizmo handle starts a constrained transform instead.
+Tools::TransformGizmo transformGizmo;
+bool gizmoDragging = false;
+// Undo snapshots captured at the start of a gizmo drag.
+Engine::Undo::ModelEditState gizmoUndoModelBefore;
+Engine::Undo::PointCloudEditState gizmoUndoPointCloudBefore;
+Engine::PointLight gizmoUndoPointLightBefore;
+Engine::SpotLight gizmoUndoSpotLightBefore;
+SelectedType gizmoUndoType = SelectedType::None;
+int gizmoUndoIndex = -1;
 
 // ---- Window Configuration ----
 int windowWidth = 1920;
@@ -3232,6 +3253,28 @@ int main() {
     // across scene loads).
     measurementTool.setMeasurements(&currentScene.measurements);
 
+    // ---- Transform Gizmo: bind target + process hover / constrained drag ----
+    // Safety net: if the mouse-up landed over an ImGui panel (whose callback
+    // early-returns) the release can be missed, so finalize here too.
+    if (gizmoDragging &&
+        glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_LEFT) == GLFW_RELEASE) {
+      finishGizmoDrag();
+    }
+    bindGizmoTargetToSelection();
+    if (transformGizmo.enabled && transformGizmo.hasTarget()) {
+      glm::vec3 gRayOrigin, gRayDir, gRayNear, gRayFar;
+      calculateMouseRay(lastX, lastY, gRayOrigin, gRayDir, gRayNear, gRayFar,
+                        aspectRatio);
+      if (gizmoDragging) {
+        bool snapHeld = (glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS ||
+                         glfwGetKey(window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS);
+        transformGizmo.updateDrag(gRayOrigin, gRayDir, camera.Position, snapHeld);
+      } else if (!camera.IsOrbiting && !camera.IsPanning && !isMovingModel &&
+                 !rightMousePressed && !ImGui::GetIO().WantCaptureMouse) {
+        transformGizmo.updateHover(gRayOrigin, gRayDir, camera.Position);
+      }
+    }
+
     // ---- Update Model Depth Movement Physics ----
     // Apply smooth scrolling physics to model depth movement when dragging
     if (isMovingModel && currentSelectedType == SelectedType::Model &&
@@ -3987,6 +4030,7 @@ void cleanup() {
 
   // Clean up measurement tool GL resources while the context is still valid
   measurementTool.cleanup();
+  transformGizmo.cleanup();
 
   // Drop undo history while the context is still valid - undo entries for
   // deleted objects own GL resources that are freed on destruction
@@ -5303,6 +5347,9 @@ void renderEye(GLenum drawBuffer, const glm::mat4 &projection,
     }
     measurementTool.render(projection, view, measurePreview);
   }
+
+  // Render the transform gizmo overlay for the selected object (per eye).
+  transformGizmo.render(projection, view, camera.Position);
 
   // Render brush tool indicator
   if (preferences.brushToolSettings.enabled &&
@@ -6685,6 +6732,135 @@ static void endDragUndo() {
   }
 }
 
+// ── Transform gizmo glue ────────────────────────────────────────────────────
+// Bind the gizmo to the currently selected object's transform every frame.
+// Models and point clouds expose position/rotation/scale; lights expose only a
+// position (which restricts the gizmo to translation). Pointers are refreshed
+// each frame so container growth between frames can't leave them dangling.
+static void bindGizmoTargetToSelection() {
+  if (gizmoDragging)
+    return; // keep the live target stable for the duration of a drag
+
+  switch (currentSelectedType) {
+  case SelectedType::Model:
+    if (currentSelectedIndex >= 0 &&
+        currentSelectedIndex < static_cast<int>(currentScene.models.size())) {
+      Engine::Model &mdl = currentScene.models[currentSelectedIndex];
+      transformGizmo.setTarget(&mdl.position, &mdl.rotation, &mdl.scale);
+      return;
+    }
+    break;
+  case SelectedType::PointCloud:
+    if (currentSelectedIndex >= 0 &&
+        currentSelectedIndex <
+            static_cast<int>(currentScene.pointClouds.size())) {
+      Engine::PointCloud &pc = currentScene.pointClouds[currentSelectedIndex];
+      transformGizmo.setTarget(&pc.position, &pc.rotation, &pc.scale);
+      return;
+    }
+    break;
+  case SelectedType::PointLight:
+    if (currentSelectedIndex >= 0 &&
+        currentSelectedIndex < static_cast<int>(pointLights.size())) {
+      transformGizmo.setTarget(&pointLights[currentSelectedIndex].position,
+                               nullptr, nullptr);
+      return;
+    }
+    break;
+  case SelectedType::SpotLight:
+    if (currentSelectedIndex >= 0 &&
+        currentSelectedIndex < static_cast<int>(spotLights.size())) {
+      transformGizmo.setTarget(&spotLights[currentSelectedIndex].position,
+                               nullptr, nullptr);
+      return;
+    }
+    break;
+  default:
+    break;
+  }
+  transformGizmo.clearTarget();
+}
+
+// Capture the before-state so the whole gizmo drag becomes one undo entry.
+static void beginGizmoDrag(Tools::TransformGizmo::Handle handle,
+                           const glm::vec3 &rayOrigin,
+                           const glm::vec3 &rayDir) {
+  gizmoUndoType = currentSelectedType;
+  gizmoUndoIndex = currentSelectedIndex;
+  switch (gizmoUndoType) {
+  case SelectedType::Model:
+    gizmoUndoModelBefore = Engine::Undo::ModelEditState::capture(
+        currentScene.models[gizmoUndoIndex]);
+    break;
+  case SelectedType::PointCloud:
+    gizmoUndoPointCloudBefore = Engine::Undo::PointCloudEditState::capture(
+        currentScene.pointClouds[gizmoUndoIndex]);
+    break;
+  case SelectedType::PointLight:
+    gizmoUndoPointLightBefore = pointLights[gizmoUndoIndex];
+    break;
+  case SelectedType::SpotLight:
+    gizmoUndoSpotLightBefore = spotLights[gizmoUndoIndex];
+    break;
+  default:
+    break;
+  }
+  gizmoDragging =
+      transformGizmo.beginDrag(handle, rayOrigin, rayDir, camera.Position);
+  if (!gizmoDragging)
+    gizmoUndoType = SelectedType::None;
+}
+
+// Commit the drag: record undo, refresh dependent systems.
+static void finishGizmoDrag() {
+  if (!gizmoDragging)
+    return;
+  transformGizmo.endDrag();
+  gizmoDragging = false;
+
+  switch (gizmoUndoType) {
+  case SelectedType::Model:
+    if (gizmoUndoIndex >= 0 &&
+        gizmoUndoIndex < static_cast<int>(currentScene.models.size())) {
+      Undo::recordModelEdit(
+          gizmoUndoIndex, gizmoUndoModelBefore,
+          Engine::Undo::ModelEditState::capture(
+              currentScene.models[gizmoUndoIndex]));
+      if (voxelizer)
+        voxelizer->markDirty();
+    }
+    break;
+  case SelectedType::PointCloud:
+    if (gizmoUndoIndex >= 0 &&
+        gizmoUndoIndex < static_cast<int>(currentScene.pointClouds.size())) {
+      Undo::recordPointCloudEdit(
+          gizmoUndoIndex, gizmoUndoPointCloudBefore,
+          Engine::Undo::PointCloudEditState::capture(
+              currentScene.pointClouds[gizmoUndoIndex]));
+    }
+    break;
+  case SelectedType::PointLight:
+    if (gizmoUndoIndex >= 0 &&
+        gizmoUndoIndex < static_cast<int>(pointLights.size())) {
+      Undo::recordPointLightEdit(gizmoUndoIndex, gizmoUndoPointLightBefore,
+                                 pointLights[gizmoUndoIndex]);
+    }
+    break;
+  case SelectedType::SpotLight:
+    if (gizmoUndoIndex >= 0 &&
+        gizmoUndoIndex < static_cast<int>(spotLights.size())) {
+      Undo::recordSpotLightEdit(gizmoUndoIndex, gizmoUndoSpotLightBefore,
+                                spotLights[gizmoUndoIndex]);
+    }
+    break;
+  default:
+    break;
+  }
+  gizmoUndoType = SelectedType::None;
+  gizmoUndoIndex = -1;
+  updateSpaceMouseBounds();
+}
+
 void mouse_button_callback(GLFWwindow *window, int button, int action,
                            int mods) {
   if (ImGui::GetIO().WantCaptureMouse) {
@@ -6697,6 +6873,23 @@ void mouse_button_callback(GLFWwindow *window, int button, int action,
       // Check if Ctrl or Alt is held down
       bool ctrlPressed = (mods & GLFW_MOD_CONTROL);
       bool altPressed = (mods & GLFW_MOD_ALT);
+
+      // Transform gizmo: if a handle is under the cursor, start a constrained
+      // drag and consume the click. This works with or without modifiers, so a
+      // plain click on an axis/ring/plane manipulates the object while a click
+      // on empty space still orbits and Ctrl/Alt body-drag still free-moves.
+      if (transformGizmo.enabled && transformGizmo.hasTarget()) {
+        glm::vec3 gRayOrigin, gRayDir, gRayNear, gRayFar;
+        calculateMouseRay(lastX, lastY, gRayOrigin, gRayDir, gRayNear, gRayFar,
+                          aspectRatio);
+        Tools::TransformGizmo::Handle hit =
+            transformGizmo.hitTest(gRayOrigin, gRayDir, camera.Position);
+        if (hit != Tools::TransformGizmo::Handle::None) {
+          beginGizmoDrag(hit, gRayOrigin, gRayDir);
+          if (gizmoDragging)
+            return;
+        }
+      }
 
       // Measurement tool: place a point at the 3D cursor position and consume
       // the click (no orbiting/selection while measuring). Ctrl/Alt clicks
@@ -7080,6 +7273,12 @@ void mouse_button_callback(GLFWwindow *window, int button, int action,
         }
       }
     } else if (action == GLFW_RELEASE) {
+      // Finalize a gizmo drag (records one undo entry) and consume the release.
+      if (gizmoDragging) {
+        finishGizmoDrag();
+        return;
+      }
+
       // Check if we were moving a model before processing the release
       bool wasMovingModel = isMovingModel;
 
@@ -7412,6 +7611,37 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
     if (key == GLFW_KEY_BACKSPACE) {
       measurementTool.undoLastPoint();
       return;
+    }
+  }
+
+  // Transform gizmo mode switching (only when an object is selected and the
+  // user isn't typing). 1=Move, 2=Rotate, 3=Scale, 4=toggle World/Local.
+  if (transformGizmo.enabled && transformGizmo.hasTarget() &&
+      !ImGui::GetIO().WantTextInput && !(mods & GLFW_MOD_CONTROL) &&
+      !(mods & GLFW_MOD_ALT)) {
+    switch (key) {
+    case GLFW_KEY_1:
+      transformGizmo.setMode(Tools::TransformGizmo::Mode::Translate);
+      GUI::ShowToast("Gizmo: Move", GUI::ToastType::Info);
+      return;
+    case GLFW_KEY_2:
+      transformGizmo.setMode(Tools::TransformGizmo::Mode::Rotate);
+      GUI::ShowToast("Gizmo: Rotate", GUI::ToastType::Info);
+      return;
+    case GLFW_KEY_3:
+      transformGizmo.setMode(Tools::TransformGizmo::Mode::Scale);
+      GUI::ShowToast("Gizmo: Scale", GUI::ToastType::Info);
+      return;
+    case GLFW_KEY_4:
+      transformGizmo.toggleSpace();
+      GUI::ShowToast(transformGizmo.space ==
+                             Tools::TransformGizmo::Space::World
+                         ? "Gizmo: World space"
+                         : "Gizmo: Local space",
+                     GUI::ToastType::Info);
+      return;
+    default:
+      break;
     }
   }
 


### PR DESCRIPTION
Introduces a custom, self-contained transform gizmo that anchors at the
selected object's pivot and lets the user translate, rotate and scale it
with constrained handles, screen-constant sizing and hover highlighting.

- New Tools::TransformGizmo (headers/Tools/TransformGizmo.h,
  src/Tools/TransformGizmo.cpp): embedded-shader world-space overlay drawn
  per eye (same pattern as MeasurementTool), analytic ray hit-testing
  (axes, plane quads, rotation rings, centre handle), world/local space,
  optional snapping, and continuous multi-turn rotation.
- Integrates with the existing selection system: bound each frame to the
  selected Model / PointCloud (full T/R/S) or Point/Spot light (translate
  only). The legacy Ctrl/Alt body-drag free-move and scroll-to-depth are
  preserved unchanged; a plain click on a handle starts a constrained drag
  while empty-space clicks still orbit.
- Each drag is recorded as a single undo entry via the existing
  ModelEditState / PointCloudEditState / light edit helpers.
- Keyboard: 1 Move, 2 Rotate, 3 Scale, 4 World/Local; hold Shift to snap.
- GUI: mode / space / snap / size controls added to the Transform panels.
- Registered the new files in the VS project and filters.

https://claude.ai/code/session_01RXVYDV2J7kFKJrstLCRx3P