### PR TITLE
Add Snapshot system for saving/restoring scene state

### DIFF
--- a/StereoVista/StereoVista.vcxproj
+++ b/StereoVista/StereoVista.vcxproj
@@ -204,6 +204,7 @@ IF %ERRORLEVEL% LEQ 7 SET ERRORLEVEL=0</Command>
     <ClCompile Include="headers\libs\portable-file-dialogs.h" />
     <ClCompile Include="src\Loaders\PointCloudLoader.cpp" />
     <ClCompile Include="src\Core\SceneManager.cpp" />
+    <ClCompile Include="src\Core\SnapshotManager.cpp" />
     <ClCompile Include="src\Core\UndoManager.cpp" />
     <ClCompile Include="src\Engine\StbImageImpl.cpp" />
     <ClCompile Include="src\Core\Voxalizer.cpp" />
@@ -223,6 +224,7 @@ IF %ERRORLEVEL% LEQ 7 SET ERRORLEVEL=0</Command>
   <ItemGroup>
     <ClInclude Include="headers\core.h" />
     <ClInclude Include="headers\Core\SceneManager.h" />
+    <ClInclude Include="headers\Core\SnapshotManager.h" />
     <ClInclude Include="headers\Core\UndoManager.h" />
     <ClInclude Include="headers\Core\CursorSynchronizer.h" />
     <ClInclude Include="headers\Core\CursorSyncState.h" />

--- a/StereoVista/StereoVista.vcxproj.filters
+++ b/StereoVista/StereoVista.vcxproj.filters
@@ -90,6 +90,9 @@
     <ClCompile Include="src\Core\SceneManager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Core\SnapshotManager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\Core\UndoManager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -462,6 +465,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="headers\Core\SceneManager.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="headers\Core\SnapshotManager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="headers\Core\UndoManager.h">

--- a/StereoVista/headers/Core/SnapshotManager.h
+++ b/StereoVista/headers/Core/SnapshotManager.h
@@ -1,0 +1,154 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <glm/glm.hpp>
+
+#include "Core/Camera.h"
+#include "Core/SceneManager.h"
+#include "Core/UndoManager.h"
+#include "Engine/Core.h"
+#include "Engine/Data.h"
+#include "Tools/BrushTool.h"
+#include "Tools/ClipPlaneTool.h"
+#include "Tools/MeasurementTool.h"
+
+namespace Core {
+
+// -----------------------------------------------------------------------
+// Snapshot system.
+//
+// A Snapshot captures a chosen subset of the live scene so the user can
+// return to it later (a coarse-grained, named "checkpoint" that complements
+// the fine-grained Undo history). The aspects saved are selectable per
+// snapshot via SnapshotFlags, so a snapshot may store only the camera, only
+// the scene, only the tools, or any combination. Every snapshot also keeps a
+// thumbnail captured from the viewer when it was taken.
+//
+// Snapshots live for the duration of the session (they are not serialized to
+// disk). Scene restore re-applies object transforms / materials by index and
+// fully replaces the lights, sun, measurements and clip planes; it does not
+// re-create objects that were deleted after the snapshot was taken.
+// -----------------------------------------------------------------------
+
+enum SnapshotFlags : uint32_t {
+  SNAPSHOT_NONE = 0,
+  SNAPSHOT_CAMERA = 1u << 0,
+  SNAPSHOT_SCENE = 1u << 1,
+  SNAPSHOT_TOOLS = 1u << 2,
+};
+
+// Saved per-object scene state. Models / point clouds reuse the Undo edit
+// snapshots (transform + material), applied back by index. Lights, sun,
+// measurements and clip planes are small/POD-like and stored as full copies.
+struct SnapshotSceneState {
+  std::vector<Engine::Undo::ModelEditState> models;
+  std::vector<Engine::Undo::PointCloudEditState> pointClouds;
+  std::vector<Engine::PointLight> pointLights;
+  std::vector<Engine::SpotLight> spotLights;
+  std::vector<Engine::Measurement> measurements;
+  std::vector<Engine::ClipPlane> clipPlanes;
+  Engine::Sun sun{};
+};
+
+// Saved runtime tool settings (the tools' editable scene data -- measurements
+// and clip planes -- live in the scene and are covered by SnapshotSceneState).
+struct SnapshotToolState {
+  // Brush tool
+  bool brushEnabled = false;
+  float brushRadius = 1.0f;
+  float brushDensity = 1.0f;
+  float brushMinSpacing = 0.0f;
+  int brushSelectedModel = -1;
+  // Measurement tool
+  bool measureEnabled = false;
+  int measureMode = 0;
+  float measureLineWidth = 2.5f;
+  bool measureShowLabels = true;
+  bool measureShowSegmentLabels = true;
+  bool measureXRay = true;
+  float measureUnitScale = 1.0f;
+  std::string measureUnitSuffix = "m";
+  glm::vec3 measureNextColor = glm::vec3(1.0f, 0.76f, 0.03f);
+  // Clip-plane tool
+  bool clipEnabled = false;
+  float clipDisplaySize = 2.0f;
+  float clipNudgeStep = 0.10f;
+  int clipActiveIndex = -1;
+};
+
+struct Snapshot {
+  std::string name;
+  std::string timestamp;
+  uint32_t flags = SNAPSHOT_NONE;
+
+  Camera::CameraState camera{};
+  SnapshotSceneState scene;
+  SnapshotToolState tools;
+
+  // Thumbnail: downscaled RGB pixels (top-down) and the GL texture built from
+  // them for display in the GUI. The texture is owned by the snapshot and
+  // released through SnapshotManager::remove()/clear().
+  std::vector<unsigned char> thumbnailRGB;
+  int thumbWidth = 0;
+  int thumbHeight = 0;
+  GLuint thumbnailTexture = 0;
+
+  Snapshot() = default;
+  Snapshot(const Snapshot &) = delete;
+  Snapshot &operator=(const Snapshot &) = delete;
+  Snapshot(Snapshot &&) = default;
+  Snapshot &operator=(Snapshot &&) = default;
+};
+
+class SnapshotManager {
+public:
+  static SnapshotManager &instance();
+
+  // Capture a new snapshot of the requested aspects. `fullRGB` is an upright
+  // (top-down) RGB image of the viewer at `fullWidth` x `fullHeight`; it is
+  // downscaled into a thumbnail and uploaded to a GL texture, so this must be
+  // called with a current GL context. Returns the stored snapshot.
+  Snapshot &create(const std::string &name, uint32_t flags,
+                   const Camera &camera, const Engine::Scene &scene,
+                   const std::vector<Engine::PointLight> &pointLights,
+                   const std::vector<Engine::SpotLight> &spotLights,
+                   const Engine::Sun &sun, const Tools::BrushTool &brush,
+                   const Tools::MeasurementTool &measure,
+                   const Tools::ClipPlaneTool &clip,
+                   const std::vector<unsigned char> &fullRGB, int fullWidth,
+                   int fullHeight);
+
+  // Apply a snapshot's saved aspects back onto the live globals.
+  void restore(const Snapshot &snap, Camera &camera, Engine::Scene &scene,
+               std::vector<Engine::PointLight> &pointLights,
+               std::vector<Engine::SpotLight> &spotLights, Engine::Sun &sun,
+               Tools::BrushTool &brush, Tools::MeasurementTool &measure,
+               Tools::ClipPlaneTool &clip);
+
+  std::vector<Snapshot> &snapshots() { return m_snapshots; }
+  const std::vector<Snapshot> &snapshots() const { return m_snapshots; }
+
+  // Delete a single snapshot (releases its GL texture). Requires a current GL
+  // context.
+  void remove(int index);
+  // Delete all snapshots (releases their GL textures).
+  void clear();
+
+private:
+  SnapshotManager() = default;
+  std::vector<Snapshot> m_snapshots;
+};
+
+// ---- Glue implemented in main.cpp (operate on the live application globals) ----
+
+// Arm a deferred snapshot capture: the next clean (GUI-free) frame is read
+// from the viewer and turned into a snapshot with the given name/flags.
+void RequestSnapshotCapture(const std::string &name, uint32_t flags);
+
+// Restore the snapshot at `index` onto the live scene/camera/tools.
+void RestoreSnapshot(int index);
+
+} // namespace Core

