### PR TITLE
Add multi section/clip-plane tool

### DIFF
--- a/StereoVista/StereoVista.vcxproj
+++ b/StereoVista/StereoVista.vcxproj
@@ -215,6 +215,7 @@ IF %ERRORLEVEL% LEQ 7 SET ERRORLEVEL=0</Command>
     <ClCompile Include="src\Gui\CursorPreview3D.cpp" />
     <ClCompile Include="src\Gui\GUI.cpp" />
     <ClCompile Include="src\Tools\BrushTool.cpp" />
+    <ClCompile Include="src\Tools\ClipPlaneTool.cpp" />
     <ClCompile Include="src\Tools\MeasurementTool.cpp" />
     <ClCompile Include="src\Tools\TransformGizmo.cpp" />
   </ItemGroup>
@@ -242,6 +243,7 @@ IF %ERRORLEVEL% LEQ 7 SET ERRORLEVEL=0</Command>
     <ClInclude Include="headers\engine\window.h" />
     <ClInclude Include="headers\Camera.h" />
     <ClInclude Include="headers\Tools\BrushTool.h" />
+    <ClInclude Include="headers\Tools\ClipPlaneTool.h" />
     <ClInclude Include="headers\Tools\MeasurementTool.h" />
     <ClInclude Include="headers\Tools\TransformGizmo.h" />
     <ClInclude Include="headers\libs\assimp\aabb.h" />

--- a/StereoVista/StereoVista.vcxproj.filters
+++ b/StereoVista/StereoVista.vcxproj.filters
@@ -126,6 +126,9 @@
     <ClCompile Include="src\Tools\BrushTool.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Tools\ClipPlaneTool.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\Tools\MeasurementTool.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -483,6 +486,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="headers\Tools\BrushTool.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="headers\Tools\ClipPlaneTool.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="headers\Tools\MeasurementTool.h">

--- a/StereoVista/assets/shaders/core/instancedVertexShader.glsl
+++ b/StereoVista/assets/shaders/core/instancedVertexShader.glsl
@@ -29,6 +29,13 @@ uniform mat4 projection;
 uniform mat4 lightSpaceMatrix;
 uniform int currentMeshIndex;
 