--- a/StereoVista/headers/Core/SnapshotManager.h
+++ b/StereoVista/headers/Core/SnapshotManager.h
@@ -27,9 +27,12 @@ namespace Core {
 // the scene, only the tools, or any combination. Every snapshot also keeps a
 // thumbnail captured from the viewer when it was taken.
 //
-// Snapshots live for the duration of the session (they are not serialized to
-// disk). Scene restore re-applies object transforms / materials by index and
-// fully replaces the lights, sun, measurements and clip planes; it does not
+// Thumbnails are written to a per-session temporary folder on disk as PNG
+// (not kept in RAM); when a scene is saved each snapshot's data and thumbnail
+// are persisted into the scene directory, and loaded back with the scene.
+//
+// Scene restore re-applies object transforms / materials by index and fully
+// replaces the lights, sun, measurements and clip planes; it does not
 // re-create objects that were deleted after the snapshot was taken.
 // -----------------------------------------------------------------------
 
@@ -88,10 +91,10 @@ struct Snapshot {
   SnapshotSceneState scene;
   SnapshotToolState tools;
 
-  // Thumbnail: downscaled RGB pixels (top-down) and the GL texture built from
-  // them for display in the GUI. The texture is owned by the snapshot and
-  // released through SnapshotManager::remove()/clear().
-  std::vector<unsigned char> thumbnailRGB;
+  // Thumbnail: a downscaled PNG written to disk (thumbnailPath) plus the GL
+  // texture built from it for display in the GUI. The texture is owned by the
+  // snapshot and released through SnapshotManager::remove()/clear().
+  std::string thumbnailPath;
   int thumbWidth = 0;
   int thumbHeight = 0;
   GLuint thumbnailTexture = 0;
@@ -137,9 +140,20 @@ public:
   // Delete all snapshots (releases their GL textures).
   void clear();
 
+  // Persist every snapshot (metadata + thumbnail PNG) into the scene's
+  // directory so they are saved with the scene. `sceneFile` is the .scene path
+  // passed to Engine::saveScene.
+  void saveToScene(const std::string &sceneFile);
+  // Replace the in-memory snapshots with those stored alongside `sceneFile`
+  // (the inverse of saveToScene). Recreates the thumbnail GL textures, so this
+  // must be called with a current GL context. Does nothing if the scene has no
+  // saved snapshots.
+  void loadFromScene(const std::string &sceneFile);
+
 private:
   SnapshotManager() = default;
   std::vector<Snapshot> m_snapshots;
+  int m_captureCounter = 0; // for unique thumbnail filenames this session
 };
 
 // ---- Glue implemented in main.cpp (operate on the live application globals) ----

--- a/StereoVista/headers/Engine/Screenshot.h
+++ b/StereoVista/headers/Engine/Screenshot.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace Engine {
 namespace Screenshot {
@@ -12,6 +13,16 @@ namespace Screenshot {
 // dependency.
 bool writePNG(const std::string &path, int width, int height, int channels,
               const unsigned char *pixels);
+
+// Read a rectangular region from the default framebuffer's color buffer into
+// an in-memory RGB buffer (3 channels). `readBuffer` selects the source buffer
+// (e.g. GL_BACK, GL_BACK_LEFT). The returned rows are flipped vertically so
+// the image is upright (top-to-bottom), matching captureToPNG. `outWidth` and
+// `outHeight` receive the captured dimensions. Returns true on success.
+bool captureToMemory(int x, int y, int width, int height,
+                     unsigned int readBuffer,
+                     std::vector<unsigned char> &outPixels, int &outWidth,
+                     int &outHeight);
 
 // Read a rectangular region from the default framebuffer's color buffer and
 // save it to a PNG file. `readBuffer` selects the source buffer (e.g.

--- a/StereoVista/headers/Gui/Gui.h
+++ b/StereoVista/headers/Gui/Gui.h
@@ -47,6 +47,7 @@ void renderCursorSettingsWindow();
 void renderBrushToolWindow();
 void renderMeasurementToolWindow();
 void renderClipPlaneToolWindow();
+void renderSnapshotsWindow();
 void renderSunManipulationPanel();
 void renderModelManipulationPanel(Engine::Model &model, Engine::Shader *shader);
 void renderMeshManipulationPanel(Engine::Model &model, int meshIndex,

--- a/StereoVista/src/Core/SnapshotManager.cpp
+++ b/StereoVista/src/Core/SnapshotManager.cpp
@@ -1,9 +1,20 @@
 #include "Core/SnapshotManager.h"
 
+#include "Engine/Screenshot.h"
+
 #include <algorithm>
 #include <ctime>
+#include <filesystem>
+#include <fstream>
 #include <iomanip>
+#include <iostream>
 #include <sstream>
+
+#include <json.h>
+#include <stb_image.h>
+
+using json = nlohmann::json;
+namespace fs = std::filesystem;
 
 namespace Core {
 
@@ -22,6 +33,352 @@ std::string nowTimestamp() {
   ss << std::put_time(&tmBuf, "%Y-%m-%d %H:%M:%S");
   return ss.str();
 }
+
+// The per-session folder where freshly captured thumbnails are written. Created
+// once on first use and reused for the lifetime of the process.
+const fs::path &sessionThumbDir() {
+  static fs::path dir = [] {
+    std::time_t t = std::time(nullptr);
+    fs::path d = fs::temp_directory_path() /
+                 ("StereoVista_snapshots_" + std::to_string(static_cast<long long>(t)));
+    std::error_code ec;
+    fs::create_directories(d, ec);
+    return d;
+  }();
+  return dir;
+}
+
+// Resolve the scene's asset directory the same way Engine::saveScene /
+// loadScene do: "<parent>/<stem>" of the .scene path.
+fs::path sceneDirOf(const std::string &sceneFile) {
+  fs::path p(sceneFile);
+  if (p.extension() != ".scene")
+    p.replace_extension(".scene");
+  return p.parent_path() / p.stem();
+}
+
+// ---- JSON helpers -------------------------------------------------------
+
+json vec3ToJson(const glm::vec3 &v) { return json::array({v.x, v.y, v.z}); }
+
+glm::vec3 jsonToVec3(const json &j, const glm::vec3 &def) {
+  if (j.is_array() && j.size() == 3)
+    return glm::vec3(j[0].get<float>(), j[1].get<float>(), j[2].get<float>());
+  return def;
+}
+
+json modelStateToJson(const Engine::Undo::ModelEditState &m) {
+  json j;
+  j["position"] = vec3ToJson(m.position);
+  j["rotation"] = vec3ToJson(m.rotation);
+  j["scale"] = vec3ToJson(m.scale);
+  j["visible"] = m.visible;
+  j["color"] = vec3ToJson(m.color);
+  j["shininess"] = m.shininess;
+  j["emissive"] = m.emissive;
+  j["metallicFactor"] = m.metallicFactor;
+  j["roughnessFactor"] = m.roughnessFactor;
+  j["F0"] = vec3ToJson(m.F0);
+  j["normalScale"] = m.normalScale;
+  j["heightScale"] = m.heightScale;
+  j["diffuseReflectivity"] = m.diffuseReflectivity;
+  j["specularColor"] = vec3ToJson(m.specularColor);
+  j["specularDiffusion"] = m.specularDiffusion;
+  j["specularReflectivity"] = m.specularReflectivity;
+  j["refractiveIndex"] = m.refractiveIndex;
+  j["transparency"] = m.transparency;
+  j["materialType"] = static_cast<int>(m.materialType);
+  json meshes = json::array();
+  for (const auto &mm : m.meshMaterials) {
+    json mj;
+    mj["visible"] = mm.visible;
+    mj["color"] = vec3ToJson(mm.color);
+    mj["shininess"] = mm.shininess;
+    mj["emissive"] = mm.emissive;
+    meshes.push_back(mj);
+  }
+  j["meshMaterials"] = meshes;
+  return j;
+}
+
+Engine::Undo::ModelEditState modelStateFromJson(const json &j) {
+  Engine::Undo::ModelEditState m;
+  m.position = jsonToVec3(j.value("position", json()), m.position);
+  m.rotation = jsonToVec3(j.value("rotation", json()), m.rotation);
+  m.scale = jsonToVec3(j.value("scale", json()), m.scale);
+  m.visible = j.value("visible", m.visible);
+  m.color = jsonToVec3(j.value("color", json()), m.color);
+  m.shininess = j.value("shininess", m.shininess);
+  m.emissive = j.value("emissive", m.emissive);
+  m.metallicFactor = j.value("metallicFactor", m.metallicFactor);
+  m.roughnessFactor = j.value("roughnessFactor", m.roughnessFactor);
+  m.F0 = jsonToVec3(j.value("F0", json()), m.F0);
+  m.normalScale = j.value("normalScale", m.normalScale);
+  m.heightScale = j.value("heightScale", m.heightScale);
+  m.diffuseReflectivity = j.value("diffuseReflectivity", m.diffuseReflectivity);
+  m.specularColor = jsonToVec3(j.value("specularColor", json()), m.specularColor);
+  m.specularDiffusion = j.value("specularDiffusion", m.specularDiffusion);
+  m.specularReflectivity = j.value("specularReflectivity", m.specularReflectivity);
+  m.refractiveIndex = j.value("refractiveIndex", m.refractiveIndex);
+  m.transparency = j.value("transparency", m.transparency);
+  m.materialType =
+      static_cast<decltype(m.materialType)>(j.value("materialType", 0));
+  if (j.contains("meshMaterials") && j["meshMaterials"].is_array()) {
+    for (const auto &mj : j["meshMaterials"]) {
+      Engine::Undo::MeshMaterialState mm;
+      mm.visible = mj.value("visible", mm.visible);
+      mm.color = jsonToVec3(mj.value("color", json()), mm.color);
+      mm.shininess = mj.value("shininess", mm.shininess);
+      mm.emissive = mj.value("emissive", mm.emissive);
+      m.meshMaterials.push_back(mm);
+    }
+  }
+  return m;
+}
+
+json cloudStateToJson(const Engine::Undo::PointCloudEditState &p) {
+  json j;
+  j["position"] = vec3ToJson(p.position);
+  j["rotation"] = vec3ToJson(p.rotation);
+  j["scale"] = vec3ToJson(p.scale);
+  j["visible"] = p.visible;
+  j["basePointSize"] = p.basePointSize;
+  return j;
+}
+
+Engine::Undo::PointCloudEditState cloudStateFromJson(const json &j) {
+  Engine::Undo::PointCloudEditState p;
+  p.position = jsonToVec3(j.value("position", json()), p.position);
+  p.rotation = jsonToVec3(j.value("rotation", json()), p.rotation);
+  p.scale = jsonToVec3(j.value("scale", json()), p.scale);
+  p.visible = j.value("visible", p.visible);
+  p.basePointSize = j.value("basePointSize", p.basePointSize);
+  return p;
+}
+
+json sceneStateToJson(const SnapshotSceneState &s) {
+  json j;
+  json models = json::array();
+  for (const auto &m : s.models)
+    models.push_back(modelStateToJson(m));
+  j["models"] = models;
+
+  json clouds = json::array();
+  for (const auto &p : s.pointClouds)
+    clouds.push_back(cloudStateToJson(p));
+  j["pointClouds"] = clouds;
+
+  json plights = json::array();
+  for (const auto &l : s.pointLights) {
+    json lj;
+    lj["position"] = vec3ToJson(l.position);
+    lj["color"] = vec3ToJson(l.color);
+    lj["intensity"] = l.intensity;
+    lj["linear"] = l.linear;
+    lj["quadratic"] = l.quadratic;
+    lj["castShadows"] = l.castShadows;
+    plights.push_back(lj);
+  }
+  j["pointLights"] = plights;
+
+  json slights = json::array();
+  for (const auto &l : s.spotLights) {
+    json lj;
+    lj["position"] = vec3ToJson(l.position);
+    lj["direction"] = vec3ToJson(l.direction);
+    lj["color"] = vec3ToJson(l.color);
+    lj["intensity"] = l.intensity;
+    lj["innerCutOff"] = l.innerCutOff;
+    lj["outerCutOff"] = l.outerCutOff;
+    lj["castShadows"] = l.castShadows;
+    slights.push_back(lj);
+  }
+  j["spotLights"] = slights;
+
+  json meas = json::array();
+  for (const auto &m : s.measurements) {
+    json mj;
+    mj["type"] = static_cast<int>(m.type);
+    mj["name"] = m.name;
+    mj["color"] = vec3ToJson(m.color);
+    mj["visible"] = m.visible;
+    json pts = json::array();
+    for (const auto &p : m.points)
+      pts.push_back(vec3ToJson(p));
+    mj["points"] = pts;
+    meas.push_back(mj);
+  }
+  j["measurements"] = meas;
+
+  json planes = json::array();
+  for (const auto &c : s.clipPlanes) {
+    json cj;
+    cj["name"] = c.name;
+    cj["position"] = vec3ToJson(c.position);
+    cj["normal"] = vec3ToJson(c.normal);
+    cj["color"] = vec3ToJson(c.color);
+    cj["enabled"] = c.enabled;
+    planes.push_back(cj);
+  }
+  j["clipPlanes"] = planes;
+
+  json sun;
+  sun["direction"] = vec3ToJson(s.sun.direction);
+  sun["color"] = vec3ToJson(s.sun.color);
+  sun["intensity"] = s.sun.intensity;
+  sun["enabled"] = s.sun.enabled;
+  j["sun"] = sun;
+
+  return j;
+}
+
+SnapshotSceneState sceneStateFromJson(const json &j) {
+  SnapshotSceneState s;
+  if (j.contains("models"))
+    for (const auto &m : j["models"])
+      s.models.push_back(modelStateFromJson(m));
+  if (j.contains("pointClouds"))
+    for (const auto &p : j["pointClouds"])
+      s.pointClouds.push_back(cloudStateFromJson(p));
+  if (j.contains("pointLights")) {
+    for (const auto &lj : j["pointLights"]) {
+      Engine::PointLight l;
+      l.position = jsonToVec3(lj.value("position", json()), glm::vec3(0.0f));
+      l.color = jsonToVec3(lj.value("color", json()), glm::vec3(1.0f));
+      l.intensity = lj.value("intensity", 1.0f);
+      l.linear = lj.value("linear", l.linear);
+      l.quadratic = lj.value("quadratic", l.quadratic);
+      l.castShadows = lj.value("castShadows", l.castShadows);
+      s.pointLights.push_back(l);
+    }
+  }
+  if (j.contains("spotLights")) {
+    for (const auto &lj : j["spotLights"]) {
+      Engine::SpotLight l;
+      l.position = jsonToVec3(lj.value("position", json()), glm::vec3(0.0f));
+      l.direction = jsonToVec3(lj.value("direction", json()), glm::vec3(0, -1, 0));
+      l.color = jsonToVec3(lj.value("color", json()), glm::vec3(1.0f));
+      l.intensity = lj.value("intensity", 1.0f);
+      l.innerCutOff = lj.value("innerCutOff", 0.9f);
+      l.outerCutOff = lj.value("outerCutOff", 0.82f);
+      l.castShadows = lj.value("castShadows", true);
+      s.spotLights.push_back(l);
+    }
+  }
+  if (j.contains("measurements")) {
+    for (const auto &mj : j["measurements"]) {
+      Engine::Measurement m;
+      m.type = static_cast<Engine::Measurement::Type>(mj.value("type", 0));
+      m.name = mj.value("name", std::string("Measurement"));
+      m.color = jsonToVec3(mj.value("color", json()), m.color);
+      m.visible = mj.value("visible", true);
+      if (mj.contains("points"))
+        for (const auto &p : mj["points"])
+          m.points.push_back(jsonToVec3(p, glm::vec3(0.0f)));
+      s.measurements.push_back(m);
+    }
+  }
+  if (j.contains("clipPlanes")) {
+    for (const auto &cj : j["clipPlanes"]) {
+      Engine::ClipPlane c;
+      c.name = cj.value("name", std::string("Plane"));
+      c.position = jsonToVec3(cj.value("position", json()), c.position);
+      c.normal = jsonToVec3(cj.value("normal", json()), c.normal);
+      c.color = jsonToVec3(cj.value("color", json()), c.color);
+      c.enabled = cj.value("enabled", true);
+      s.clipPlanes.push_back(c);
+    }
+  }
+  if (j.contains("sun")) {
+    const auto &sj = j["sun"];
+    s.sun.direction = jsonToVec3(sj.value("direction", json()), glm::vec3(0, -1, 0));
+    s.sun.color = jsonToVec3(sj.value("color", json()), glm::vec3(1.0f));
+    s.sun.intensity = sj.value("intensity", 1.0f);
+    s.sun.enabled = sj.value("enabled", true);
+  }
+  return s;
+}
+
+json toolStateToJson(const SnapshotToolState &t) {
+  json j;
+  j["brushEnabled"] = t.brushEnabled;
+  j["brushRadius"] = t.brushRadius;
+  j["brushDensity"] = t.brushDensity;
+  j["brushMinSpacing"] = t.brushMinSpacing;
+  j["brushSelectedModel"] = t.brushSelectedModel;
+  j["measureEnabled"] = t.measureEnabled;
+  j["measureMode"] = t.measureMode;
+  j["measureLineWidth"] = t.measureLineWidth;
+  j["measureShowLabels"] = t.measureShowLabels;
+  j["measureShowSegmentLabels"] = t.measureShowSegmentLabels;
+  j["measureXRay"] = t.measureXRay;
+  j["measureUnitScale"] = t.measureUnitScale;
+  j["measureUnitSuffix"] = t.measureUnitSuffix;
+  j["measureNextColor"] = vec3ToJson(t.measureNextColor);
+  j["clipEnabled"] = t.clipEnabled;
+  j["clipDisplaySize"] = t.clipDisplaySize;
+  j["clipNudgeStep"] = t.clipNudgeStep;
+  j["clipActiveIndex"] = t.clipActiveIndex;
+  return j;
+}
+
+SnapshotToolState toolStateFromJson(const json &j) {
+  SnapshotToolState t;
+  t.brushEnabled = j.value("brushEnabled", t.brushEnabled);
+  t.brushRadius = j.value("brushRadius", t.brushRadius);
+  t.brushDensity = j.value("brushDensity", t.brushDensity);
+  t.brushMinSpacing = j.value("brushMinSpacing", t.brushMinSpacing);
+  t.brushSelectedModel = j.value("brushSelectedModel", t.brushSelectedModel);
+  t.measureEnabled = j.value("measureEnabled", t.measureEnabled);
+  t.measureMode = j.value("measureMode", t.measureMode);
+  t.measureLineWidth = j.value("measureLineWidth", t.measureLineWidth);
+  t.measureShowLabels = j.value("measureShowLabels", t.measureShowLabels);
+  t.measureShowSegmentLabels =
+      j.value("measureShowSegmentLabels", t.measureShowSegmentLabels);
+  t.measureXRay = j.value("measureXRay", t.measureXRay);
+  t.measureUnitScale = j.value("measureUnitScale", t.measureUnitScale);
+  t.measureUnitSuffix = j.value("measureUnitSuffix", t.measureUnitSuffix);
+  t.measureNextColor = jsonToVec3(j.value("measureNextColor", json()), t.measureNextColor);
+  t.clipEnabled = j.value("clipEnabled", t.clipEnabled);
+  t.clipDisplaySize = j.value("clipDisplaySize", t.clipDisplaySize);
+  t.clipNudgeStep = j.value("clipNudgeStep", t.clipNudgeStep);
+  t.clipActiveIndex = j.value("clipActiveIndex", t.clipActiveIndex);
+  return t;
+}
+
+json cameraStateToJson(const Camera::CameraState &c) {
+  json j;
+  j["position"] = vec3ToJson(c.position);
+  j["front"] = vec3ToJson(c.front);
+  j["up"] = vec3ToJson(c.up);
+  j["yaw"] = c.yaw;
+  j["pitch"] = c.pitch;
+  j["zoom"] = c.zoom;
+  j["orientation"] =
+      json::array({c.orientation.x, c.orientation.y, c.orientation.z, c.orientation.w});
+  return j;
+}
+
+Camera::CameraState cameraStateFromJson(const json &j) {
+  Camera::CameraState c{};
+  c.position = jsonToVec3(j.value("position", json()), glm::vec3(0.0f));
+  c.front = jsonToVec3(j.value("front", json()), glm::vec3(0, 0, -1));
+  c.up = jsonToVec3(j.value("up", json()), glm::vec3(0, 1, 0));
+  c.yaw = j.value("yaw", -90.0f);
+  c.pitch = j.value("pitch", 0.0f);
+  c.zoom = j.value("zoom", 45.0f);
+  if (j.contains("orientation") && j["orientation"].is_array() &&
+      j["orientation"].size() == 4) {
+    const auto &o = j["orientation"];
+    c.orientation = glm::quat(o[3].get<float>(), o[0].get<float>(),
+                              o[1].get<float>(), o[2].get<float>());
+  } else {
+    c.orientation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+  }
+  return c;
+}
+
+// ---- Thumbnail pixel helpers --------------------------------------------
 
 // Nearest-neighbour downscale of an upright (top-down) RGB image so its
 // largest side is at most `maxDim`. Keeps aspect ratio; never upscales.
@@ -48,8 +405,7 @@ void downscaleRGB(const std::vector<unsigned char> &src, int srcW, int srcH,
     int sy = std::min(srcH - 1, static_cast<int>(y / scale));
     for (int x = 0; x < dstW; ++x) {
       int sx = std::min(srcW - 1, static_cast<int>(x / scale));
-      const unsigned char *s =
-          &src[(static_cast<size_t>(sy) * srcW + sx) * 3];
+      const unsigned char *s = &src[(static_cast<size_t>(sy) * srcW + sx) * 3];
       unsigned char *d = &dst[(static_cast<size_t>(y) * dstW + x) * 3];
       d[0] = s[0];
       d[1] = s[1];
@@ -61,8 +417,8 @@ void downscaleRGB(const std::vector<unsigned char> &src, int srcW, int srcH,
 // Upload an upright (top-down) RGB image to a freshly created GL texture.
 // Returns 0 on failure. With top-down data and ImGui's default UVs the image
 // displays upright.
-GLuint uploadThumbnail(const std::vector<unsigned char> &rgb, int w, int h) {
-  if (w <= 0 || h <= 0 || rgb.size() < static_cast<size_t>(w) * h * 3)
+GLuint uploadThumbnail(const unsigned char *rgb, int w, int h) {
+  if (!rgb || w <= 0 || h <= 0)
     return 0;
 
   GLuint tex = 0;
@@ -77,8 +433,7 @@ GLuint uploadThumbnail(const std::vector<unsigned char> &rgb, int w, int h) {
 
   glBindTexture(GL_TEXTURE_2D, tex);
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, w, h, 0, GL_RGB, GL_UNSIGNED_BYTE,
-               rgb.data());
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, w, h, 0, GL_RGB, GL_UNSIGNED_BYTE, rgb);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
@@ -86,6 +441,23 @@ GLuint uploadThumbnail(const std::vector<unsigned char> &rgb, int w, int h) {
 
   glPixelStorei(GL_UNPACK_ALIGNMENT, prevAlign);
   glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(prevTex));
+  return tex;
+}
+
+// Load a PNG from disk and upload it as a thumbnail texture. Fills outW/outH.
+GLuint loadThumbnailTexture(const std::string &path, int &outW, int &outH) {
+  outW = outH = 0;
+  if (path.empty())
+    return 0;
+  int w = 0, h = 0, n = 0;
+  // Force 3 channels; stb_image returns rows top-to-bottom (upright).
+  unsigned char *data = stbi_load(path.c_str(), &w, &h, &n, 3);
+  if (!data)
+    return 0;
+  GLuint tex = uploadThumbnail(data, w, h);
+  stbi_image_free(data);
+  outW = w;
+  outH = h;
   return tex;
 }
 
@@ -156,11 +528,24 @@ Snapshot &SnapshotManager::create(
     t.clipActiveIndex = clip.activeIndex();
   }
 
-  // Thumbnail (always captured) -------------------------------------------
-  downscaleRGB(fullRGB, fullWidth, fullHeight, 320, snap.thumbnailRGB,
-               snap.thumbWidth, snap.thumbHeight);
-  snap.thumbnailTexture =
-      uploadThumbnail(snap.thumbnailRGB, snap.thumbWidth, snap.thumbHeight);
+  // Thumbnail (always captured): downscale, write to the session temp folder
+  // as PNG, then upload a GL texture for display. The full pixels are not
+  // retained in memory.
+  std::vector<unsigned char> thumb;
+  downscaleRGB(fullRGB, fullWidth, fullHeight, 320, thumb, snap.thumbWidth,
+               snap.thumbHeight);
+  if (!thumb.empty()) {
+    std::ostringstream fn;
+    fn << "snapshot_" << m_captureCounter++ << "_" << std::time(nullptr)
+       << ".png";
+    fs::path path = sessionThumbDir() / fn.str();
+    if (Engine::Screenshot::writePNG(path.string(), snap.thumbWidth,
+                                     snap.thumbHeight, 3, thumb.data())) {
+      snap.thumbnailPath = path.string();
+    }
+    snap.thumbnailTexture =
+        uploadThumbnail(thumb.data(), snap.thumbWidth, snap.thumbHeight);
+  }
 
   m_snapshots.push_back(std::move(snap));
   return m_snapshots.back();
@@ -249,6 +634,100 @@ void SnapshotManager::clear() {
       glDeleteTextures(1, &snap.thumbnailTexture);
   }
   m_snapshots.clear();
+}
+
+void SnapshotManager::saveToScene(const std::string &sceneFile) {
+  try {
+    fs::path dir = sceneDirOf(sceneFile);
+    fs::path thumbDir = dir / "snapshots";
+    std::error_code ec;
+    fs::create_directories(thumbDir, ec);
+
+    json root;
+    root["snapshots"] = json::array();
+    for (size_t i = 0; i < m_snapshots.size(); ++i) {
+      const Snapshot &s = m_snapshots[i];
+      json j;
+      j["name"] = s.name;
+      j["timestamp"] = s.timestamp;
+      j["flags"] = s.flags;
+      if (s.flags & SNAPSHOT_CAMERA)
+        j["camera"] = cameraStateToJson(s.camera);
+      if (s.flags & SNAPSHOT_SCENE)
+        j["scene"] = sceneStateToJson(s.scene);
+      if (s.flags & SNAPSHOT_TOOLS)
+        j["tools"] = toolStateToJson(s.tools);
+
+      // Copy the thumbnail PNG into the scene directory, preserving each
+      // snapshot's own (unique) filename so reordering/deletion can't make one
+      // copy clobber another's source.
+      if (!s.thumbnailPath.empty() && fs::exists(s.thumbnailPath)) {
+        std::string thumbName = fs::path(s.thumbnailPath).filename().string();
+        fs::path dst = thumbDir / thumbName;
+        try {
+          std::error_code cmpEc;
+          bool sameFile = fs::exists(dst) &&
+                          fs::equivalent(s.thumbnailPath, dst, cmpEc) && !cmpEc;
+          if (!sameFile)
+            fs::copy_file(s.thumbnailPath, dst,
+                          fs::copy_options::overwrite_existing);
+          j["thumbnail"] = "snapshots/" + thumbName;
+        } catch (const std::exception &e) {
+          std::cerr << "Snapshot thumbnail copy failed: " << e.what()
+                    << std::endl;
+        }
+      }
+      root["snapshots"].push_back(j);
+    }
+
+    std::ofstream out(dir / "snapshots.json");
+    if (out.is_open())
+      out << root.dump(2);
+  } catch (const std::exception &e) {
+    std::cerr << "Failed to save snapshots: " << e.what() << std::endl;
+  }
+}
+
+void SnapshotManager::loadFromScene(const std::string &sceneFile) {
+  // Always start from a clean slate so snapshots match the loaded scene.
+  clear();
+
+  try {
+    fs::path dir = sceneDirOf(sceneFile);
+    fs::path jsonPath = dir / "snapshots.json";
+    if (!fs::exists(jsonPath))
+      return;
+
+    std::ifstream in(jsonPath);
+    if (!in.is_open())
+      return;
+    json root;
+    in >> root;
+    if (!root.contains("snapshots") || !root["snapshots"].is_array())
+      return;
+
+    for (const auto &j : root["snapshots"]) {
+      Snapshot s;
+      s.name = j.value("name", std::string("Snapshot"));
+      s.timestamp = j.value("timestamp", std::string());
+      s.flags = j.value("flags", 0u);
+      if (j.contains("camera"))
+        s.camera = cameraStateFromJson(j["camera"]);
+      if (j.contains("scene"))
+        s.scene = sceneStateFromJson(j["scene"]);
+      if (j.contains("tools"))
+        s.tools = toolStateFromJson(j["tools"]);
+      if (j.contains("thumbnail")) {
+        fs::path thumb = dir / j["thumbnail"].get<std::string>();
+        s.thumbnailPath = thumb.string();
+        s.thumbnailTexture =
+            loadThumbnailTexture(s.thumbnailPath, s.thumbWidth, s.thumbHeight);
+      }
+      m_snapshots.push_back(std::move(s));
+    }
+  } catch (const std::exception &e) {
+    std::cerr << "Failed to load snapshots: " << e.what() << std::endl;
+  }
 }
 
 } // namespace Core

--- a/StereoVista/src/Core/SnapshotManager.cpp
+++ b/StereoVista/src/Core/SnapshotManager.cpp
@@ -1,0 +1,254 @@
+#include "Core/SnapshotManager.h"
+
+#include <algorithm>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+
+namespace Core {
+
+namespace {
+
+// Build a human-readable "YYYY-MM-DD HH:MM:SS" timestamp for display.
+std::string nowTimestamp() {
+  std::time_t t = std::time(nullptr);
+  std::tm tmBuf{};
+#if defined(_WIN32)
+  localtime_s(&tmBuf, &t);
+#else
+  localtime_r(&t, &tmBuf);
+#endif
+  std::ostringstream ss;
+  ss << std::put_time(&tmBuf, "%Y-%m-%d %H:%M:%S");
+  return ss.str();
+}
+
+// Nearest-neighbour downscale of an upright (top-down) RGB image so its
+// largest side is at most `maxDim`. Keeps aspect ratio; never upscales.
+void downscaleRGB(const std::vector<unsigned char> &src, int srcW, int srcH,
+                  int maxDim, std::vector<unsigned char> &dst, int &dstW,
+                  int &dstH) {
+  if (srcW <= 0 || srcH <= 0 ||
+      src.size() < static_cast<size_t>(srcW) * srcH * 3) {
+    dst.clear();
+    dstW = dstH = 0;
+    return;
+  }
+
+  float scale = 1.0f;
+  int largest = std::max(srcW, srcH);
+  if (largest > maxDim)
+    scale = static_cast<float>(maxDim) / static_cast<float>(largest);
+
+  dstW = std::max(1, static_cast<int>(srcW * scale));
+  dstH = std::max(1, static_cast<int>(srcH * scale));
+
+  dst.assign(static_cast<size_t>(dstW) * dstH * 3, 0);
+  for (int y = 0; y < dstH; ++y) {
+    int sy = std::min(srcH - 1, static_cast<int>(y / scale));
+    for (int x = 0; x < dstW; ++x) {
+      int sx = std::min(srcW - 1, static_cast<int>(x / scale));
+      const unsigned char *s =
+          &src[(static_cast<size_t>(sy) * srcW + sx) * 3];
+      unsigned char *d = &dst[(static_cast<size_t>(y) * dstW + x) * 3];
+      d[0] = s[0];
+      d[1] = s[1];
+      d[2] = s[2];
+    }
+  }
+}
+
+// Upload an upright (top-down) RGB image to a freshly created GL texture.
+// Returns 0 on failure. With top-down data and ImGui's default UVs the image
+// displays upright.
+GLuint uploadThumbnail(const std::vector<unsigned char> &rgb, int w, int h) {
+  if (w <= 0 || h <= 0 || rgb.size() < static_cast<size_t>(w) * h * 3)
+    return 0;
+
+  GLuint tex = 0;
+  glGenTextures(1, &tex);
+  if (tex == 0)
+    return 0;
+
+  GLint prevAlign = 4;
+  glGetIntegerv(GL_UNPACK_ALIGNMENT, &prevAlign);
+  GLint prevTex = 0;
+  glGetIntegerv(GL_TEXTURE_BINDING_2D, &prevTex);
+
+  glBindTexture(GL_TEXTURE_2D, tex);
+  glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, w, h, 0, GL_RGB, GL_UNSIGNED_BYTE,
+               rgb.data());
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+  glPixelStorei(GL_UNPACK_ALIGNMENT, prevAlign);
+  glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(prevTex));
+  return tex;
+}
+
+} // namespace
+
+SnapshotManager &SnapshotManager::instance() {
+  static SnapshotManager s;
+  return s;
+}
+
+Snapshot &SnapshotManager::create(
+    const std::string &name, uint32_t flags, const Camera &camera,
+    const Engine::Scene &scene,
+    const std::vector<Engine::PointLight> &pointLights,
+    const std::vector<Engine::SpotLight> &spotLights, const Engine::Sun &sun,
+    const Tools::BrushTool &brush, const Tools::MeasurementTool &measure,
+    const Tools::ClipPlaneTool &clip, const std::vector<unsigned char> &fullRGB,
+    int fullWidth, int fullHeight) {
+  Snapshot snap;
+  snap.name = name.empty() ? "Snapshot" : name;
+  snap.timestamp = nowTimestamp();
+  snap.flags = flags;
+
+  // Camera ----------------------------------------------------------------
+  if (flags & SNAPSHOT_CAMERA)
+    snap.camera = camera.GetState();
+
+  // Scene -----------------------------------------------------------------
+  if (flags & SNAPSHOT_SCENE) {
+    snap.scene.models.reserve(scene.models.size());
+    for (const auto &m : scene.models)
+      snap.scene.models.push_back(Engine::Undo::ModelEditState::capture(m));
+
+    snap.scene.pointClouds.reserve(scene.pointClouds.size());
+    for (const auto &pc : scene.pointClouds)
+      snap.scene.pointClouds.push_back(
+          Engine::Undo::PointCloudEditState::capture(pc));
+
+    snap.scene.pointLights = pointLights;
+    snap.scene.spotLights = spotLights;
+    snap.scene.measurements = scene.measurements;
+    snap.scene.clipPlanes = scene.clipPlanes;
+    snap.scene.sun = sun;
+  }
+
+  // Tools -----------------------------------------------------------------
+  if (flags & SNAPSHOT_TOOLS) {
+    SnapshotToolState &t = snap.tools;
+    t.brushEnabled = brush.isEnabled();
+    t.brushRadius = brush.getBrushRadius();
+    t.brushDensity = brush.getDensity();
+    t.brushMinSpacing = brush.getMinSpacing();
+    t.brushSelectedModel = brush.getSelectedModel();
+
+    t.measureEnabled = measure.isEnabled();
+    t.measureMode = static_cast<int>(measure.getMode());
+    t.measureLineWidth = measure.lineWidth;
+    t.measureShowLabels = measure.showLabels;
+    t.measureShowSegmentLabels = measure.showSegmentLabels;
+    t.measureXRay = measure.xRay;
+    t.measureUnitScale = measure.unitScale;
+    t.measureUnitSuffix = measure.unitSuffix;
+    t.measureNextColor = measure.nextColor;
+
+    t.clipEnabled = clip.isEnabled();
+    t.clipDisplaySize = clip.displaySize;
+    t.clipNudgeStep = clip.nudgeStep;
+    t.clipActiveIndex = clip.activeIndex();
+  }
+
+  // Thumbnail (always captured) -------------------------------------------
+  downscaleRGB(fullRGB, fullWidth, fullHeight, 320, snap.thumbnailRGB,
+               snap.thumbWidth, snap.thumbHeight);
+  snap.thumbnailTexture =
+      uploadThumbnail(snap.thumbnailRGB, snap.thumbWidth, snap.thumbHeight);
+
+  m_snapshots.push_back(std::move(snap));
+  return m_snapshots.back();
+}
+
+void SnapshotManager::restore(const Snapshot &snap, Camera &camera,
+                              Engine::Scene &scene,
+                              std::vector<Engine::PointLight> &pointLights,
+                              std::vector<Engine::SpotLight> &spotLights,
+                              Engine::Sun &sun, Tools::BrushTool &brush,
+                              Tools::MeasurementTool &measure,
+                              Tools::ClipPlaneTool &clip) {
+  // Camera ----------------------------------------------------------------
+  if (snap.flags & SNAPSHOT_CAMERA)
+    camera.SetState(snap.camera);
+
+  // Scene -----------------------------------------------------------------
+  if (snap.flags & SNAPSHOT_SCENE) {
+    // Re-apply object transforms / materials by index. Objects added or
+    // removed since the snapshot are left untouched (no GPU reload here).
+    size_t nModels = std::min(snap.scene.models.size(), scene.models.size());
+    for (size_t i = 0; i < nModels; ++i)
+      snap.scene.models[i].apply(scene.models[i]);
+
+    size_t nClouds =
+        std::min(snap.scene.pointClouds.size(), scene.pointClouds.size());
+    for (size_t i = 0; i < nClouds; ++i)
+      snap.scene.pointClouds[i].apply(scene.pointClouds[i]);
+
+    // Lights / sun / annotations are cheap to copy, so restore them fully.
+    pointLights = snap.scene.pointLights;
+    spotLights = snap.scene.spotLights;
+    scene.pointLights = snap.scene.pointLights;
+    scene.spotLights = snap.scene.spotLights;
+    // Assigning the vectors' contents keeps the same vector objects, so the
+    // tool pointers bound to scene.measurements / scene.clipPlanes stay valid.
+    scene.measurements = snap.scene.measurements;
+    scene.clipPlanes = snap.scene.clipPlanes;
+    sun = snap.scene.sun;
+
+    // Re-clamp the clip tool's active selection to the restored plane count.
+    clip.setActiveIndex(clip.activeIndex());
+  }
+
+  // Tools -----------------------------------------------------------------
+  if (snap.flags & SNAPSHOT_TOOLS) {
+    const SnapshotToolState &t = snap.tools;
+
+    brush.setBrushRadius(t.brushRadius);
+    brush.setDensity(t.brushDensity);
+    brush.setMinSpacing(t.brushMinSpacing);
+    brush.setSelectedModel(t.brushSelectedModel);
+    if (t.brushEnabled)
+      brush.enable();
+    else
+      brush.disable();
+
+    measure.setEnabled(t.measureEnabled);
+    measure.setMode(static_cast<Engine::Measurement::Type>(t.measureMode));
+    measure.lineWidth = t.measureLineWidth;
+    measure.showLabels = t.measureShowLabels;
+    measure.showSegmentLabels = t.measureShowSegmentLabels;
+    measure.xRay = t.measureXRay;
+    measure.unitScale = t.measureUnitScale;
+    measure.unitSuffix = t.measureUnitSuffix;
+    measure.nextColor = t.measureNextColor;
+
+    clip.setEnabled(t.clipEnabled);
+    clip.displaySize = t.clipDisplaySize;
+    clip.nudgeStep = t.clipNudgeStep;
+    clip.setActiveIndex(t.clipActiveIndex);
+  }
+}
+
+void SnapshotManager::remove(int index) {
+  if (index < 0 || index >= static_cast<int>(m_snapshots.size()))
+    return;
+  if (m_snapshots[index].thumbnailTexture != 0)
+    glDeleteTextures(1, &m_snapshots[index].thumbnailTexture);
+  m_snapshots.erase(m_snapshots.begin() + index);
+}
+
+void SnapshotManager::clear() {
+  for (auto &snap : m_snapshots) {
+    if (snap.thumbnailTexture != 0)
+      glDeleteTextures(1, &snap.thumbnailTexture);
+  }
+  m_snapshots.clear();
+}
+
+} // namespace Core

--- a/StereoVista/src/Engine/Screenshot.cpp
+++ b/StereoVista/src/Engine/Screenshot.cpp
@@ -155,8 +155,10 @@ bool writePNG(const std::string &path, int width, int height, int channels,
   return file.good();
 }
 
-bool captureToPNG(const std::string &path, int x, int y, int width, int height,
-                  unsigned int readBuffer) {
+bool captureToMemory(int x, int y, int width, int height,
+                     unsigned int readBuffer,
+                     std::vector<unsigned char> &outPixels, int &outWidth,
+                     int &outHeight) {
   if (width <= 0 || height <= 0)
     return false;
 
@@ -182,16 +184,27 @@ bool captureToPNG(const std::string &path, int x, int y, int width, int height,
   glReadBuffer(static_cast<GLenum>(prevReadBuffer));
   glBindFramebuffer(GL_READ_FRAMEBUFFER, prevReadFbo);
 
-  // OpenGL returns rows bottom-to-top; flip so the PNG is upright.
+  // OpenGL returns rows bottom-to-top; flip so the image is upright.
   const size_t rowBytes = static_cast<size_t>(width) * channels;
-  std::vector<unsigned char> flipped(pixels.size());
+  outPixels.assign(pixels.size(), 0);
   for (int row = 0; row < height; ++row) {
     std::copy(pixels.begin() + static_cast<size_t>(height - 1 - row) * rowBytes,
               pixels.begin() + static_cast<size_t>(height - row) * rowBytes,
-              flipped.begin() + static_cast<size_t>(row) * rowBytes);
+              outPixels.begin() + static_cast<size_t>(row) * rowBytes);
   }
+  outWidth = width;
+  outHeight = height;
+  return true;
+}
 
-  return writePNG(path, width, height, channels, flipped.data());
+bool captureToPNG(const std::string &path, int x, int y, int width, int height,
+                  unsigned int readBuffer) {
+  std::vector<unsigned char> flipped;
+  int w = 0, h = 0;
+  if (!captureToMemory(x, y, width, height, readBuffer, flipped, w, h))
+    return false;
+
+  return writePNG(path, w, h, 3, flipped.data());
 }
 
 std::string makeTimestampedPath(const std::string &directory) {

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -1203,6 +1203,9 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
       }
       spotLights = currentScene.spotLights;
 
+      // Replace the snapshot list with the ones saved for this scene.
+      Core::SnapshotManager::instance().loadFromScene(sceneFile);
+
       for (auto &model : currentScene.models) {
         glm::vec3 targetScale = model.scale;
         if (preferences.enableSpawnAnimation) {
@@ -1288,6 +1291,9 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
       pl.castShadows = true;
     }
     spotLights = currentScene.spotLights;
+
+    // Replace the snapshot list with the ones saved for this scene.
+    Core::SnapshotManager::instance().loadFromScene(sceneFile);
 
     for (auto &model : currentScene.models) {
       glm::vec3 targetScale = model.scale;
@@ -1511,6 +1517,8 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
             currentScene.pointLights = pointLights;
             currentScene.spotLights = spotLights;
             Engine::saveScene(destination, currentScene, camera);
+            // Persist this scene's snapshots (metadata + thumbnails) alongside it.
+            Core::SnapshotManager::instance().saveToScene(destination);
             GUI::UpdateWindowTitleForScene(destination);
             GUI::ShowToast(
                 "Scene saved: " +

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -1,5 +1,6 @@
 #include "Gui/Gui.h"
 #include "Core/Camera.h"
+#include "Core/SnapshotManager.h"
 #include "Core/UndoManager.h"
 #include "Core/Voxalizer.h"
 #include "Cursors/Base/CursorManager.h"
@@ -78,6 +79,9 @@ extern bool showMeasurementToolWindow;
 // Section / clip plane tool
 extern Tools::ClipPlaneTool clipPlaneTool;
 extern bool showClipPlaneToolWindow;
+
+// Snapshots
+extern bool showSnapshotsWindow;
 // Defined in main.cpp: place planes using the 3D cursor / selection context.
 void addClipPlaneAtCursor();
 void addClipPlaneAxisAligned(int axis);
@@ -1977,6 +1981,11 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
       showClipPlaneToolWindow = true;
     }
 
+    // Snapshots Menu
+    if (ImGui::MenuItem("Snapshots")) {
+      showSnapshotsWindow = true;
+    }
+
     // AI Assistant quick access (accent-highlighted, deep-links into Settings)
     ImGui::PushStyleColor(ImGuiCol_Text, g_StyleColors.accent);
     if (ImGui::MenuItem("AI Assistant")) {
@@ -2641,6 +2650,10 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
 
   if (showClipPlaneToolWindow) {
     renderClipPlaneToolWindow();
+  }
+
+  if (showSnapshotsWindow) {
+    renderSnapshotsWindow();
   }
 
   // Screen-space measurement labels (distances/angles/coordinates) projected
@@ -6527,6 +6540,169 @@ void renderClipPlaneToolWindow() {
   // Closing the window (X) disables the editing UX; the planes keep clipping.
   if (!showClipPlaneToolWindow)
     clipPlaneTool.setEnabled(false);
+}
+
+// Draw a FontAwesome glyph inline with an optional hover tooltip. The icon font
+// is merged into the regular font, so the glyph is available directly; the
+// explicit PushFont keeps it visually consistent with the rest of the GUI.
+static void DrawSnapshotIcon(const char *icon, const char *tooltip) {
+  if (g_Fonts.icons)
+    ImGui::PushFont(g_Fonts.icons);
+  ImGui::TextUnformatted(icon);
+  if (g_Fonts.icons)
+    ImGui::PopFont();
+  if (tooltip && ImGui::IsItemHovered())
+    ImGui::SetTooltip("%s", tooltip);
+}
+
+// Snapshots panel: capture the current camera / scene / tool state into named,
+// thumbnailed checkpoints and roll back to them. Mirrors the screenshot capture
+// pipeline for the thumbnail and the Undo edit-states for the scene data.
+void renderSnapshotsWindow() {
+  float scale = g_GuiScale.currentScale;
+  ImGui::SetNextWindowSize(ImVec2(560 * scale, 620 * scale),
+                           ImGuiCond_FirstUseEver);
+  ImGui::SetNextWindowSizeConstraints(ImVec2(380 * scale, 300 * scale),
+                                      ImVec2(100000.0f, 100000.0f));
+  ImGui::Begin("Snapshots", &showSnapshotsWindow);
+
+  auto &mgr = Core::SnapshotManager::instance();
+
+  // ── Create section ──────────────────────────────────────────────────────
+  DrawSectionHeader("New Snapshot");
+  ImGui::TextWrapped(
+      "Capture the current state into a named snapshot. Choose which aspects to "
+      "store; restoring rolls those aspects back to this point.");
+  ImGui::Spacing();
+
+  static char snapName[128] = "";
+  static bool saveCamera = true;
+  static bool saveScene = true;
+  static bool saveTools = false;
+  static int autoCounter = 1;
+
+  ImGui::InputTextWithHint("Name", "Snapshot name (optional)", snapName,
+                           IM_ARRAYSIZE(snapName));
+
+  DrawSnapshotIcon(ICON_FA_CAMERA, "Camera position & orientation");
+  ImGui::SameLine();
+  ImGui::Checkbox("Camera", &saveCamera);
+  ImGui::SameLine(0, 24 * scale);
+  DrawSnapshotIcon(ICON_FA_CUBES, "Objects: transform, color, visibility, "
+                                  "materials, lights, sun, measurements, "
+                                  "section planes");
+  ImGui::SameLine();
+  ImGui::Checkbox("Scene", &saveScene);
+  ImGui::SameLine(0, 24 * scale);
+  DrawSnapshotIcon(ICON_FA_TOOLS,
+                   "Tool settings (brush, measure, section planes)");
+  ImGui::SameLine();
+  ImGui::Checkbox("Tools", &saveTools);
+
+  uint32_t flags = (saveCamera ? Core::SNAPSHOT_CAMERA : 0u) |
+                   (saveScene ? Core::SNAPSHOT_SCENE : 0u) |
+                   (saveTools ? Core::SNAPSHOT_TOOLS : 0u);
+
+  ImGui::Spacing();
+  const bool canCapture = flags != 0u;
+  if (!canCapture)
+    ImGui::BeginDisabled();
+  if (ImGui::Button(ICON_FA_PLUS " Capture Snapshot",
+                    ImVec2(-1, 32 * scale))) {
+    std::string name = snapName[0] != '\0'
+                           ? std::string(snapName)
+                           : ("Snapshot " + std::to_string(autoCounter));
+    autoCounter++;
+    Core::RequestSnapshotCapture(name, flags);
+    snapName[0] = '\0';
+  }
+  if (!canCapture) {
+    ImGui::EndDisabled();
+    ImGui::TextDisabled("Select at least one aspect to capture.");
+  }
+
+  ImGui::Spacing();
+  ImGui::Separator();
+  ImGui::Spacing();
+
+  // ── Saved snapshots list ────────────────────────────────────────────────
+  auto &snaps = mgr.snapshots();
+  DrawSectionHeader(
+      ("Saved Snapshots (" + std::to_string(snaps.size()) + ")").c_str());
+
+  if (snaps.empty()) {
+    ImGui::TextDisabled("No snapshots yet. Capture one above.");
+    ImGui::End();
+    return;
+  }
+
+  int toRestore = -1;
+  int toDelete = -1;
+
+  ImGui::BeginChild("SnapshotList", ImVec2(0, 0), false);
+  for (int i = 0; i < static_cast<int>(snaps.size()); ++i) {
+    Core::Snapshot &s = snaps[i];
+    ImGui::PushID(i);
+
+    const float thumbW = 170 * scale;
+    const float thumbH =
+        s.thumbWidth > 0
+            ? thumbW * static_cast<float>(s.thumbHeight) /
+                  static_cast<float>(s.thumbWidth)
+            : thumbW * 0.5625f;
+
+    if (s.thumbnailTexture != 0)
+      ImGui::Image((void *)(intptr_t)s.thumbnailTexture,
+                   ImVec2(thumbW, thumbH));
+    else
+      ImGui::Dummy(ImVec2(thumbW, thumbH));
+
+    ImGui::SameLine();
+    ImGui::BeginGroup();
+
+    if (g_Fonts.bold)
+      ImGui::PushFont(g_Fonts.bold);
+    ImGui::TextUnformatted(s.name.c_str());
+    if (g_Fonts.bold)
+      ImGui::PopFont();
+    ImGui::TextDisabled("%s", s.timestamp.c_str());
+
+    // Icons marking which aspects this snapshot stored.
+    if (s.flags & Core::SNAPSHOT_CAMERA) {
+      DrawSnapshotIcon(ICON_FA_CAMERA, "Camera");
+      ImGui::SameLine();
+    }
+    if (s.flags & Core::SNAPSHOT_SCENE) {
+      DrawSnapshotIcon(ICON_FA_CUBES, "Scene");
+      ImGui::SameLine();
+    }
+    if (s.flags & Core::SNAPSHOT_TOOLS) {
+      DrawSnapshotIcon(ICON_FA_TOOLS, "Tools");
+      ImGui::SameLine();
+    }
+    ImGui::NewLine();
+
+    if (ImGui::Button(ICON_FA_HISTORY " Restore"))
+      toRestore = i;
+    ImGui::SameLine();
+    ImGui::PushStyleColor(ImGuiCol_Button, g_StyleColors.danger);
+    if (ImGui::Button(ICON_FA_TRASH " Delete"))
+      toDelete = i;
+    ImGui::PopStyleColor();
+
+    ImGui::EndGroup();
+    ImGui::PopID();
+    ImGui::Separator();
+  }
+  ImGui::EndChild();
+
+  // Apply deferred actions after the loop so the list isn't mutated mid-draw.
+  if (toRestore >= 0)
+    Core::RestoreSnapshot(toRestore);
+  if (toDelete >= 0)
+    mgr.remove(toDelete);
+
+  ImGui::End();
 }
 
 // Projects measurement values (segment lengths, angles, coordinates) into

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -2904,6 +2904,9 @@ int main() {
     pointLights = currentScene.pointLights;
     spotLights = currentScene.spotLights;
 
+    // Load any snapshots saved with this scene.
+    Core::SnapshotManager::instance().loadFromScene("office.scene");
+
     // Start spawn animation for all loaded models
     for (auto &model : currentScene.models) {
       glm::vec3 targetScale = model.scale;
@@ -3022,6 +3025,10 @@ int main() {
       // Sync lights from scene to global variables
       pointLights = currentScene.pointLights;
       spotLights = currentScene.spotLights;
+
+      // Load any snapshots saved with this scene.
+      Core::SnapshotManager::instance().loadFromScene(
+          preferences.startupScenePath);
 
       // Start spawn animation for all loaded models
       for (auto &model : currentScene.models) {

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -17,6 +17,7 @@
 #include "Core/CursorSyncState.h"
 #include "Core/CursorSynchronizer.h"
 #include "Core/SceneManager.h"
+#include "Core/SnapshotManager.h"
 #include "Core/UndoManager.h"
 #include "Core/Voxalizer.h"
 #include "Cursors/Base/CursorManager.h"
@@ -206,6 +207,13 @@ bool showFPS = true;
 // Screenshot) and the keyboard shortcut set these.
 bool g_requestScreenshot = false;
 std::string g_screenshotPath;
+// ---- Snapshots ----
+// Set by the GUI to request a snapshot capture on the next clean (GUI-free)
+// frame. The flags select which aspects (camera/scene/tools) to store; the
+// name labels the snapshot in the panel.
+bool g_requestSnapshot = false;
+std::string g_pendingSnapshotName;
+uint32_t g_pendingSnapshotFlags = 0;
 bool isDarkTheme = true;
 bool showInfoWindow = false;
 bool showSettingsWindow = false;
@@ -214,6 +222,7 @@ bool showCursorSettingsWindow = false;
 bool showBrushToolWindow = false;
 bool showMeasurementToolWindow = false;
 bool showClipPlaneToolWindow = false;
+bool showSnapshotsWindow = false;
 enum class SelectedType {
   None,
   Model,
@@ -3190,6 +3199,12 @@ int main() {
   // hidden for a single clean frame before reading the pixels.
   bool screenshotArmed = false;
   std::string screenshotArmedPath;
+
+  // Snapshot capture is deferred the same way: armed for the next frame so the
+  // thumbnail is read from a clean, GUI-free viewer image.
+  bool snapshotArmed = false;
+  std::string snapshotArmedName;
+  uint32_t snapshotArmedFlags = 0;
   while (!glfwWindowShouldClose(window)) {
     // ---- Per-frame Time Logic ----
     float currentFrame =
@@ -3669,11 +3684,18 @@ int main() {
     // right after the pixels are read (just before the buffer swap).
     bool captureThisFrame = screenshotArmed;
     std::string captureThisFramePath = screenshotArmedPath;
+    bool captureSnapshotThisFrame = snapshotArmed;
+    std::string snapshotThisFrameName = snapshotArmedName;
+    uint32_t snapshotThisFrameFlags = snapshotArmedFlags;
     bool savedShowGuiForCapture = showGui;
-    if (captureThisFrame && !preferences.screenshotIncludeUI) {
+    // Snapshots always want a clean viewer image (GUI hidden), as do screenshots
+    // when the UI is excluded.
+    if ((captureThisFrame && !preferences.screenshotIncludeUI) ||
+        captureSnapshotThisFrame) {
       showGui = false;
     }
     screenshotArmed = false;
+    snapshotArmed = false;
 
     // ---- Size the 3D viewport to the free area beside the docked GUI ----
     // g_dockLeftWidth / g_dockTopHeight are published by renderGUI each frame
@@ -4001,12 +4023,41 @@ int main() {
       showGui = savedShowGuiForCapture;
     }
 
+    // ---- Snapshot: read the clean frame and store it ----
+    if (captureSnapshotThisFrame) {
+      GLenum readBuffer = isStereoWindow ? GL_BACK_LEFT : GL_BACK;
+      std::vector<unsigned char> px;
+      int pw = 0, ph = 0;
+      bool ok = Engine::Screenshot::captureToMemory(
+          0, 0, windowWidth, windowHeight, readBuffer, px, pw, ph);
+      if (ok) {
+        Core::SnapshotManager::instance().create(
+            snapshotThisFrameName, snapshotThisFrameFlags, camera, currentScene,
+            pointLights, spotLights, sun, brushTool, measurementTool,
+            clipPlaneTool, px, pw, ph);
+        GUI::ShowToast("Snapshot saved: " + snapshotThisFrameName,
+                       GUI::ToastType::Success);
+      } else {
+        GUI::ShowToast("Failed to capture snapshot", GUI::ToastType::Error);
+      }
+      showGui = savedShowGuiForCapture;
+    }
+
     // Arm a capture for the next frame if one was requested this frame.
     if (g_requestScreenshot) {
       screenshotArmed = true;
       screenshotArmedPath = g_screenshotPath;
       g_requestScreenshot = false;
       g_screenshotPath.clear();
+    }
+
+    if (g_requestSnapshot) {
+      snapshotArmed = true;
+      snapshotArmedName = g_pendingSnapshotName;
+      snapshotArmedFlags = g_pendingSnapshotFlags;
+      g_requestSnapshot = false;
+      g_pendingSnapshotName.clear();
+      g_pendingSnapshotFlags = 0;
     }
 
     // ---- Swap Buffers ----
@@ -6398,6 +6449,38 @@ void updateSpaceMouseBounds() {
   // Update SpaceMouse with new bounds
   spaceMouseInput.SetModelExtents(modelMin, modelMax);
 }
+
+// ---- Snapshot glue (declared in Core/SnapshotManager.h) ----
+namespace Core {
+
+void RequestSnapshotCapture(const std::string &name, uint32_t flags) {
+  g_pendingSnapshotName = name;
+  g_pendingSnapshotFlags = flags;
+  g_requestSnapshot = true;
+}
+
+void RestoreSnapshot(int index) {
+  auto &mgr = Core::SnapshotManager::instance();
+  if (index < 0 || index >= static_cast<int>(mgr.snapshots().size()))
+    return;
+
+  const Core::Snapshot &snap = mgr.snapshots()[index];
+  std::string name = snap.name;
+  mgr.restore(snap, camera, currentScene, pointLights, spotLights, sun,
+              brushTool, measurementTool, clipPlaneTool);
+
+  // Resync the systems that depend on scene structure. BVH / triangle data and
+  // DDGI rebuild automatically via the per-frame scene-change check; the
+  // voxelizer and SpaceMouse bounds are refreshed explicitly here (mirroring
+  // the undo/redo resync).
+  if (voxelizer)
+    voxelizer->markDirty();
+  updateSpaceMouseBounds();
+
+  GUI::ShowToast("Restored snapshot: " + name, GUI::ToastType::Info);
+}
+
+} // namespace Core
 
 void updateSpaceMouseCursorAnchor() {
   // Update SpaceMouse cursor anchor based on mode

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -6484,6 +6484,32 @@ void RestoreSnapshot(int index) {
     voxelizer->markDirty();
   updateSpaceMouseBounds();
 
+  // Restoring lights can change their counts, so make sure the current
+  // selection still points at a valid object (same guard as undo/redo).
+  int objectCount = -1;
+  switch (currentSelectedType) {
+  case SelectedType::Model:
+    objectCount = static_cast<int>(currentScene.models.size());
+    break;
+  case SelectedType::PointCloud:
+    objectCount = static_cast<int>(currentScene.pointClouds.size());
+    break;
+  case SelectedType::PointLight:
+    objectCount = static_cast<int>(pointLights.size());
+    break;
+  case SelectedType::SpotLight:
+    objectCount = static_cast<int>(spotLights.size());
+    break;
+  default:
+    break;
+  }
+  if (objectCount >= 0 &&
+      (currentSelectedIndex < 0 || currentSelectedIndex >= objectCount)) {
+    currentSelectedType = SelectedType::None;
+    currentSelectedIndex = -1;
+    currentSelectedMeshIndex = -1;
+  }
+
   GUI::ShowToast("Restored snapshot: " + name, GUI::ToastType::Info);
 }
 


### PR DESCRIPTION
Introduce a session-scoped Snapshot system that captures selectable
aspects of the current scene into named, thumbnailed checkpoints and
restores them on demand.

- Core::SnapshotManager (new): singleton storing Snapshots. Each snapshot
  records a flags bitmask (Camera/Scene/Tools), the camera CameraState,
  scene state (reusing the Undo ModelEditState/PointCloudEditState plus
  full copies of lights, sun, measurements and clip planes), tool
  settings, and a downscaled GL-texture thumbnail.
- Engine::Screenshot::captureToMemory: refactored out of captureToPNG so
  both PNG export and snapshot thumbnails share the framebuffer read/flip.
- main.cpp: deferred clean-frame capture (GUI hidden, same armed pattern
  as screenshots) plus RequestSnapshotCapture/RestoreSnapshot glue that
  operates on the live globals and resyncs dependent systems.
- GUI: dedicated "Snapshots" panel with a create section (Camera/Scene/
  Tools toggles) and a list showing each snapshot's thumbnail, aspect
  icons, and restore/delete actions.
- Registered the new files in the Visual Studio project.

Scene restore re-applies object transforms/materials by index and fully
replaces lights/sun/measurements/clip planes; it does not re-create
objects deleted after the snapshot was taken.