+// User-controllable section/clip planes (world space); see the comment in
+// shadowMappingVertexShader.glsl. Brush instances are exempt from the radar
+// slice (index 0) but ARE cut by user section planes (indices 1..6).
+const int MAX_CLIP_PLANES = 6;
+uniform int  clipPlaneCount;
+uniform vec4 clipPlanes[MAX_CLIP_PLANES];
+
 void main() {
     // Use instance model matrix instead of uniform model matrix
     vs_out.FragPos = vec3(instanceModel * vec4(aPos, 1.0));
@@ -66,4 +73,14 @@ void main() {
     // Brush instances are never sliced by the radar clip plane; keep them when
     // GL_CLIP_DISTANCE0 is enabled during the radar scene pass.
     gl_ClipDistance[0] = 1.0;
+
+    // User section planes occupy gl_ClipDistance[1..6]. Inactive slots stay
+    // positive (+1.0). Constant indices keep the implicit gl_ClipDistance[]
+    // array sized correctly.
+    gl_ClipDistance[1] = (clipPlaneCount > 0) ? dot(clipPlanes[0].xyz, vs_out.FragPos) + clipPlanes[0].w : 1.0;
+    gl_ClipDistance[2] = (clipPlaneCount > 1) ? dot(clipPlanes[1].xyz, vs_out.FragPos) + clipPlanes[1].w : 1.0;
+    gl_ClipDistance[3] = (clipPlaneCount > 2) ? dot(clipPlanes[2].xyz, vs_out.FragPos) + clipPlanes[2].w : 1.0;
+    gl_ClipDistance[4] = (clipPlaneCount > 3) ? dot(clipPlanes[3].xyz, vs_out.FragPos) + clipPlanes[3].w : 1.0;
+    gl_ClipDistance[5] = (clipPlaneCount > 4) ? dot(clipPlanes[4].xyz, vs_out.FragPos) + clipPlanes[4].w : 1.0;
+    gl_ClipDistance[6] = (clipPlaneCount > 5) ? dot(clipPlanes[5].xyz, vs_out.FragPos) + clipPlanes[5].w : 1.0;
 }

--- a/StereoVista/assets/shaders/core/pointcloud_rasterize.comp
+++ b/StereoVista/assets/shaders/core/pointcloud_rasterize.comp
@@ -67,6 +67,16 @@ uniform int   uPointsPerThread; // ceil(kComputeBatchSize / 128)
 uniform uint  uCloudID;         // 5-bit id of this cloud → packed in framebuffer payload
 uniform int   uSplatMaxRadius;  // 0 = single-pixel (off); >0 = max adaptive round-splat radius (px)
 
+// User section/clip planes, expressed in this cloud's LOCAL space so they can be
+// tested directly against the decoded `point` (which is local, like the batch
+// AABBs). The host pre-multiplies each world-space plane by transpose(model):
+//   localPlane = transpose(model) * vec4(worldNormal, worldD)
+// A point is discarded when dot(plane.xyz, point) + plane.w < 0 (the clipped
+// side). uClipPlaneCount is 0..MAX_CLIP_PLANES.
+const int MAX_CLIP_PLANES = 6;
+uniform int  uClipPlaneCount;
+uniform vec4 uClipPlanes[MAX_CLIP_PLANES];
+
 // ── Frustum culling ───────────────────────────────────────────────────────────
 // Adapted from Schütz compute_rasterizer / three.js (MIT).
 // Extracts 6 clip planes directly from the MVP matrix (Gribb/Hartmann method).
@@ -319,6 +329,18 @@ void main() {
             point = vec3(float(X), float(Y), float(Z))
                   * (boxSize / float(STEPS_10BIT)) + wgMin;
         }
+
+        // ── Section/clip planes ───────────────────────────────────────────────
+        // Discard points on the clipped side of any active plane (planes are in
+        // local space, so this matches the decoded `point` directly).
+        bool clipped = false;
+        for (int cp = 0; cp < uClipPlaneCount; ++cp) {
+            if (dot(uClipPlanes[cp].xyz, point) + uClipPlanes[cp].w < 0.0) {
+                clipped = true;
+                break;
+            }
+        }
+        if (clipped) continue;
 
         // ── Project to clip space ─────────────────────────────────────────────
         vec4 clip = uMVP * vec4(point, 1.0);

--- a/StereoVista/assets/shaders/core/radianceVertexShader.glsl
+++ b/StereoVista/assets/shaders/core/radianceVertexShader.glsl
@@ -36,6 +36,16 @@ uniform int currentMeshIndex;
 uniform bool radarClipEnabled;
 uniform float radarClipHeight;
 
+// User-controllable section/clip planes (world space). Each active plane i is
+// written to gl_ClipDistance[i + 1] (index 0 is the radar slice above). A plane
+// is vec4(normal.xyz, d) with d = -dot(normal, pointOnPlane); a fragment is kept
+// while dot(normal, worldPos) + d >= 0 (the +normal side). clipPlaneCount is the
+// number of active planes; the host enables the matching GL_CLIP_DISTANCE slots
+// only for the main lit pass, so these have no effect in other passes.
+const int MAX_CLIP_PLANES = 6;
+uniform int  clipPlaneCount;
+uniform vec4 clipPlanes[MAX_CLIP_PLANES];
+
 void main() {
     // Normal matrix from model
     mat3 normalMatrix = transpose(inverse(mat3(model)));
@@ -64,4 +74,15 @@ void main() {
     // Radar slice clip plane (no effect unless GL_CLIP_DISTANCE0 is enabled)
     gl_ClipDistance[0] =
         radarClipEnabled ? (radarClipHeight - vs_out.FragPos.y) : 1.0;
+
+    // User section planes occupy gl_ClipDistance[1..6]. Inactive slots stay
+    // positive (+1.0) so they never clip. Constant indices keep the implicit
+    // gl_ClipDistance[] array sized correctly (a dynamic loop index would leave
+    // its size undefined).
+    gl_ClipDistance[1] = (clipPlaneCount > 0) ? dot(clipPlanes[0].xyz, vs_out.FragPos) + clipPlanes[0].w : 1.0;
+    gl_ClipDistance[2] = (clipPlaneCount > 1) ? dot(clipPlanes[1].xyz, vs_out.FragPos) + clipPlanes[1].w : 1.0;
+    gl_ClipDistance[3] = (clipPlaneCount > 2) ? dot(clipPlanes[2].xyz, vs_out.FragPos) + clipPlanes[2].w : 1.0;
+    gl_ClipDistance[4] = (clipPlaneCount > 3) ? dot(clipPlanes[3].xyz, vs_out.FragPos) + clipPlanes[3].w : 1.0;
+    gl_ClipDistance[5] = (clipPlaneCount > 4) ? dot(clipPlanes[4].xyz, vs_out.FragPos) + clipPlanes[4].w : 1.0;
+    gl_ClipDistance[6] = (clipPlaneCount > 5) ? dot(clipPlanes[5].xyz, vs_out.FragPos) + clipPlanes[5].w : 1.0;
 }

--- a/StereoVista/assets/shaders/core/shadowMappingVertexShader.glsl
+++ b/StereoVista/assets/shaders/core/shadowMappingVertexShader.glsl
@@ -40,6 +40,16 @@ uniform int currentMeshIndex;
 uniform bool radarClipEnabled;
 uniform float radarClipHeight;
 
+// User-controllable section/clip planes (world space). Each active plane i is
+// written to gl_ClipDistance[i + 1] (index 0 is the radar slice above). A plane
+// is vec4(normal.xyz, d) with d = -dot(normal, pointOnPlane); a fragment is kept
+// while dot(normal, worldPos) + d >= 0 (the +normal side). clipPlaneCount is the
+// number of active planes; the host enables the matching GL_CLIP_DISTANCE slots
+// only for the main lit pass, so these have no effect in other passes.
+const int MAX_CLIP_PLANES = 6;
+uniform int  clipPlaneCount;
+uniform vec4 clipPlanes[MAX_CLIP_PLANES];
+
 void main() {
     // Normal matrix is provided via uniform
 
@@ -82,4 +92,15 @@ void main() {
     // Radar slice clip plane (no effect unless GL_CLIP_DISTANCE0 is enabled)
     gl_ClipDistance[0] =
         radarClipEnabled ? (radarClipHeight - vs_out.FragPos.y) : 1.0;
+
+    // User section planes occupy gl_ClipDistance[1..6]. Inactive slots stay
+    // positive (+1.0) so they never clip. Constant indices keep the implicit
+    // gl_ClipDistance[] array sized correctly (a dynamic loop index would leave
+    // its size undefined).
+    gl_ClipDistance[1] = (clipPlaneCount > 0) ? dot(clipPlanes[0].xyz, vs_out.FragPos) + clipPlanes[0].w : 1.0;
+    gl_ClipDistance[2] = (clipPlaneCount > 1) ? dot(clipPlanes[1].xyz, vs_out.FragPos) + clipPlanes[1].w : 1.0;
+    gl_ClipDistance[3] = (clipPlaneCount > 2) ? dot(clipPlanes[2].xyz, vs_out.FragPos) + clipPlanes[2].w : 1.0;
+    gl_ClipDistance[4] = (clipPlaneCount > 3) ? dot(clipPlanes[3].xyz, vs_out.FragPos) + clipPlanes[3].w : 1.0;
+    gl_ClipDistance[5] = (clipPlaneCount > 4) ? dot(clipPlanes[4].xyz, vs_out.FragPos) + clipPlanes[4].w : 1.0;
+    gl_ClipDistance[6] = (clipPlaneCount > 5) ? dot(clipPlanes[5].xyz, vs_out.FragPos) + clipPlanes[5].w : 1.0;
 }

--- a/StereoVista/assets/shaders/core/voxelConeTracingVertexShader.glsl
+++ b/StereoVista/assets/shaders/core/voxelConeTracingVertexShader.glsl
@@ -40,6 +40,16 @@ uniform int currentMeshIndex;
 uniform bool radarClipEnabled;
 uniform float radarClipHeight;
 
+// User-controllable section/clip planes (world space). Each active plane i is
+// written to gl_ClipDistance[i + 1] (index 0 is the radar slice above). A plane
+// is vec4(normal.xyz, d) with d = -dot(normal, pointOnPlane); a fragment is kept
+// while dot(normal, worldPos) + d >= 0 (the +normal side). clipPlaneCount is the
+// number of active planes; the host enables the matching GL_CLIP_DISTANCE slots
+// only for the main lit pass, so these have no effect in other passes.
+const int MAX_CLIP_PLANES = 6;
+uniform int  clipPlaneCount;
+uniform vec4 clipPlanes[MAX_CLIP_PLANES];
+
 void main() {
     // Normal matrix is provided via uniform
 
@@ -82,4 +92,15 @@ void main() {
     // Radar slice clip plane (no effect unless GL_CLIP_DISTANCE0 is enabled)
     gl_ClipDistance[0] =
         radarClipEnabled ? (radarClipHeight - vs_out.FragPos.y) : 1.0;
+
+    // User section planes occupy gl_ClipDistance[1..6]. Inactive slots stay
+    // positive (+1.0) so they never clip. Constant indices keep the implicit
+    // gl_ClipDistance[] array sized correctly (a dynamic loop index would leave
+    // its size undefined).
+    gl_ClipDistance[1] = (clipPlaneCount > 0) ? dot(clipPlanes[0].xyz, vs_out.FragPos) + clipPlanes[0].w : 1.0;
+    gl_ClipDistance[2] = (clipPlaneCount > 1) ? dot(clipPlanes[1].xyz, vs_out.FragPos) + clipPlanes[1].w : 1.0;
+    gl_ClipDistance[3] = (clipPlaneCount > 2) ? dot(clipPlanes[2].xyz, vs_out.FragPos) + clipPlanes[2].w : 1.0;
+    gl_ClipDistance[4] = (clipPlaneCount > 3) ? dot(clipPlanes[3].xyz, vs_out.FragPos) + clipPlanes[3].w : 1.0;
+    gl_ClipDistance[5] = (clipPlaneCount > 4) ? dot(clipPlanes[4].xyz, vs_out.FragPos) + clipPlanes[4].w : 1.0;
+    gl_ClipDistance[6] = (clipPlaneCount > 5) ? dot(clipPlanes[5].xyz, vs_out.FragPos) + clipPlanes[5].w : 1.0;
 }

--- a/StereoVista/headers/Core/SceneManager.h
+++ b/StereoVista/headers/Core/SceneManager.h
@@ -15,6 +15,7 @@ namespace Engine {
         std::vector<PointLight> pointLights;
         std::vector<SpotLight> spotLights;
         std::vector<Measurement> measurements;
+        std::vector<ClipPlane> clipPlanes;
         Camera::CameraState cameraState;
         
         // Default constructor with default camera state

--- a/StereoVista/headers/Engine/ComputePointCloudRenderer.h
+++ b/StereoVista/headers/Engine/ComputePointCloudRenderer.h
@@ -40,6 +40,13 @@ public:
     // Must be called before any renderNode() calls for this frame.
     void beginFrame();
 
+    // Set the active world-space section/clip planes for this frame. Each plane
+    // is vec4(unitNormal.xyz, d) with d = -dot(n, pointOnPlane); points on the
+    // clipped side (dot(n, worldP) + d < 0) are discarded. renderNode()
+    // transforms these into each cloud's local space. Pass count == 0 to clip
+    // nothing. Call before the renderNode() calls for the frame.
+    void setClipPlanes(int count, const glm::vec4* worldPlanes);
+
     // Rasterize one point cloud using the Schütz batch-based compute path.
     //
     //   batchSSBO        – binding 40: ComputeBatch descriptor array
@@ -54,6 +61,8 @@ public:
     //   proj             – projection matrix    (precision-level sphere projection)
     //   splatMaxRadius   – 0 = single-pixel rasterize (off); >0 = max adaptive
     //                      round-splat radius in pixels (fills close-up/sparse gaps)
+    //   model            – the cloud's model matrix, used to transform the
+    //                       active world-space clip planes into local space
     void renderNode(GLuint batchSSBO,
                     GLuint xyz12bSSBO,
                     GLuint xyz8bSSBO,
@@ -64,6 +73,7 @@ public:
                     const glm::mat4& mvp,
                     const glm::mat4& modelView,
                     const glm::mat4& proj,
+                    const glm::mat4& model,
                     int      splatMaxRadius = 0);
 
     // Wait for all compute work to finish, then composite the point cloud result
@@ -116,6 +126,13 @@ private:
     GLint m_locPointsPerThread   = -1;
     GLint m_locCloudID           = -1;   // uCloudID in the rasterize shader
     GLint m_locSplatMaxRadius    = -1;   // uSplatMaxRadius in the rasterize shader
+    GLint m_locClipPlaneCount    = -1;   // uClipPlaneCount in the rasterize shader
+    GLint m_locClipPlanes        = -1;   // uClipPlanes[0] in the rasterize shader
+
+    // Active world-space section/clip planes for the current frame (set via
+    // setClipPlanes); transformed into each cloud's local space in renderNode.
+    int       m_clipPlaneCount = 0;
+    glm::vec4 m_clipPlanesWorld[6] = {};
 
     // Cached color-lookup compute shader uniform location
     GLint m_locColorLookupImageSize  = -1;

--- a/StereoVista/headers/Engine/Data.h
+++ b/StereoVista/headers/Engine/Data.h
@@ -356,6 +356,38 @@ namespace Engine {
         }
     };
 
+    // Maximum number of simultaneous user section/clip planes. The scene
+    // vertex shaders write these to gl_ClipDistance[1..MAX_CLIP_PLANES]; index 0
+    // stays reserved for the legacy radar top-down slice. 6 user planes + the
+    // radar slice = 7 clip distances, within the GL-guaranteed minimum of 8.
+    static constexpr int MAX_CLIP_PLANES = 6;
+
+    // A user-controllable section / clipping plane. Geometry on the negative
+    // side of the plane (dot(normal, p - position) < 0) is hidden in the main
+    // lit pass; the "kept" side is the one the normal points to. Planes are part
+    // of the scene and serialized to/from scene files by SceneManager, exactly
+    // like Measurement.
+    struct ClipPlane {
+        glm::vec3   position = glm::vec3(0.0f);            // a point on the plane
+        glm::vec3   normal   = glm::vec3(0.0f, 1.0f, 0.0f); // unit normal (kept side)
+        bool        enabled  = true;
+        std::string name;
+        glm::vec3   color    = glm::vec3(0.25f, 0.60f, 1.0f); // overlay tint
+
+        // Unit normal, guarded against a degenerate (zero-length) normal.
+        glm::vec3 unitNormal() const {
+            const float len = glm::length(normal);
+            return (len > 1e-6f) ? (normal / len) : glm::vec3(0.0f, 1.0f, 0.0f);
+        }
+
+        // Plane packed for the shader / point-cloud test: (normal.xyz, d) with
+        // d = -dot(n, position). A point p is kept while dot(n, p) + d >= 0.
+        glm::vec4 packed() const {
+            const glm::vec3 n = unitNormal();
+            return glm::vec4(n, -glm::dot(n, position));
+        }
+    };
+
     struct Sun {
         glm::vec3 direction;
         glm::vec3 color;

--- a/StereoVista/headers/Engine/ShortcutManager.h
+++ b/StereoVista/headers/Engine/ShortcutManager.h
@@ -61,6 +61,7 @@ enum class ShortcutAction {
   OpenCursorSettings,  // Open cursor settings
   OpenBrushTool,       // Open brush tool window
   OpenMeasurementTool, // Open measurement tool window
+  OpenClipPlaneTool,   // P - Open section/clip plane tool window
 
   // File Operations
   ImportModel,      // Open import model dialog

--- a/StereoVista/headers/Gui/Gui.h
+++ b/StereoVista/headers/Gui/Gui.h
@@ -46,6 +46,7 @@ void renderSettingsWindow();
 void renderCursorSettingsWindow();
 void renderBrushToolWindow();
 void renderMeasurementToolWindow();
+void renderClipPlaneToolWindow();
 void renderSunManipulationPanel();
 void renderModelManipulationPanel(Engine::Model &model, Engine::Shader *shader);
 void renderMeshManipulationPanel(Engine::Model &model, int meshIndex,

--- a/StereoVista/headers/Tools/ClipPlaneTool.h
+++ b/StereoVista/headers/Tools/ClipPlaneTool.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include "Engine/Core.h"
+#include "Engine/Data.h"
+#include "Engine/Shader.h"
+#include "Tools/TransformGizmo.h"
+#include <glm/glm.hpp>
+#include <string>
+#include <vector>
+
+namespace Tools {
+
+    // Interactive section / clipping-plane tool. Up to Engine::MAX_CLIP_PLANES
+    // user planes hide the scene geometry on one side of each plane. The planes
+    // live in the active scene (Engine::Scene::clipPlanes) so they are saved /
+    // loaded with scene files, exactly like measurements.
+    //
+    // Responsibilities:
+    //   • Own the "active plane" selection and the gizmo Euler scratch used to
+    //     drive a Tools::TransformGizmo bound to the active plane.
+    //   • Pack the enabled planes for the scene vertex shaders (gl_ClipDistance
+    //     1..N) and the point-cloud compute rasterizer.
+    //   • Draw a translucent quad + normal arrow overlay per eye, mirroring the
+    //     MeasurementTool / TransformGizmo overlay pattern (embedded shaders, no
+    //     asset dependency).
+    //
+    // Clipping is applied whenever planes exist, regardless of the tool's
+    // enabled state; "enabled" only controls the editing UX (overlay, gizmo
+    // takeover, cursor/scroll nudging).
+    class ClipPlaneTool {
+    public:
+        ClipPlaneTool();
+        ~ClipPlaneTool();
+
+        void initialize(); // create GL resources (requires a current context)
+        void cleanup();
+
+        // Bind the tool to the scene's clip-plane storage. The pointer must
+        // outlive the tool (it points into the global scene object).
+        void setPlanes(std::vector<Engine::ClipPlane>* planes) { m_planes = planes; }
+        std::vector<Engine::ClipPlane>* getPlanes() { return m_planes; }
+
+        // Editing mode (overlay + gizmo takeover + cursor/scroll nudge).
+        void setEnabled(bool enabled) { m_enabled = enabled; }
+        bool isEnabled() const { return m_enabled; }
+
+        // ── Active-plane selection ───────────────────────────────────────────
+        int  activeIndex() const { return m_activeIndex; }
+        void setActiveIndex(int index);
+        // True when there is a valid, in-range active plane.
+        bool hasActivePlane() const;
+
+        // ── Plane creation / editing ─────────────────────────────────────────
+        // Add a plane at a world point with the given normal (camera-facing
+        // fallback should be supplied by the caller). Returns the new index, or
+        // -1 if the plane budget is full. The new plane becomes active.
+        int addPlane(const glm::vec3& position, const glm::vec3& normal);
+        // Add an axis-aligned plane (0 = X, 1 = Y, 2 = Z) through `center`.
+        int addAxisAlignedPlane(int axis, const glm::vec3& center);
+        void deletePlane(int index);
+        void flipNormal(int index);
+        // Slide the active plane along its normal (e.g. from scroll). Not
+        // recorded for undo (used for quick scrubbing).
+        void nudgeActive(float distance);
+
+        // ── Shader / point-cloud integration ─────────────────────────────────
+        // Fill out[] (size Engine::MAX_CLIP_PLANES) with the packed vec4 planes
+        // (normal.xyz, d) of every ENABLED plane and return the count.
+        int collectEnabledPlanes(glm::vec4 out[]) const;
+        // Set clipPlaneCount + clipPlanes[i] on the given scene shader and return
+        // the number of active (enabled) planes so the caller can enable the
+        // matching GL_CLIP_DISTANCE slots. The shader must already be in use.
+        int applyToShader(Engine::Shader* shader) const;
+
+        // ── Gizmo glue ───────────────────────────────────────────────────────
+        // Bind the gizmo to the active plane (position + Euler scratch). Returns
+        // false when there is no valid active plane.
+        bool bindGizmo(TransformGizmo& gizmo);
+        // After a gizmo rotate drag, refresh the active plane's normal from the
+        // gizmo Euler scratch.
+        void syncActiveNormalFromGizmo();
+        // Capture the active plane's state before a gizmo drag (for undo).
+        void captureGizmoUndo();
+        // Record an undo entry for the gizmo drag just finished.
+        void recordGizmoUndo();
+
+        // ── Rendering ────────────────────────────────────────────────────────
+        // World-space overlay (translucent quad + normal arrow). Called once per
+        // eye with that eye's matrices. Only drawn while the tool is enabled.
+        void render(const glm::mat4& projection, const glm::mat4& view,
+                    const glm::vec3& cameraPos);
+
+        // ── Display settings (runtime) ───────────────────────────────────────
+        float displaySize = 2.0f;   // half-extent of the visualised quad (world)
+        float nudgeStep   = 0.10f;  // world units per scroll notch
+
+    private:
+        // Convert between a plane normal and the gizmo's X-Y-Z Euler degrees
+        // (matching the TransformGizmo convention: normal = R(euler) * +Z).
+        static glm::vec3 eulerFromNormal(const glm::vec3& normal);
+        static glm::vec3 normalFromEuler(const glm::vec3& eulerDeg);
+
+        bool validIndex(int index) const;
+        void clampActiveIndex();
+        void appendLine(std::vector<float>& out, const glm::vec3& a,
+                        const glm::vec3& b) const;
+        void drawTris(const glm::mat4& viewProj, const std::vector<float>& verts,
+                      const glm::vec4& color);
+        void drawLines(const glm::mat4& viewProj, const std::vector<float>& verts,
+                       const glm::vec4& color, float width);
+
+        std::vector<Engine::ClipPlane>* m_planes = nullptr;
+        int  m_activeIndex = -1;
+        bool m_enabled = false;
+        int  m_nameCounter = 0;
+
+        // Gizmo scratch: the gizmo edits position (in-place on the plane) and
+        // this Euler triple; the plane normal is derived from it on drag.
+        glm::vec3 m_gizmoEuler = glm::vec3(0.0f);
+
+        // Undo snapshot captured at gizmo drag start.
+        int       m_undoIndex = -1;
+        glm::vec3 m_undoPos = glm::vec3(0.0f);
+        glm::vec3 m_undoNormal = glm::vec3(0.0f, 1.0f, 0.0f);
+
+        // GL resources (pos-only verts, dynamic; flat colour via uniform).
+        bool   m_initialized = false;
+        GLuint m_vao = 0, m_vbo = 0;
+        GLuint m_program = 0;
+    };
+
+} // namespace Tools

--- a/StereoVista/src/Core/SceneManager.cpp
+++ b/StereoVista/src/Core/SceneManager.cpp
@@ -254,6 +254,19 @@ namespace Engine {
             }
             sceneJson["measurements"] = measurementsJson;
 
+            // Save section / clip planes (world-space)
+            json clipPlanesJson = json::array();
+            for (const auto& plane : scene.clipPlanes) {
+                json planeJson;
+                planeJson["name"] = plane.name;
+                planeJson["position"] = { plane.position.x, plane.position.y, plane.position.z };
+                planeJson["normal"] = { plane.normal.x, plane.normal.y, plane.normal.z };
+                planeJson["color"] = { plane.color.r, plane.color.g, plane.color.b };
+                planeJson["enabled"] = plane.enabled;
+                clipPlanesJson.push_back(planeJson);
+            }
+            sceneJson["clipPlanes"] = clipPlanesJson;
+
             // Save point lights
             json pointLightsJson = json::array();
             for (const auto& pointLight : scene.pointLights) {
@@ -714,6 +727,45 @@ namespace Engine {
                     }
                     catch (const std::exception& e) {
                         std::cerr << "Failed to load measurement: " << e.what() << std::endl;
+                    }
+                }
+            }
+
+            // Load section / clip planes
+            if (sceneJson.contains("clipPlanes")) {
+                for (const auto& planeJson : sceneJson["clipPlanes"]) {
+                    try {
+                        ClipPlane plane;
+                        plane.name = planeJson.value("name", std::string("Plane"));
+                        plane.enabled = planeJson.value("enabled", true);
+                        if (planeJson.contains("position") &&
+                            planeJson["position"].is_array() &&
+                            planeJson["position"].size() == 3) {
+                            plane.position = glm::vec3(
+                                planeJson["position"][0].get<float>(),
+                                planeJson["position"][1].get<float>(),
+                                planeJson["position"][2].get<float>());
+                        }
+                        if (planeJson.contains("normal") &&
+                            planeJson["normal"].is_array() &&
+                            planeJson["normal"].size() == 3) {
+                            plane.normal = glm::vec3(
+                                planeJson["normal"][0].get<float>(),
+                                planeJson["normal"][1].get<float>(),
+                                planeJson["normal"][2].get<float>());
+                        }
+                        if (planeJson.contains("color") &&
+                            planeJson["color"].is_array() &&
+                            planeJson["color"].size() == 3) {
+                            plane.color = glm::vec3(
+                                planeJson["color"][0].get<float>(),
+                                planeJson["color"][1].get<float>(),
+                                planeJson["color"][2].get<float>());
+                        }
+                        scene.clipPlanes.push_back(std::move(plane));
+                    }
+                    catch (const std::exception& e) {
+                        std::cerr << "Failed to load clip plane: " << e.what() << std::endl;
                     }
                 }
             }

--- a/StereoVista/src/Engine/ComputePointCloudRenderer.cpp
+++ b/StereoVista/src/Engine/ComputePointCloudRenderer.cpp
@@ -80,6 +80,8 @@ void ComputePointCloudRenderer::init(int width, int height) {
     m_locPointsPerThread  = glGetUniformLocation(pid, "uPointsPerThread");
     m_locCloudID          = glGetUniformLocation(pid, "uCloudID");
     m_locSplatMaxRadius   = glGetUniformLocation(pid, "uSplatMaxRadius");
+    m_locClipPlaneCount   = glGetUniformLocation(pid, "uClipPlaneCount");
+    m_locClipPlanes       = glGetUniformLocation(pid, "uClipPlanes");
 
     // Cache color-lookup compute uniform location
     m_colorLookupShader->use();
@@ -195,6 +197,12 @@ void ComputePointCloudRenderer::beginFrame() {
 
 // ─────────────────────────────────────────────────────────────────────────────
 
+void ComputePointCloudRenderer::setClipPlanes(int count, const glm::vec4* worldPlanes) {
+    m_clipPlaneCount = glm::clamp(count, 0, 6);
+    for (int i = 0; i < m_clipPlaneCount; ++i)
+        m_clipPlanesWorld[i] = worldPlanes[i];
+}
+
 void ComputePointCloudRenderer::renderNode(
         GLuint batchSSBO,
         GLuint xyz12bSSBO,
@@ -206,6 +214,7 @@ void ComputePointCloudRenderer::renderNode(
         const glm::mat4& mvp,
         const glm::mat4& modelView,
         const glm::mat4& proj,
+        const glm::mat4& model,
         int      splatMaxRadius)
 {
     if (!m_initialized || numBatches == 0) return;
@@ -239,6 +248,18 @@ void ComputePointCloudRenderer::renderNode(
     glUniform2i(m_locImageSize, m_width, m_height);
     glUniform1ui(m_locCloudID, cloudID);
     glUniform1i(m_locSplatMaxRadius, splatMaxRadius);
+
+    // Section/clip planes: transform each active world-space plane into this
+    // cloud's local space (localPlane = transpose(model) * worldPlane) so the
+    // shader can test it against the decoded local-space points directly.
+    glUniform1i(m_locClipPlaneCount, m_clipPlaneCount);
+    if (m_clipPlaneCount > 0 && m_locClipPlanes >= 0) {
+        const glm::mat4 mt = glm::transpose(model);
+        glm::vec4 localPlanes[6];
+        for (int i = 0; i < m_clipPlaneCount; ++i)
+            localPlanes[i] = mt * m_clipPlanesWorld[i];
+        glUniform4fv(m_locClipPlanes, m_clipPlaneCount, glm::value_ptr(localPlanes[0]));
+    }
 
     // Bind packed-coordinate and batch SSBOs (matching shader bindings)
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 40, batchSSBO);

--- a/StereoVista/src/Engine/ShortcutManager.cpp
+++ b/StereoVista/src/Engine/ShortcutManager.cpp
@@ -434,6 +434,8 @@ ShortcutProfile ShortcutManager::createDefaultProfile() {
   profile.setBinding(ShortcutAction::ResetCamera, KeyBinding(GLFW_KEY_HOME), 0);
   profile.setBinding(ShortcutAction::OpenMeasurementTool, KeyBinding(GLFW_KEY_M),
                      0);
+  profile.setBinding(ShortcutAction::OpenClipPlaneTool, KeyBinding(GLFW_KEY_P),
+                     0);
   profile.setBinding(ShortcutAction::Undo, KeyBinding(GLFW_KEY_Z, true), 0);
   profile.setBinding(ShortcutAction::Redo, KeyBinding(GLFW_KEY_Y, true), 0);
   profile.setBinding(ShortcutAction::Redo,
@@ -632,6 +634,8 @@ std::string ShortcutManager::getActionName(ShortcutAction action) {
     return "OpenBrushTool";
   case ShortcutAction::OpenMeasurementTool:
     return "OpenMeasurementTool";
+  case ShortcutAction::OpenClipPlaneTool:
+    return "OpenClipPlaneTool";
 
   // File Operations
   case ShortcutAction::ImportModel:
@@ -755,6 +759,8 @@ std::string ShortcutManager::getActionDescription(ShortcutAction action) {
     return "Open Brush Tool Window";
   case ShortcutAction::OpenMeasurementTool:
     return "Open Measurement Tool Window";
+  case ShortcutAction::OpenClipPlaneTool:
+    return "Open Section / Clip Plane Tool Window";
 
   // File Operations
   case ShortcutAction::ImportModel:

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -10,6 +10,7 @@
 #include "Engine/ThreeDConnexionSync.h"
 #include "Gui/GuiTypes.h"
 #include "Tools/BrushTool.h"
+#include "Tools/ClipPlaneTool.h"
 #include "Tools/MeasurementTool.h"
 #include "Tools/TransformGizmo.h"
 #include "imgui/IconsFontAwesome5.h"
@@ -70,6 +71,13 @@ extern Tools::BrushTool brushTool;
 // Measurement tool
 extern Tools::MeasurementTool measurementTool;
 extern bool showMeasurementToolWindow;
+
+// Section / clip plane tool
+extern Tools::ClipPlaneTool clipPlaneTool;
+extern bool showClipPlaneToolWindow;
+// Defined in main.cpp: place planes using the 3D cursor / selection context.
+void addClipPlaneAtCursor();
+void addClipPlaneAxisAligned(int axis);
 
 // Transform gizmo
 extern Tools::TransformGizmo transformGizmo;
@@ -1931,6 +1939,11 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
       showMeasurementToolWindow = true;
     }
 
+    // Section / Clip Plane Tool Menu
+    if (ImGui::MenuItem("Section Planes")) {
+      showClipPlaneToolWindow = true;
+    }
+
     // AI Assistant quick access (accent-highlighted, deep-links into Settings)
     ImGui::PushStyleColor(ImGuiCol_Text, g_StyleColors.accent);
     if (ImGui::MenuItem("AI Assistant")) {
@@ -2591,6 +2604,10 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
 
   if (showMeasurementToolWindow) {
     renderMeasurementToolWindow();
+  }
+
+  if (showClipPlaneToolWindow) {
+    renderClipPlaneToolWindow();
   }
 
   // Screen-space measurement labels (distances/angles/coordinates) projected
@@ -6361,6 +6378,121 @@ void renderMeasurementToolWindow() {
   ImGui::TextDisabled("Measurements are saved with the scene file.");
 
   ImGui::End();
+}
+
+void renderClipPlaneToolWindow() {
+  ImGui::SetNextWindowSize(ImVec2(440, 560), ImGuiCond_FirstUseEver);
+  ImGui::Begin("Section Planes", &showClipPlaneToolWindow);
+
+  // The tool's editing UX (overlay, gizmo takeover, scroll scrub) is active
+  // while this panel is open.
+  clipPlaneTool.setEnabled(true);
+
+  DrawSectionHeader("Section / Clip Planes");
+  ImGui::TextWrapped(
+      "Section planes hide scene geometry on the back side of each plane. Add a "
+      "plane at the 3D cursor or an axis-aligned plane, then move / rotate it "
+      "with the transform gizmo, or scroll to slide the active plane along its "
+      "normal.");
+
+  auto *planes = clipPlaneTool.getPlanes();
+  const int planeCount = planes ? static_cast<int>(planes->size()) : 0;
+  const bool full = planeCount >= Engine::MAX_CLIP_PLANES;
+
+  ImGui::Spacing();
+  DrawSectionHeader("Add Plane");
+  if (full)
+    ImGui::BeginDisabled();
+  if (ImGui::Button("At Cursor", ImVec2(120 * g_GuiScale.currentScale, 0)))
+    addClipPlaneAtCursor();
+  ImGui::SameLine();
+  DrawHelpMarker("Places a plane at the 3D cursor, oriented by the surface "
+                 "normal under it (camera-facing fallback). Hover geometry "
+                 "first so the cursor has a valid position.");
+  ImGui::SameLine();
+  if (ImGui::Button("X##addAxisX", ImVec2(34 * g_GuiScale.currentScale, 0)))
+    addClipPlaneAxisAligned(0);
+  ImGui::SameLine();
+  if (ImGui::Button("Y##addAxisY", ImVec2(34 * g_GuiScale.currentScale, 0)))
+    addClipPlaneAxisAligned(1);
+  ImGui::SameLine();
+  if (ImGui::Button("Z##addAxisZ", ImVec2(34 * g_GuiScale.currentScale, 0)))
+    addClipPlaneAxisAligned(2);
+  ImGui::SameLine();
+  DrawHelpMarker("Add an axis-aligned plane through the selection centre, else "
+                 "the 3D cursor, else the world origin.");
+  if (full) {
+    ImGui::EndDisabled();
+    ImGui::TextDisabled("Plane budget full (%d).", Engine::MAX_CLIP_PLANES);
+  }
+
+  ImGui::Spacing();
+  DrawSectionHeader("Display");
+  ImGui::SliderFloat("Overlay Size", &clipPlaneTool.displaySize, 0.25f, 25.0f,
+                     "%.2f");
+  ImGui::SliderFloat("Scroll Step", &clipPlaneTool.nudgeStep, 0.01f, 2.0f,
+                     "%.3f");
+
+  ImGui::Spacing();
+  DrawSectionHeader("Planes");
+  if (planeCount == 0) {
+    ImGui::TextDisabled("No section planes yet.");
+  } else {
+    const int activeIdx = clipPlaneTool.activeIndex();
+    int deleteIndex = -1;
+    for (int i = 0; i < planeCount; ++i) {
+      auto &p = (*planes)[i];
+      ImGui::PushID(i);
+
+      ImGui::Checkbox("##enabled", &p.enabled);
+      ImGui::SameLine();
+      ImGui::ColorEdit3("##color", glm::value_ptr(p.color),
+                        ImGuiColorEditFlags_NoInputs |
+                            ImGuiColorEditFlags_NoLabel);
+      ImGui::SameLine();
+      const bool selected = (i == activeIdx);
+      if (ImGui::RadioButton(p.name.c_str(), selected))
+        clipPlaneTool.setActiveIndex(selected ? -1 : i);
+
+      ImGui::SameLine(ImGui::GetWindowWidth() - 96 * g_GuiScale.currentScale);
+      if (ImGui::SmallButton("Flip"))
+        clipPlaneTool.flipNormal(i);
+      ImGui::SameLine();
+      if (ImGui::SmallButton("X"))
+        deleteIndex = i;
+
+      if (selected) {
+        ImGui::Indent();
+        ImGui::DragFloat3("Position", glm::value_ptr(p.position), 0.05f);
+        ImGui::DragFloat3("Normal", glm::value_ptr(p.normal), 0.02f, -1.0f,
+                          1.0f);
+        ImGui::Unindent();
+      }
+      ImGui::PopID();
+    }
+    if (deleteIndex >= 0)
+      clipPlaneTool.deletePlane(deleteIndex);
+
+    // Gizmo controls (move / rotate) for the active plane.
+    if (clipPlaneTool.activeIndex() >= 0) {
+      ImGui::Spacing();
+      DrawSectionHeader("Active Plane Gizmo");
+      DrawTransformGizmoControls(/*canRotateScale=*/true);
+    } else {
+      ImGui::Spacing();
+      ImGui::TextDisabled("Select a plane to edit it with the gizmo.");
+    }
+  }
+
+  ImGui::Spacing();
+  ImGui::TextDisabled(
+      "Section planes are saved with the scene file. Default key: P.");
+
+  ImGui::End();
+
+  // Closing the window (X) disables the editing UX; the planes keep clipping.
+  if (!showClipPlaneToolWindow)
+    clipPlaneTool.setEnabled(false);
 }
 
 // Projects measurement values (segment lengths, angles, coordinates) into

--- a/StereoVista/src/Tools/ClipPlaneTool.cpp
+++ b/StereoVista/src/Tools/ClipPlaneTool.cpp
@@ -358,6 +358,12 @@ void main() {
         glGetBooleanv(GL_DEPTH_WRITEMASK, &prevDepthMask);
         const GLboolean prevBlend = glIsEnabled(GL_BLEND);
         const GLboolean prevCull = glIsEnabled(GL_CULL_FACE);
+        GLint prevBlendSrcRGB = GL_SRC_ALPHA, prevBlendDstRGB = GL_ONE_MINUS_SRC_ALPHA;
+        GLint prevBlendSrcA = GL_SRC_ALPHA, prevBlendDstA = GL_ONE_MINUS_SRC_ALPHA;
+        glGetIntegerv(GL_BLEND_SRC_RGB, &prevBlendSrcRGB);
+        glGetIntegerv(GL_BLEND_DST_RGB, &prevBlendDstRGB);
+        glGetIntegerv(GL_BLEND_SRC_ALPHA, &prevBlendSrcA);
+        glGetIntegerv(GL_BLEND_DST_ALPHA, &prevBlendDstA);
 
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -416,6 +422,8 @@ void main() {
         // Restore state.
         glDepthFunc(prevDepthFunc);
         glDepthMask(prevDepthMask);
+        glBlendFuncSeparate(prevBlendSrcRGB, prevBlendDstRGB, prevBlendSrcA,
+                            prevBlendDstA);
         if (!prevBlend) glDisable(GL_BLEND);
         if (prevCull) glEnable(GL_CULL_FACE);
         glBindVertexArray(0);

--- a/StereoVista/src/Tools/ClipPlaneTool.cpp
+++ b/StereoVista/src/Tools/ClipPlaneTool.cpp
@@ -1,0 +1,426 @@
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef GLM_ENABLE_EXPERIMENTAL
+#define GLM_ENABLE_EXPERIMENTAL
+#endif
+
+#include "Tools/ClipPlaneTool.h"
+#include "Core/UndoManager.h"
+
+#include <glm/gtc/type_ptr.hpp>
+#include <glm/gtx/euler_angles.hpp> // eulerAngleXYZ, extractEulerAngleXYZ
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <memory>
+
+namespace Tools {
+
+    // ── Embedded overlay shader ──────────────────────────────────────────────
+    // Flat-colour pass: positions only, colour (incl. alpha) via uniform. Same
+    // self-contained approach as MeasurementTool / BVHDebugRenderer.
+    static const char* kVertexSrc = R"(
+#version 330 core
+layout (location = 0) in vec3 aPos;
+uniform mat4 uViewProj;
+void main() {
+    gl_Position = uViewProj * vec4(aPos, 1.0);
+}
+)";
+
+    static const char* kFragmentSrc = R"(
+#version 330 core
+out vec4 FragColor;
+uniform vec4 uColor;
+void main() {
+    FragColor = uColor;
+}
+)";
+
+    static GLuint compileProgram(const char* vsSrc, const char* fsSrc) {
+        auto compile = [&](GLenum type, const char* src) -> GLuint {
+            GLuint shader = glCreateShader(type);
+            glShaderSource(shader, 1, &src, nullptr);
+            glCompileShader(shader);
+            GLint ok = GL_FALSE;
+            glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
+            if (!ok) {
+                char log[1024];
+                glGetShaderInfoLog(shader, sizeof(log), nullptr, log);
+                std::cerr << "[ClipPlaneTool] shader compile error: " << log << std::endl;
+            }
+            return shader;
+        };
+
+        GLuint vs = compile(GL_VERTEX_SHADER, vsSrc);
+        GLuint fs = compile(GL_FRAGMENT_SHADER, fsSrc);
+        GLuint program = glCreateProgram();
+        glAttachShader(program, vs);
+        glAttachShader(program, fs);
+        glLinkProgram(program);
+        glDeleteShader(vs);
+        glDeleteShader(fs);
+
+        GLint ok = GL_FALSE;
+        glGetProgramiv(program, GL_LINK_STATUS, &ok);
+        if (!ok) {
+            char log[1024];
+            glGetProgramInfoLog(program, sizeof(log), nullptr, log);
+            std::cerr << "[ClipPlaneTool] program link error: " << log << std::endl;
+        }
+        return program;
+    }
+
+    ClipPlaneTool::ClipPlaneTool() = default;
+
+    ClipPlaneTool::~ClipPlaneTool() {
+        cleanup();
+    }
+
+    void ClipPlaneTool::initialize() {
+        if (m_initialized) return;
+
+        glGenVertexArrays(1, &m_vao);
+        glGenBuffers(1, &m_vbo);
+        glBindVertexArray(m_vao);
+        glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
+        glEnableVertexAttribArray(0);
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+        glBindVertexArray(0);
+
+        m_program = compileProgram(kVertexSrc, kFragmentSrc);
+        m_initialized = true;
+    }
+
+    void ClipPlaneTool::cleanup() {
+        if (m_vao) { glDeleteVertexArrays(1, &m_vao); m_vao = 0; }
+        if (m_vbo) { glDeleteBuffers(1, &m_vbo); m_vbo = 0; }
+        if (m_program) { glDeleteProgram(m_program); m_program = 0; }
+        m_initialized = false;
+    }
+
+    // ── Normal <-> Euler conversion (TransformGizmo convention) ──────────────
+    // The gizmo stores rotations as X-Y-Z Euler degrees and its rotation matrix
+    // is mat3(glm::eulerAngleXYZ(...)). We define the plane normal as the matrix
+    // +Z column, so the gizmo's rotate handles steer the normal directly.
+    glm::vec3 ClipPlaneTool::eulerFromNormal(const glm::vec3& normal) {
+        glm::vec3 z = normal;
+        const float len = glm::length(z);
+        z = (len > 1e-6f) ? z / len : glm::vec3(0.0f, 0.0f, 1.0f);
+        // Build an orthonormal basis [x, y, z] with z = normal. Determinant is
+        // +1, so extractEulerAngleXYZ recovers a clean rotation.
+        const glm::vec3 ref = (std::fabs(z.y) < 0.99f) ? glm::vec3(0, 1, 0)
+                                                       : glm::vec3(1, 0, 0);
+        const glm::vec3 x = glm::normalize(glm::cross(ref, z));
+        const glm::vec3 y = glm::cross(z, x);
+        glm::mat4 R(1.0f);
+        R[0] = glm::vec4(x, 0.0f);
+        R[1] = glm::vec4(y, 0.0f);
+        R[2] = glm::vec4(z, 0.0f);
+        float ex, ey, ez;
+        glm::extractEulerAngleXYZ(R, ex, ey, ez);
+        return glm::degrees(glm::vec3(ex, ey, ez));
+    }
+
+    glm::vec3 ClipPlaneTool::normalFromEuler(const glm::vec3& eulerDeg) {
+        const glm::mat4 R = glm::eulerAngleXYZ(glm::radians(eulerDeg.x),
+                                               glm::radians(eulerDeg.y),
+                                               glm::radians(eulerDeg.z));
+        return glm::normalize(glm::vec3(R[2])); // R * (0,0,1)
+    }
+
+    // ── Selection ────────────────────────────────────────────────────────────
+    bool ClipPlaneTool::validIndex(int index) const {
+        return m_planes && index >= 0 && index < static_cast<int>(m_planes->size());
+    }
+
+    bool ClipPlaneTool::hasActivePlane() const { return validIndex(m_activeIndex); }
+
+    void ClipPlaneTool::setActiveIndex(int index) {
+        m_activeIndex = (index >= 0 && validIndex(index)) ? index : -1;
+    }
+
+    void ClipPlaneTool::clampActiveIndex() {
+        if (!m_planes || m_planes->empty()) { m_activeIndex = -1; return; }
+        if (m_activeIndex >= static_cast<int>(m_planes->size()))
+            m_activeIndex = static_cast<int>(m_planes->size()) - 1;
+    }
+
+    // ── Creation / editing ─────────────────────────────────────────────────
+    int ClipPlaneTool::addPlane(const glm::vec3& position, const glm::vec3& normal) {
+        if (!m_planes) return -1;
+        if (static_cast<int>(m_planes->size()) >= Engine::MAX_CLIP_PLANES) {
+            std::cerr << "[ClipPlaneTool] clip-plane budget full ("
+                      << Engine::MAX_CLIP_PLANES << ")\n";
+            return -1;
+        }
+
+        Engine::ClipPlane p;
+        p.position = position;
+        const float len = glm::length(normal);
+        p.normal = (len > 1e-6f) ? (normal / len) : glm::vec3(0.0f, 1.0f, 0.0f);
+        p.enabled = true;
+        p.name = "Plane " + std::to_string(++m_nameCounter);
+
+        m_planes->push_back(p);
+        const int idx = static_cast<int>(m_planes->size()) - 1;
+        m_activeIndex = idx;
+
+        std::vector<Engine::ClipPlane>* planes = m_planes;
+        const Engine::ClipPlane val = p;
+        Engine::UndoManager::instance().record(std::make_unique<Engine::LambdaUndoCommand>(
+            "Add clip plane",
+            [planes, idx]() {
+                if (idx < static_cast<int>(planes->size()))
+                    planes->erase(planes->begin() + idx);
+            },
+            [planes, idx, val]() {
+                const size_t at = std::min(static_cast<size_t>(idx), planes->size());
+                planes->insert(planes->begin() + at, val);
+            }));
+        return idx;
+    }
+
+    int ClipPlaneTool::addAxisAlignedPlane(int axis, const glm::vec3& center) {
+        glm::vec3 n(0.0f);
+        n[std::min(std::max(axis, 0), 2)] = 1.0f;
+        return addPlane(center, n);
+    }
+
+    void ClipPlaneTool::deletePlane(int index) {
+        if (!validIndex(index)) return;
+        std::vector<Engine::ClipPlane>* planes = m_planes;
+        const Engine::ClipPlane val = (*planes)[index];
+        planes->erase(planes->begin() + index);
+        clampActiveIndex();
+
+        Engine::UndoManager::instance().record(std::make_unique<Engine::LambdaUndoCommand>(
+            "Delete clip plane",
+            [planes, index, val]() {
+                const size_t at = std::min(static_cast<size_t>(index), planes->size());
+                planes->insert(planes->begin() + at, val);
+            },
+            [planes, index]() {
+                if (index < static_cast<int>(planes->size()))
+                    planes->erase(planes->begin() + index);
+            }));
+    }
+
+    void ClipPlaneTool::flipNormal(int index) {
+        if (!validIndex(index)) return;
+        std::vector<Engine::ClipPlane>* planes = m_planes;
+        (*planes)[index].normal = -(*planes)[index].normal;
+
+        Engine::UndoManager::instance().record(std::make_unique<Engine::LambdaUndoCommand>(
+            "Flip clip plane",
+            [planes, index]() {
+                if (index < static_cast<int>(planes->size()))
+                    (*planes)[index].normal = -(*planes)[index].normal;
+            },
+            [planes, index]() {
+                if (index < static_cast<int>(planes->size()))
+                    (*planes)[index].normal = -(*planes)[index].normal;
+            }));
+    }
+
+    void ClipPlaneTool::nudgeActive(float distance) {
+        if (!hasActivePlane()) return;
+        Engine::ClipPlane& p = (*m_planes)[m_activeIndex];
+        p.position += p.unitNormal() * distance;
+    }
+
+    // ── Shader / point-cloud integration ─────────────────────────────────────
+    int ClipPlaneTool::collectEnabledPlanes(glm::vec4 out[]) const {
+        int n = 0;
+        if (!m_planes) return 0;
+        for (const auto& p : *m_planes) {
+            if (!p.enabled) continue;
+            if (n >= Engine::MAX_CLIP_PLANES) break;
+            out[n++] = p.packed();
+        }
+        return n;
+    }
+
+    int ClipPlaneTool::applyToShader(Engine::Shader* shader) const {
+        glm::vec4 packed[Engine::MAX_CLIP_PLANES];
+        const int n = collectEnabledPlanes(packed);
+        if (!shader) return n;
+        shader->use();
+        shader->setInt("clipPlaneCount", n);
+        for (int i = 0; i < n; ++i)
+            shader->setVec4("clipPlanes[" + std::to_string(i) + "]", packed[i]);
+        return n;
+    }
+
+    // ── Gizmo glue ───────────────────────────────────────────────────────────
+    bool ClipPlaneTool::bindGizmo(TransformGizmo& gizmo) {
+        if (!hasActivePlane()) return false;
+        Engine::ClipPlane& p = (*m_planes)[m_activeIndex];
+        // Refresh the Euler scratch from the current normal while not dragging so
+        // the gizmo's rotation handles show the plane's true orientation.
+        if (!gizmo.isDragging())
+            m_gizmoEuler = eulerFromNormal(p.normal);
+        gizmo.setTarget(&p.position, &m_gizmoEuler, nullptr);
+        return true;
+    }
+
+    void ClipPlaneTool::syncActiveNormalFromGizmo() {
+        if (!hasActivePlane()) return;
+        (*m_planes)[m_activeIndex].normal = normalFromEuler(m_gizmoEuler);
+    }
+
+    void ClipPlaneTool::captureGizmoUndo() {
+        if (!hasActivePlane()) { m_undoIndex = -1; return; }
+        m_undoIndex = m_activeIndex;
+        m_undoPos = (*m_planes)[m_activeIndex].position;
+        m_undoNormal = (*m_planes)[m_activeIndex].normal;
+    }
+
+    void ClipPlaneTool::recordGizmoUndo() {
+        if (m_undoIndex < 0 || !validIndex(m_undoIndex)) { m_undoIndex = -1; return; }
+        std::vector<Engine::ClipPlane>* planes = m_planes;
+        const int idx = m_undoIndex;
+        const glm::vec3 beforePos = m_undoPos, beforeN = m_undoNormal;
+        const glm::vec3 afterPos = (*planes)[idx].position;
+        const glm::vec3 afterN = (*planes)[idx].normal;
+        m_undoIndex = -1;
+        if (beforePos == afterPos && beforeN == afterN) return; // no-op drag
+
+        Engine::UndoManager::instance().record(std::make_unique<Engine::LambdaUndoCommand>(
+            "Edit clip plane",
+            [planes, idx, beforePos, beforeN]() {
+                if (idx < static_cast<int>(planes->size())) {
+                    (*planes)[idx].position = beforePos;
+                    (*planes)[idx].normal = beforeN;
+                }
+            },
+            [planes, idx, afterPos, afterN]() {
+                if (idx < static_cast<int>(planes->size())) {
+                    (*planes)[idx].position = afterPos;
+                    (*planes)[idx].normal = afterN;
+                }
+            }));
+    }
+
+    // ── Overlay rendering ──────────────────────────────────────────────────
+    void ClipPlaneTool::appendLine(std::vector<float>& out, const glm::vec3& a,
+                                   const glm::vec3& b) const {
+        out.insert(out.end(), { a.x, a.y, a.z, b.x, b.y, b.z });
+    }
+
+    void ClipPlaneTool::drawTris(const glm::mat4& viewProj,
+                                 const std::vector<float>& verts,
+                                 const glm::vec4& color) {
+        if (verts.empty()) return;
+        glUseProgram(m_program);
+        glUniformMatrix4fv(glGetUniformLocation(m_program, "uViewProj"), 1, GL_FALSE,
+                           &viewProj[0][0]);
+        glUniform4fv(glGetUniformLocation(m_program, "uColor"), 1, &color[0]);
+        glBindVertexArray(m_vao);
+        glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+        glBufferData(GL_ARRAY_BUFFER,
+                     static_cast<GLsizeiptr>(verts.size() * sizeof(float)),
+                     verts.data(), GL_DYNAMIC_DRAW);
+        glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(verts.size() / 3));
+    }
+
+    void ClipPlaneTool::drawLines(const glm::mat4& viewProj,
+                                  const std::vector<float>& verts,
+                                  const glm::vec4& color, float width) {
+        if (verts.empty()) return;
+        glLineWidth(width);
+        glUseProgram(m_program);
+        glUniformMatrix4fv(glGetUniformLocation(m_program, "uViewProj"), 1, GL_FALSE,
+                           &viewProj[0][0]);
+        glUniform4fv(glGetUniformLocation(m_program, "uColor"), 1, &color[0]);
+        glBindVertexArray(m_vao);
+        glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+        glBufferData(GL_ARRAY_BUFFER,
+                     static_cast<GLsizeiptr>(verts.size() * sizeof(float)),
+                     verts.data(), GL_DYNAMIC_DRAW);
+        glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(verts.size() / 3));
+    }
+
+    void ClipPlaneTool::render(const glm::mat4& projection, const glm::mat4& view,
+                               const glm::vec3& /*cameraPos*/) {
+        if (!m_enabled || !m_planes || m_planes->empty()) return;
+        if (!m_initialized) initialize();
+
+        clampActiveIndex();
+
+        // Save the GL state we touch.
+        GLint prevDepthFunc = GL_LESS;
+        glGetIntegerv(GL_DEPTH_FUNC, &prevDepthFunc);
+        GLboolean prevDepthMask = GL_TRUE;
+        glGetBooleanv(GL_DEPTH_WRITEMASK, &prevDepthMask);
+        const GLboolean prevBlend = glIsEnabled(GL_BLEND);
+        const GLboolean prevCull = glIsEnabled(GL_CULL_FACE);
+
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        glDisable(GL_CULL_FACE);     // the quad must be visible from both sides
+        glDepthMask(GL_FALSE);       // never write depth (cursor reads scene depth)
+        glDepthFunc(GL_LEQUAL);
+
+        const glm::mat4 viewProj = projection * view;
+        const float S = displaySize;
+
+        for (int i = 0; i < static_cast<int>(m_planes->size()); ++i) {
+            const Engine::ClipPlane& p = (*m_planes)[i];
+            const bool active = (i == m_activeIndex);
+
+            const glm::vec3 n = p.unitNormal();
+            const glm::vec3 ref = (std::fabs(n.y) < 0.99f) ? glm::vec3(0, 1, 0)
+                                                          : glm::vec3(1, 0, 0);
+            const glm::vec3 u = glm::normalize(glm::cross(ref, n));
+            const glm::vec3 v = glm::cross(n, u);
+
+            const glm::vec3 c0 = p.position + (-u - v) * S;
+            const glm::vec3 c1 = p.position + ( u - v) * S;
+            const glm::vec3 c2 = p.position + ( u + v) * S;
+            const glm::vec3 c3 = p.position + (-u + v) * S;
+
+            // Translucent fill (two triangles).
+            const std::vector<float> tris = {
+                c0.x, c0.y, c0.z, c1.x, c1.y, c1.z, c2.x, c2.y, c2.z,
+                c0.x, c0.y, c0.z, c2.x, c2.y, c2.z, c3.x, c3.y, c3.z,
+            };
+            const float fillA = p.enabled ? (active ? 0.22f : 0.12f) : 0.05f;
+            drawTris(viewProj, tris, glm::vec4(p.color, fillA));
+
+            // Border quad + normal arrow.
+            std::vector<float> lines;
+            appendLine(lines, c0, c1);
+            appendLine(lines, c1, c2);
+            appendLine(lines, c2, c3);
+            appendLine(lines, c3, c0);
+
+            const glm::vec3 tip = p.position + n * S;
+            appendLine(lines, p.position, tip);
+            const glm::vec3 back = tip - n * (S * 0.18f);
+            appendLine(lines, tip, back + u * (S * 0.10f));
+            appendLine(lines, tip, back - u * (S * 0.10f));
+            appendLine(lines, tip, back + v * (S * 0.10f));
+            appendLine(lines, tip, back - v * (S * 0.10f));
+
+            const float lineA = p.enabled ? (active ? 1.0f : 0.7f) : 0.35f;
+            const glm::vec3 lineCol =
+                active ? glm::mix(p.color, glm::vec3(1.0f), 0.4f) : p.color;
+            drawLines(viewProj, lines, glm::vec4(lineCol, lineA),
+                      active ? 2.5f : 1.5f);
+        }
+
+        // Restore state.
+        glDepthFunc(prevDepthFunc);
+        glDepthMask(prevDepthMask);
+        if (!prevBlend) glDisable(GL_BLEND);
+        if (prevCull) glEnable(GL_CULL_FACE);
+        glBindVertexArray(0);
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+        glUseProgram(0);
+    }
+
+} // namespace Tools

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -6967,18 +6967,21 @@ void addClipPlaneAtCursor() {
     return;
   const glm::vec3 pos = cursorManager.getCursorPosition();
 
-  // Default to a camera-facing normal, then refine with the surface normal
-  // under the cursor if a model is hit.
+  // Default to a camera-facing normal, then refine with the surface normal of
+  // the NEAREST model under the cursor (so overlapping models pick the visible
+  // surface, matching the cursor's own hit point).
   glm::vec3 normal = glm::normalize(camera.Position - pos);
   glm::vec3 rayOrigin, rayDir, rayNear, rayFar;
   calculateMouseRay(lastX, lastY, rayOrigin, rayDir, rayNear, rayFar,
                     aspectRatio);
-  float distance;
+  float closest = std::numeric_limits<float>::max();
   for (const auto &model : currentScene.models) {
+    float distance;
     glm::vec3 hitNormal;
-    if (rayIntersectsModel(rayOrigin, rayDir, model, distance, hitNormal)) {
+    if (rayIntersectsModel(rayOrigin, rayDir, model, distance, hitNormal) &&
+        distance < closest) {
+      closest = distance;
       normal = hitNormal;
-      break;
     }
   }
   clipPlaneTool.addPlane(pos, normal);

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -32,6 +32,7 @@
 #include "Loaders/PointCloudLoader.h"
 #include "Tools/BrushTool.h"
 #include "Tools/MeasurementTool.h"
+#include "Tools/ClipPlaneTool.h"
 #include "Tools/TransformGizmo.h"
 
 
@@ -203,6 +204,7 @@ bool show3DCursor = true;
 bool showCursorSettingsWindow = false;
 bool showBrushToolWindow = false;
 bool showMeasurementToolWindow = false;
+bool showClipPlaneToolWindow = false;
 enum class SelectedType {
   None,
   Model,
@@ -294,6 +296,9 @@ Tools::BrushTool brushTool;
 // ---- Measurement Tool ----
 Tools::MeasurementTool measurementTool;
 
+// ---- Section / Clip Plane Tool ----
+Tools::ClipPlaneTool clipPlaneTool;
+
 // ---- Transform Gizmo ----
 // Visual translate/rotate/scale gizmo anchored at the selected object's pivot.
 // Coexists with the legacy Ctrl/Alt body-drag free-move (which is preserved):
@@ -307,6 +312,9 @@ Engine::PointLight gizmoUndoPointLightBefore;
 Engine::SpotLight gizmoUndoSpotLightBefore;
 SelectedType gizmoUndoType = SelectedType::None;
 int gizmoUndoIndex = -1;
+// True while the gizmo is driving the active clip plane (instead of a scene
+// object), so the drag press/update/release routes to the clip-plane tool.
+bool g_clipPlaneGizmoActive = false;
 
 // ---- Window Configuration ----
 int windowWidth = 1920;
@@ -3256,6 +3264,9 @@ int main() {
     // across scene loads).
     measurementTool.setMeasurements(&currentScene.measurements);
 
+    // Keep the clip-plane tool bound to the current scene's plane storage.
+    clipPlaneTool.setPlanes(&currentScene.clipPlanes);
+
     // ---- Transform Gizmo: bind target + process hover / constrained drag ----
     // Safety net: if the mouse-up landed over an ImGui panel (whose callback
     // early-returns) the release can be missed, so finalize here too.
@@ -3272,6 +3283,10 @@ int main() {
         bool snapHeld = (glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS ||
                          glfwGetKey(window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS);
         transformGizmo.updateDrag(gRayOrigin, gRayDir, camera.Position, snapHeld);
+        // A clip-plane rotate drag updates the gizmo Euler scratch; mirror it
+        // back into the plane's normal.
+        if (g_clipPlaneGizmoActive)
+          clipPlaneTool.syncActiveNormalFromGizmo();
       } else if (!camera.IsOrbiting && !camera.IsPanning && !isMovingModel &&
                  !rightMousePressed && !ImGui::GetIO().WantCaptureMouse) {
         transformGizmo.updateHover(gRayOrigin, gRayDir, camera.Position);
@@ -4041,6 +4056,7 @@ void cleanup() {
 
   // Clean up measurement tool GL resources while the context is still valid
   measurementTool.cleanup();
+  clipPlaneTool.cleanup();
   transformGizmo.cleanup();
 
   // Drop undo history while the context is still valid - undo entries for
@@ -5146,11 +5162,25 @@ void renderEye(GLenum drawBuffer, const glm::mat4 &projection,
   // Wireframe is scoped to the model pass only: the skybox stays solid and,
   // crucially, GL_LINE is reset before the post-process/composite passes so it
   // can't turn the full-screen HDR quads into stray lines.
+  // Section / clip planes: push the active planes to the scene shader and
+  // enable the matching GL_CLIP_DISTANCE slots (index 0 stays reserved for the
+  // radar slice, so user planes use slots 1..N). Scoped to the model pass only
+  // and disabled immediately after so the clip state can't leak into the skybox,
+  // point-cloud, or post-process passes (whose shaders don't write
+  // gl_ClipDistance, which would otherwise clip them with undefined values).
+  int activeClipPlanes = clipPlaneTool.applyToShader(shader);
+  for (int i = 0; i < activeClipPlanes; ++i)
+    glEnable(GL_CLIP_DISTANCE0 + 1 + i);
+
   if (camera.wireframe)
     glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
   renderModels(shader, projection * view);
   if (camera.wireframe)
     glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
+  for (int i = 0; i < activeClipPlanes; ++i)
+    glDisable(GL_CLIP_DISTANCE0 + 1 + i);
+
   renderSkybox(projection, view, shader);
   renderPointClouds(shader, view, projection);
 
@@ -5372,6 +5402,10 @@ void renderEye(GLenum drawBuffer, const glm::mat4 &projection,
   // Render the transform gizmo overlay for the selected object (per eye).
   transformGizmo.render(projection, view, camera.Position);
 
+  // Render the section/clip-plane overlay (translucent quad + normal arrow);
+  // only while the tool is active (panel/toolbar open).
+  clipPlaneTool.render(projection, view, camera.Position);
+
   // Render brush tool indicator
   if (preferences.brushToolSettings.enabled &&
       preferences.brushToolSettings.selectedModelIndex >= 0 &&
@@ -5566,6 +5600,11 @@ void renderModels(Engine::Shader *shader, const glm::mat4 &viewProj,
     instancedShader->setFloat("sunIntensity", sun.intensity);
     instancedShader->setBool("useInstanceColor", true);
 
+    // Section/clip planes: the matching GL_CLIP_DISTANCE slots are already
+    // enabled by renderEye for the model pass, so feed the instanced program the
+    // same planes (otherwise its gl_ClipDistance writes default to "keep").
+    clipPlaneTool.applyToShader(instancedShader);
+
     // Bind shadow map
     if (enableShadows) {
       glActiveTexture(GL_TEXTURE0 + Engine::SHADOW_MAP_TEXTURE_UNIT);
@@ -5592,6 +5631,11 @@ void renderPointClouds(Engine::Shader *shader, const glm::mat4 &view,
   bool useCompute =
       computePointCloudRenderer && computePointCloudRenderer->isInitialized();
   if (useCompute) {
+    // Feed the active section/clip planes to the compute rasterizer so clipped
+    // points are discarded (point clouds don't use gl_ClipDistance).
+    glm::vec4 worldPlanes[Engine::MAX_CLIP_PLANES];
+    int nClip = clipPlaneTool.collectEnabledPlanes(worldPlanes);
+    computePointCloudRenderer->setClipPlanes(nClip, worldPlanes);
     computePointCloudRenderer->beginFrame();
   }
 
@@ -5637,6 +5681,7 @@ void renderPointClouds(Engine::Shader *shader, const glm::mat4 &view,
             projection * view * modelMatrix, // uMVP
             view * modelMatrix,              // uModelView (for precision level)
             projection,                      // uProj      (for precision level)
+            modelMatrix,                     // model (for local-space clip planes)
             splatMaxRadius);                 // adaptive splat radius clamp (px)
       }
     } else if (pointCloud.octreeRoot) {
@@ -6651,6 +6696,14 @@ void framebuffer_size_callback(GLFWwindow *window, int width, int height) {
 
 void scroll_callback(GLFWwindow *window, double xoffset, double yoffset) {
   if (!ImGui::GetIO().WantCaptureMouse && !spaceMouseActive) {
+    // Clip-plane scrubbing: while the tool is active with a selected plane,
+    // scroll nudges the plane along its normal (mirrors model scroll-to-depth)
+    // so the user can quickly slice through the model.
+    if (clipPlaneTool.isEnabled() && clipPlaneTool.hasActivePlane()) {
+      clipPlaneTool.nudgeActive(static_cast<float>(yoffset) *
+                                clipPlaneTool.nudgeStep);
+      return;
+    }
     // Check if we're currently moving a model with Ctrl+drag
     if (isMovingModel && currentSelectedType == SelectedType::Model &&
         currentSelectedIndex != -1) {
@@ -6762,6 +6815,13 @@ static void bindGizmoTargetToSelection() {
   if (gizmoDragging)
     return; // keep the live target stable for the duration of a drag
 
+  // The clip-plane tool takes over the gizmo when active with a plane selected,
+  // so the user can slide (move) and rotate the section plane directly.
+  if (clipPlaneTool.isEnabled() && clipPlaneTool.hasActivePlane()) {
+    if (clipPlaneTool.bindGizmo(transformGizmo))
+      return;
+  }
+
   switch (currentSelectedType) {
   case SelectedType::Model:
     if (currentSelectedIndex >= 0 &&
@@ -6806,6 +6866,16 @@ static void bindGizmoTargetToSelection() {
 static void beginGizmoDrag(Tools::TransformGizmo::Handle handle,
                            const glm::vec3 &rayOrigin,
                            const glm::vec3 &rayDir) {
+  // Clip-plane gizmo drag: the plane (not a scene object) is the target.
+  if (clipPlaneTool.isEnabled() && clipPlaneTool.hasActivePlane()) {
+    gizmoUndoType = SelectedType::None;
+    clipPlaneTool.captureGizmoUndo();
+    gizmoDragging =
+        transformGizmo.beginDrag(handle, rayOrigin, rayDir, camera.Position);
+    g_clipPlaneGizmoActive = gizmoDragging;
+    return;
+  }
+
   gizmoUndoType = currentSelectedType;
   gizmoUndoIndex = currentSelectedIndex;
   switch (gizmoUndoType) {
@@ -6838,6 +6908,13 @@ static void finishGizmoDrag() {
     return;
   transformGizmo.endDrag();
   gizmoDragging = false;
+
+  // Clip-plane drag: record the position/normal change as one undo entry.
+  if (g_clipPlaneGizmoActive) {
+    g_clipPlaneGizmoActive = false;
+    clipPlaneTool.recordGizmoUndo();
+    return;
+  }
 
   switch (gizmoUndoType) {
   case SelectedType::Model:
@@ -6880,6 +6957,51 @@ static void finishGizmoDrag() {
   gizmoUndoType = SelectedType::None;
   gizmoUndoIndex = -1;
   updateSpaceMouseBounds();
+}
+
+// ── Clip-plane creation helpers (invoked from the GUI panel) ────────────────
+// Place a clip plane at the 3D cursor, oriented by the surface normal under the
+// cursor (camera-facing fallback). No-op when the cursor isn't on geometry.
+void addClipPlaneAtCursor() {
+  if (!cursorManager.isCursorPositionValid())
+    return;
+  const glm::vec3 pos = cursorManager.getCursorPosition();
+
+  // Default to a camera-facing normal, then refine with the surface normal
+  // under the cursor if a model is hit.
+  glm::vec3 normal = glm::normalize(camera.Position - pos);
+  glm::vec3 rayOrigin, rayDir, rayNear, rayFar;
+  calculateMouseRay(lastX, lastY, rayOrigin, rayDir, rayNear, rayFar,
+                    aspectRatio);
+  float distance;
+  for (const auto &model : currentScene.models) {
+    glm::vec3 hitNormal;
+    if (rayIntersectsModel(rayOrigin, rayDir, model, distance, hitNormal)) {
+      normal = hitNormal;
+      break;
+    }
+  }
+  clipPlaneTool.addPlane(pos, normal);
+  clipPlaneTool.setEnabled(true);
+}
+
+// Add an axis-aligned plane (0 = X, 1 = Y, 2 = Z) through the selection centre,
+// else the 3D cursor, else the world origin.
+void addClipPlaneAxisAligned(int axis) {
+  glm::vec3 center(0.0f);
+  if (currentSelectedType == SelectedType::Model && currentSelectedIndex >= 0 &&
+      currentSelectedIndex < static_cast<int>(currentScene.models.size())) {
+    center = currentScene.models[currentSelectedIndex].position;
+  } else if (currentSelectedType == SelectedType::PointCloud &&
+             currentSelectedIndex >= 0 &&
+             currentSelectedIndex <
+                 static_cast<int>(currentScene.pointClouds.size())) {
+    center = currentScene.pointClouds[currentSelectedIndex].position;
+  } else if (cursorManager.isCursorPositionValid()) {
+    center = cursorManager.getCursorPosition();
+  }
+  clipPlaneTool.addAxisAlignedPlane(axis, center);
+  clipPlaneTool.setEnabled(true);
 }
 
 void mouse_button_callback(GLFWwindow *window, int button, int action,
@@ -7960,6 +8082,12 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
     case StereoVista::ShortcutAction::OpenMeasurementTool:
       showMeasurementToolWindow = true;
       std::cout << "Opening measurement tool window" << std::endl;
+      break;
+
+    case StereoVista::ShortcutAction::OpenClipPlaneTool:
+      showClipPlaneToolWindow = true;
+      clipPlaneTool.setEnabled(true);
+      std::cout << "Opening clip plane tool window" << std::endl;
       break;
 
     // File Operations - these will trigger file dialogs through GUI


### PR DESCRIPTION
Add up to 6 user-controllable section planes that hide scene geometry on
one side of each plane, integrated like the existing 3D cursor /
MeasurementTool / TransformGizmo tools and working in stereo with HDR.

Data & persistence
- Engine::ClipPlane struct + Scene::clipPlanes vector (Data.h, SceneManager.h)
- JSON save/load of clip planes in SceneManager, mirroring measurements
- Universal undo/redo for add / delete / flip / gizmo-edit via LambdaUndoCommand

Shaders
- Generalise the single radar clip (gl_ClipDistance[0]) to N world-space
  planes on gl_ClipDistance[1..6] in every main-pass scene vertex shader
  (shadowMapping, radiance, voxelConeTracing, instanced). Radar slice is
  untouched and keeps working. Constant indices keep the implicit
  gl_ClipDistance[] array sized correctly.
- Point clouds use the compute rasterizer (no gl_ClipDistance): planes are
  transformed into each cloud's local space and points failing the test are
  discarded in pointcloud_rasterize.comp.

Tool & integration
- Tools::ClipPlaneTool: world-space overlay (translucent quad + normal
  arrow per eye, embedded shaders), plane packing for shaders / point
  clouds, active-plane selection, gizmo glue (position + normal via a Euler
  scratch), and cursor/scroll nudging along the normal.
- renderEye enables GL_CLIP_DISTANCE1..N only around the model pass so clip
  state can't leak into skybox / point-cloud / post-process passes.
- TransformGizmo reused to move/rotate the active plane; cursor-driven and
  axis-aligned (X/Y/Z) placement.
- GUI "Section Planes" panel + menu entry, rebindable OpenClipPlaneTool
  shortcut (default P).
- Register ClipPlaneTool in the vcxproj / filters.

https://claude.ai/code/session_01FzMUrKbUscA9tojMZEAy9j