### PR TITLE
Add snapshot organization: tags, color markers, fuzzy search & filters

### DIFF
--- a/StereoVista/headers/Core/Camera.h
+++ b/StereoVista/headers/Core/Camera.h
@@ -79,6 +79,10 @@ public:
   float AnimationEndZoom = ZOOM;
   float AnimationProgress;
   float AnimationDuration;
+  // Whether to fire centeringCompletedCallback when the current animation
+  // finishes. Centering animations want it; snapshot-restore animations do not
+  // (they must not warp the cursor or start orbiting).
+  bool AnimationInvokeCallback = true;
 
   bool useNewMethod = true;
   bool wireframe = false;
@@ -575,6 +579,7 @@ public:
   // Starts animation to center camera on target point
   void StartCenteringAnimation(const glm::vec3 &targetPoint) {
     IsAnimating = true;
+    AnimationInvokeCallback = true;
     AnimationStartPosition = Position;
     AnimationStartOrientation = Orientation;
     // Zoom (FOV) is unchanged by centering.
@@ -605,6 +610,9 @@ public:
   // untouched and re-anchored along the new front on completion.
   void StartStateAnimation(const CameraState &target, float duration = 0.6f) {
     IsAnimating = true;
+    // Snapshot restores must not trigger the centering callback (cursor warp /
+    // auto-orbit); that behavior is specific to double-click centering.
+    AnimationInvokeCallback = false;
     AnimationStartPosition = Position;
     AnimationStartOrientation = Orientation;
     AnimationStartZoom = Zoom;
@@ -638,7 +646,7 @@ public:
 
       OrbitPoint = Position + Front * OrbitDistance;
 
-      if (centeringCompletedCallback) {
+      if (AnimationInvokeCallback && centeringCompletedCallback) {
         centeringCompletedCallback();
       }
     } else {

--- a/StereoVista/headers/Core/Camera.h
+++ b/StereoVista/headers/Core/Camera.h
@@ -75,6 +75,8 @@ public:
   glm::vec3 AnimationEndPosition;
   glm::quat AnimationStartOrientation;
   glm::quat AnimationEndOrientation;
+  float AnimationStartZoom = ZOOM;
+  float AnimationEndZoom = ZOOM;
   float AnimationProgress;
   float AnimationDuration;
 
@@ -575,6 +577,9 @@ public:
     IsAnimating = true;
     AnimationStartPosition = Position;
     AnimationStartOrientation = Orientation;
+    // Zoom (FOV) is unchanged by centering.
+    AnimationStartZoom = Zoom;
+    AnimationEndZoom = Zoom;
 
     float initialDistance = glm::length(Position - targetPoint);
     glm::vec3 directionToCamera = glm::normalize(Position - targetPoint);
@@ -590,7 +595,30 @@ public:
     AnimationEndOrientation = glm::normalize(glm::quat_cast(targetRotMatrix));
 
     AnimationProgress = 0.0f;
+    AnimationDuration = 0.5f;
     OrbitDistance = initialDistance;
+  }
+
+  // Smoothly animate every camera parameter (position, orientation and zoom)
+  // toward a saved state with easing. Used when restoring a snapshot's camera
+  // so the view glides into place instead of jumping. OrbitDistance is left
+  // untouched and re-anchored along the new front on completion.
+  void StartStateAnimation(const CameraState &target, float duration = 0.6f) {
+    IsAnimating = true;
+    AnimationStartPosition = Position;
+    AnimationStartOrientation = Orientation;
+    AnimationStartZoom = Zoom;
+
+    AnimationEndPosition = target.position;
+    glm::quat endOrient = glm::normalize(target.orientation);
+    // Take the shortest rotational path so large turns don't spin the long way.
+    if (glm::dot(AnimationStartOrientation, endOrient) < 0.0f)
+      endOrient = -endOrient;
+    AnimationEndOrientation = endOrient;
+    AnimationEndZoom = target.zoom;
+
+    AnimationProgress = 0.0f;
+    AnimationDuration = (duration > 0.0001f) ? duration : 0.0001f;
   }
 
   // Updates camera animation with smooth easing
@@ -604,6 +632,7 @@ public:
       // Animation complete
       Position = AnimationEndPosition;
       Orientation = AnimationEndOrientation;
+      Zoom = AnimationEndZoom;
       IsAnimating = false;
       updateCameraVectorsFromQuaternion();
 
@@ -616,10 +645,11 @@ public:
       // Apply cubic easing function
       float t = easeOutCubic(AnimationProgress);
 
-      // Interpolate position and orientation using SLERP for smooth rotation
+      // Interpolate position, orientation (SLERP) and zoom for a smooth glide.
       Position = glm::mix(AnimationStartPosition, AnimationEndPosition, t);
       Orientation = glm::normalize(
           glm::slerp(AnimationStartOrientation, AnimationEndOrientation, t));
+      Zoom = glm::mix(AnimationStartZoom, AnimationEndZoom, t);
 
       // Update camera vectors from interpolated quaternion
       updateCameraVectorsFromQuaternion();

--- a/StereoVista/headers/Core/SnapshotManager.h
+++ b/StereoVista/headers/Core/SnapshotManager.h
@@ -87,6 +87,14 @@ struct Snapshot {
   std::string timestamp;
   uint32_t flags = SNAPSHOT_NONE;
 
+  // Organization metadata (user-editable after capture, persisted with the
+  // scene). `tags` are freeform labels / categories used for filtering and
+  // search; `color` is an optional marker used to visually group snapshots in
+  // the panel (only shown when `hasColor` is set).
+  std::vector<std::string> tags;
+  bool hasColor = false;
+  glm::vec3 color = glm::vec3(0.40f, 0.65f, 1.0f);
+
   Camera::CameraState camera{};
   SnapshotSceneState scene;
   SnapshotToolState tools;

--- a/StereoVista/src/Core/SnapshotManager.cpp
+++ b/StereoVista/src/Core/SnapshotManager.cpp
@@ -651,6 +651,10 @@ void SnapshotManager::saveToScene(const std::string &sceneFile) {
       j["name"] = s.name;
       j["timestamp"] = s.timestamp;
       j["flags"] = s.flags;
+      if (!s.tags.empty())
+        j["tags"] = s.tags;
+      if (s.hasColor)
+        j["color"] = vec3ToJson(s.color);
       if (s.flags & SNAPSHOT_CAMERA)
         j["camera"] = cameraStateToJson(s.camera);
       if (s.flags & SNAPSHOT_SCENE)
@@ -711,6 +715,15 @@ void SnapshotManager::loadFromScene(const std::string &sceneFile) {
       s.name = j.value("name", std::string("Snapshot"));
       s.timestamp = j.value("timestamp", std::string());
       s.flags = j.value("flags", 0u);
+      if (j.contains("tags") && j["tags"].is_array()) {
+        for (const auto &t : j["tags"])
+          if (t.is_string())
+            s.tags.push_back(t.get<std::string>());
+      }
+      if (j.contains("color")) {
+        s.color = jsonToVec3(j["color"], s.color);
+        s.hasColor = true;
+      }
       if (j.contains("camera"))
         s.camera = cameraStateFromJson(j["camera"]);
       if (j.contains("scene"))

--- a/StereoVista/src/Core/SnapshotManager.cpp
+++ b/StereoVista/src/Core/SnapshotManager.cpp
@@ -559,8 +559,10 @@ void SnapshotManager::restore(const Snapshot &snap, Camera &camera,
                               Tools::MeasurementTool &measure,
                               Tools::ClipPlaneTool &clip) {
   // Camera ----------------------------------------------------------------
+  // Glide the view into place (position, orientation and zoom all eased)
+  // instead of snapping, so restoring a camera reads as a smooth move.
   if (snap.flags & SNAPSHOT_CAMERA)
-    camera.SetState(snap.camera);
+    camera.StartStateAnimation(snap.camera);
 
   // Scene -----------------------------------------------------------------
   if (snap.flags & SNAPSHOT_SCENE) {

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -6671,12 +6671,8 @@ void renderSnapshotsWindow() {
 
   auto &mgr = Core::SnapshotManager::instance();
 
-  // ── Create section ──────────────────────────────────────────────────────
+  // ── Create card ─────────────────────────────────────────────────────────
   DrawSectionHeader("New Snapshot");
-  ImGui::TextWrapped(
-      "Capture the current state into a named snapshot. Choose which aspects to "
-      "store; restoring rolls those aspects back to this point.");
-  ImGui::Spacing();
 
   static char snapName[128] = "";
   static bool saveCamera = true;
@@ -6684,23 +6680,52 @@ void renderSnapshotsWindow() {
   static bool saveTools = false;
   static int autoCounter = 1;
 
-  ImGui::InputTextWithHint("Name", "Snapshot name (optional)", snapName,
+  ImGui::PushStyleColor(ImGuiCol_ChildBg,
+                        ImVec4(g_StyleColors.primary.x, g_StyleColors.primary.y,
+                               g_StyleColors.primary.z, 0.06f));
+  ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.0f * scale);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
+                      ImVec2(12.0f * scale, 12.0f * scale));
+  ImGui::BeginChild("CreateCard", ImVec2(0, 0),
+                    ImGuiChildFlags_Border | ImGuiChildFlags_AutoResizeY);
+
+  ImGui::SetNextItemWidth(-1);
+  ImGui::InputTextWithHint("##snapName", "Name (optional)…", snapName,
                            IM_ARRAYSIZE(snapName));
 
-  DrawSnapshotIcon(ICON_FA_CAMERA, "Camera position & orientation");
-  ImGui::SameLine();
-  ImGui::Checkbox("Camera", &saveCamera);
-  ImGui::SameLine(0, 24 * scale);
-  DrawSnapshotIcon(ICON_FA_CUBES, "Objects: transform, color, visibility, "
-                                  "materials, lights, sun, measurements, "
-                                  "section planes");
-  ImGui::SameLine();
-  ImGui::Checkbox("Scene", &saveScene);
-  ImGui::SameLine(0, 24 * scale);
-  DrawSnapshotIcon(ICON_FA_TOOLS,
-                   "Tool settings (brush, measure, section planes)");
-  ImGui::SameLine();
-  ImGui::Checkbox("Tools", &saveTools);
+  ImGui::Spacing();
+  ImGui::TextDisabled("WHICH ASPECTS TO CAPTURE");
+  ImGui::Spacing();
+
+  // Right-aligned toggle rows so the three aspects read as a clean list. The
+  // leading icon brightens to the accent color when its aspect is enabled.
+  auto aspectRow = [&](const char *icon, const char *label, const char *help,
+                       bool *v) {
+    DrawInlineIcon(icon, *v ? g_StyleColors.accent
+                            : ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted(label);
+    if (help) {
+      ImGui::SameLine();
+      DrawHelpMarker(help);
+    }
+    float tw = ImGui::GetFrameHeight() * 1.85f;
+    ImGui::SameLine();
+    float room = ImGui::GetContentRegionAvail().x;
+    if (room > tw)
+      ImGui::SetCursorPosX(ImGui::GetCursorPosX() + room - tw);
+    ImGui::PushID(label);
+    DrawToggleSwitch("##t", v);
+    ImGui::PopID();
+  };
+  aspectRow(ICON_FA_CAMERA, "Camera", "Camera position & orientation",
+            &saveCamera);
+  aspectRow(ICON_FA_CUBES, "Scene",
+            "Objects: transform, color, visibility, materials, lights, sun, "
+            "measurements, section planes",
+            &saveScene);
+  aspectRow(ICON_FA_TOOLS, "Tools",
+            "Tool settings (brush, measure, section planes)", &saveTools);
 
   uint32_t flags = (saveCamera ? Core::SNAPSHOT_CAMERA : 0u) |
                    (saveScene ? Core::SNAPSHOT_SCENE : 0u) |
@@ -6710,8 +6735,12 @@ void renderSnapshotsWindow() {
   const bool canCapture = flags != 0u;
   if (!canCapture)
     ImGui::BeginDisabled();
-  if (ImGui::Button(ICON_FA_PLUS " Capture Snapshot",
-                    ImVec2(-1, 32 * scale))) {
+  ImGui::PushStyleColor(ImGuiCol_Button, g_StyleColors.primary);
+  ImGui::PushStyleColor(ImGuiCol_ButtonHovered, g_StyleColors.primaryHover);
+  ImGui::PushStyleColor(ImGuiCol_ButtonActive, g_StyleColors.primaryActive);
+  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 8.0f * scale);
+  if (ImGui::Button(ICON_FA_CAMERA "  Capture Snapshot",
+                    ImVec2(-1, 36 * scale))) {
     std::string name = snapName[0] != '\0'
                            ? std::string(snapName)
                            : ("Snapshot " + std::to_string(autoCounter));
@@ -6719,22 +6748,33 @@ void renderSnapshotsWindow() {
     Core::RequestSnapshotCapture(name, flags);
     snapName[0] = '\0';
   }
+  ImGui::PopStyleVar();
+  ImGui::PopStyleColor(3);
   if (!canCapture) {
     ImGui::EndDisabled();
+    ImGui::Spacing();
     ImGui::TextDisabled("Select at least one aspect to capture.");
   }
 
-  ImGui::Spacing();
-  ImGui::Separator();
+  ImGui::EndChild();
+  ImGui::PopStyleVar(2);
+  ImGui::PopStyleColor();
+
   ImGui::Spacing();
 
-  // ── Saved snapshots list ────────────────────────────────────────────────
+  // ── Saved snapshots ──────────────────────────────────────────────────────
   auto &snaps = mgr.snapshots();
   DrawSectionHeader(
       ("Saved Snapshots (" + std::to_string(snaps.size()) + ")").c_str());
 
   if (snaps.empty()) {
-    ImGui::TextDisabled("No snapshots yet. Capture one above.");
+    ImGui::Spacing();
+    ImGui::Spacing();
+    const char *msg = "No snapshots yet — capture one above.";
+    float tw = ImGui::CalcTextSize(msg).x;
+    ImGui::SetCursorPosX(
+        std::max(0.0f, (ImGui::GetContentRegionAvail().x - tw) * 0.5f));
+    ImGui::TextDisabled("%s", msg);
     ImGui::End();
     return;
   }
@@ -6742,17 +6782,18 @@ void renderSnapshotsWindow() {
   // ── Search box ──────────────────────────────────────────────────────────
   // Fuzzy (subsequence) match across name, timestamp, tags and aspect names.
   static char searchBuf[128] = "";
-  DrawSnapshotIcon(ICON_FA_SEARCH, "Fuzzy search over name, tags, date & "
-                                   "aspects");
-  ImGui::SameLine();
-  ImGui::SetNextItemWidth(-(40 * scale));
-  ImGui::InputTextWithHint("##snapSearch", "Search snapshots…", searchBuf,
-                           IM_ARRAYSIZE(searchBuf));
+  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 8.0f * scale);
+  DrawInlineIcon(ICON_FA_SEARCH,
+                 ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+  ImGui::SetNextItemWidth(-(38 * scale));
+  ImGui::InputTextWithHint("##snapSearch", "Search name, tags, date, aspects…",
+                           searchBuf, IM_ARRAYSIZE(searchBuf));
   ImGui::SameLine();
   if (ImGui::Button(ICON_FA_TIMES "##clearSearch"))
     searchBuf[0] = '\0';
   if (ImGui::IsItemHovered())
     ImGui::SetTooltip("Clear search");
+  ImGui::PopStyleVar();
 
   // ── Tag filter chips ────────────────────────────────────────────────────
   // Collect the live tag set and drop any active filters whose tag no longer
@@ -6774,7 +6815,8 @@ void renderSnapshotsWindow() {
     const ImGuiStyle &style = ImGui::GetStyle();
     float rightEdge =
         ImGui::GetCursorScreenPos().x + ImGui::GetContentRegionAvail().x;
-    DrawSnapshotIcon(ICON_FA_FILTER, "Filter by tag (matches any selected)");
+    DrawInlineIcon(ICON_FA_FILTER,
+                   ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     int chipId = 0;
     for (const auto &t : allTags) {
       ImGui::PushID(chipId++);
@@ -6793,8 +6835,10 @@ void renderSnapshotsWindow() {
     }
     if (!activeTagFilters.empty()) {
       ImGui::SameLine();
-      if (ImGui::SmallButton("Clear filters"))
+      if (ImGui::SmallButton("Clear"))
         activeTagFilters.clear();
+      if (ImGui::IsItemHovered())
+        ImGui::SetTooltip("Clear tag filters");
     }
   }
 
@@ -6813,7 +6857,7 @@ void renderSnapshotsWindow() {
 
   int visibleCount = 0;
 
-  ImGui::BeginChild("SnapshotList", ImVec2(0, 0), false);
+  ImGui::BeginChild("SnapshotList", ImVec2(0, 0), ImGuiChildFlags_None);
   for (int i = 0; i < static_cast<int>(snaps.size()); ++i) {
     Core::Snapshot &s = snaps[i];
 
@@ -6835,13 +6879,25 @@ void renderSnapshotsWindow() {
 
     ImGui::PushID(i);
 
-    const float thumbW = 170 * scale;
+    // Each snapshot is a self-contained rounded card.
+    ImGui::PushStyleColor(
+        ImGuiCol_ChildBg,
+        ImVec4(g_StyleColors.primary.x, g_StyleColors.primary.y,
+               g_StyleColors.primary.z, 0.05f));
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.0f * scale);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
+                        ImVec2(10.0f * scale, 10.0f * scale));
+    ImGui::BeginChild("card", ImVec2(0, 0),
+                      ImGuiChildFlags_Border | ImGuiChildFlags_AutoResizeY);
+
+    const float thumbW = 150 * scale;
     const float thumbH =
         s.thumbWidth > 0
             ? thumbW * static_cast<float>(s.thumbHeight) /
                   static_cast<float>(s.thumbWidth)
             : thumbW * 0.5625f;
 
+    // Top row: thumbnail on the left, details column on the right.
     if (s.thumbnailTexture != 0)
       ImGui::Image((void *)(intptr_t)s.thumbnailTexture,
                    ImVec2(thumbW, thumbH));
@@ -6851,13 +6907,13 @@ void renderSnapshotsWindow() {
     ImGui::SameLine();
     ImGui::BeginGroup();
 
-    // Optional color marker, then the name.
+    // Color marker dot + name.
     if (s.hasColor) {
       ImGui::ColorButton("##marker",
                          ImVec4(s.color.r, s.color.g, s.color.b, 1.0f),
                          ImGuiColorEditFlags_NoTooltip |
                              ImGuiColorEditFlags_NoPicker,
-                         ImVec2(14 * scale, 14 * scale));
+                         ImVec2(12 * scale, 12 * scale));
       ImGui::SameLine();
     }
     if (g_Fonts.bold)
@@ -6865,9 +6921,12 @@ void renderSnapshotsWindow() {
     ImGui::TextUnformatted(s.name.c_str());
     if (g_Fonts.bold)
       ImGui::PopFont();
+
+    DrawInlineIcon(ICON_FA_CLOCK,
+                   ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     ImGui::TextDisabled("%s", s.timestamp.c_str());
 
-    // Icons marking which aspects this snapshot stored.
+    // Aspect badges marking what this snapshot stored.
     if (s.flags & Core::SNAPSHOT_CAMERA) {
       DrawSnapshotIcon(ICON_FA_CAMERA, "Camera");
       ImGui::SameLine();
@@ -6898,12 +6957,30 @@ void renderSnapshotsWindow() {
         ImGui::PopID();
       }
     }
+    ImGui::EndGroup();
 
+    // Action row (full card width). Restore reads as the primary action via
+    // the accent fill; Delete uses the danger color.
+    ImGui::Spacing();
+    ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 7.0f * scale);
+    ImGui::PushStyleColor(ImGuiCol_Button, g_StyleColors.primary);
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, g_StyleColors.primaryHover);
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, g_StyleColors.primaryActive);
     if (ImGui::Button(ICON_FA_HISTORY " Restore"))
       toRestore = i;
+    ImGui::PopStyleColor(3);
+    if (ImGui::IsItemHovered())
+      ImGui::SetTooltip("Roll the saved aspects back onto the scene");
+
     ImGui::SameLine();
+    const bool editingThis = (editingIndex == i);
+    if (editingThis) {
+      ImGui::PushStyleColor(ImGuiCol_Button, g_StyleColors.accent);
+      ImGui::PushStyleColor(ImGuiCol_ButtonHovered, g_StyleColors.accent);
+      ImGui::PushStyleColor(ImGuiCol_ButtonActive, g_StyleColors.accent);
+    }
     if (ImGui::Button(ICON_FA_PEN " Edit")) {
-      editingIndex = (editingIndex == i) ? -1 : i;
+      editingIndex = editingThis ? -1 : i;
       if (editingIndex == i) {
         std::snprintf(editName, sizeof(editName), "%s", s.name.c_str());
         std::string joined = joinSnapshotTags(s.tags);
@@ -6912,14 +6989,20 @@ void renderSnapshotsWindow() {
         editColor = s.color;
       }
     }
+    if (editingThis)
+      ImGui::PopStyleColor(3);
+
     ImGui::SameLine();
     ImGui::PushStyleColor(ImGuiCol_Button, g_StyleColors.danger);
     if (ImGui::Button(ICON_FA_TRASH " Delete"))
       toDelete = i;
     ImGui::PopStyleColor();
+    ImGui::PopStyleVar();
 
     // Inline editor for name / tags / color.
     if (editingIndex == i) {
+      ImGui::Spacing();
+      ImGui::Separator();
       ImGui::Spacing();
       ImGui::SetNextItemWidth(-1);
       ImGui::InputTextWithHint("##editName", "Name", editName,
@@ -6934,6 +7017,9 @@ void renderSnapshotsWindow() {
                           ImGuiColorEditFlags_NoInputs |
                               ImGuiColorEditFlags_NoLabel);
       }
+      ImGui::Spacing();
+      ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 7.0f * scale);
+      ImGui::PushStyleColor(ImGuiCol_Button, g_StyleColors.success);
       if (ImGui::Button(ICON_FA_CHECK " Save")) {
         if (editName[0] != '\0')
           s.name = editName;
@@ -6942,17 +7028,42 @@ void renderSnapshotsWindow() {
         s.color = editColor;
         editingIndex = -1;
       }
+      ImGui::PopStyleColor();
       ImGui::SameLine();
       if (ImGui::Button(ICON_FA_TIMES " Cancel"))
         editingIndex = -1;
+      ImGui::PopStyleVar();
     }
 
-    ImGui::EndGroup();
+    ImGui::EndChild();
+    ImGui::PopStyleVar(2);
+    ImGui::PopStyleColor();
+
+    // Draw the left color stripe and a hover ring over the finished card.
+    ImVec2 cardMin = ImGui::GetItemRectMin();
+    ImVec2 cardMax = ImGui::GetItemRectMax();
+    ImDrawList *dl = ImGui::GetWindowDrawList();
+    if (s.hasColor)
+      dl->AddRectFilled(
+          cardMin, ImVec2(cardMin.x + 4.0f * scale, cardMax.y),
+          ImGui::ColorConvertFloat4ToU32(
+              ImVec4(s.color.r, s.color.g, s.color.b, 1.0f)),
+          10.0f * scale, ImDrawFlags_RoundCornersLeft);
+    if (ImGui::IsItemHovered())
+      dl->AddRect(cardMin, cardMax, ImGui::GetColorU32(g_StyleColors.accent),
+                  10.0f * scale, 0, 1.5f * scale);
+
     ImGui::PopID();
-    ImGui::Separator();
+    ImGui::Spacing();
   }
-  if (visibleCount == 0)
-    ImGui::TextDisabled("No snapshots match the current search / filters.");
+  if (visibleCount == 0) {
+    ImGui::Spacing();
+    const char *msg = "No snapshots match the current search / filters.";
+    float tw = ImGui::CalcTextSize(msg).x;
+    ImGui::SetCursorPosX(
+        std::max(0.0f, (ImGui::GetContentRegionAvail().x - tw) * 0.5f));
+    ImGui::TextDisabled("%s", msg);
+  }
   ImGui::EndChild();
 
   // Apply deferred actions after the loop so the list isn't mutated mid-draw.

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -19,6 +19,7 @@
 #include "imgui/imgui_sytle.h"
 #include "libs/portable-file-dialogs.h"
 #include <algorithm>
+#include <cctype>
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
@@ -6563,6 +6564,100 @@ static void DrawSnapshotIcon(const char *icon, const char *tooltip) {
     ImGui::SetTooltip("%s", tooltip);
 }
 
+// ── Snapshot organization helpers ─────────────────────────────────────────
+
+// Case-insensitive subsequence match: every character of `needle` must appear
+// in `haystack` in order (not necessarily contiguous). An empty needle always
+// matches. This gives a forgiving "fuzzy" feel for the search box.
+static bool snapshotFuzzyMatch(const std::string &needle,
+                               const std::string &haystack) {
+  if (needle.empty())
+    return true;
+  size_t h = 0;
+  for (char rawN : needle) {
+    char n = static_cast<char>(std::tolower(static_cast<unsigned char>(rawN)));
+    bool found = false;
+    for (; h < haystack.size(); ++h) {
+      char c = static_cast<char>(
+          std::tolower(static_cast<unsigned char>(haystack[h])));
+      if (c == n) {
+        ++h;
+        found = true;
+        break;
+      }
+    }
+    if (!found)
+      return false;
+  }
+  return true;
+}
+
+// Build the combined searchable text for a snapshot: name, timestamp, tags and
+// the names of the aspects it stored. Used by the fuzzy search box.
+static std::string snapshotSearchText(const Core::Snapshot &s) {
+  std::string text = s.name + " " + s.timestamp;
+  for (const auto &t : s.tags)
+    text += " " + t;
+  if (s.flags & Core::SNAPSHOT_CAMERA)
+    text += " camera";
+  if (s.flags & Core::SNAPSHOT_SCENE)
+    text += " scene";
+  if (s.flags & Core::SNAPSHOT_TOOLS)
+    text += " tools";
+  return text;
+}
+
+// Split a comma-separated string into trimmed, non-empty tags.
+static std::vector<std::string> parseSnapshotTags(const char *csv) {
+  std::vector<std::string> out;
+  std::string cur;
+  auto flush = [&]() {
+    size_t a = cur.find_first_not_of(" \t");
+    size_t b = cur.find_last_not_of(" \t");
+    if (a != std::string::npos)
+      out.push_back(cur.substr(a, b - a + 1));
+    cur.clear();
+  };
+  for (const char *p = csv; *p; ++p) {
+    if (*p == ',')
+      flush();
+    else
+      cur += *p;
+  }
+  flush();
+  return out;
+}
+
+static std::string joinSnapshotTags(const std::vector<std::string> &tags) {
+  std::string s;
+  for (size_t i = 0; i < tags.size(); ++i) {
+    if (i)
+      s += ", ";
+    s += tags[i];
+  }
+  return s;
+}
+
+// A small rounded "chip" used to display / toggle a tag. Returns true when the
+// chip is clicked. `active` draws it with the accent fill (used for active
+// filters).
+static bool DrawTagChip(const char *label, bool active) {
+  ImVec4 base =
+      active ? g_StyleColors.accent
+             : ImVec4(g_StyleColors.primary.x, g_StyleColors.primary.y,
+                      g_StyleColors.primary.z, 0.35f);
+  ImGui::PushStyleColor(ImGuiCol_Button, base);
+  ImGui::PushStyleColor(ImGuiCol_ButtonHovered, g_StyleColors.primaryHover);
+  ImGui::PushStyleColor(ImGuiCol_ButtonActive, g_StyleColors.primaryActive);
+  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding,
+                      ImGui::GetFrameHeight() * 0.5f);
+  std::string id = std::string(label) + "##chip";
+  bool clicked = ImGui::SmallButton(id.c_str());
+  ImGui::PopStyleVar();
+  ImGui::PopStyleColor(3);
+  return clicked;
+}
+
 // Snapshots panel: capture the current camera / scene / tool state into named,
 // thumbnailed checkpoints and roll back to them. Mirrors the screenshot capture
 // pipeline for the thumbnail and the Undo edit-states for the scene data.
@@ -6644,12 +6739,100 @@ void renderSnapshotsWindow() {
     return;
   }
 
+  // ── Search box ──────────────────────────────────────────────────────────
+  // Fuzzy (subsequence) match across name, timestamp, tags and aspect names.
+  static char searchBuf[128] = "";
+  DrawSnapshotIcon(ICON_FA_SEARCH, "Fuzzy search over name, tags, date & "
+                                   "aspects");
+  ImGui::SameLine();
+  ImGui::SetNextItemWidth(-(40 * scale));
+  ImGui::InputTextWithHint("##snapSearch", "Search snapshots…", searchBuf,
+                           IM_ARRAYSIZE(searchBuf));
+  ImGui::SameLine();
+  if (ImGui::Button(ICON_FA_TIMES "##clearSearch"))
+    searchBuf[0] = '\0';
+  if (ImGui::IsItemHovered())
+    ImGui::SetTooltip("Clear search");
+
+  // ── Tag filter chips ────────────────────────────────────────────────────
+  // Collect the live tag set and drop any active filters whose tag no longer
+  // exists (e.g. after an edit or delete). A snapshot passes when it carries
+  // any of the selected tags.
+  static std::set<std::string> activeTagFilters;
+  std::set<std::string> allTags;
+  for (const auto &s : snaps)
+    for (const auto &t : s.tags)
+      allTags.insert(t);
+  for (auto it = activeTagFilters.begin(); it != activeTagFilters.end();) {
+    if (allTags.find(*it) == allTags.end())
+      it = activeTagFilters.erase(it);
+    else
+      ++it;
+  }
+
+  if (!allTags.empty()) {
+    const ImGuiStyle &style = ImGui::GetStyle();
+    float rightEdge =
+        ImGui::GetCursorScreenPos().x + ImGui::GetContentRegionAvail().x;
+    DrawSnapshotIcon(ICON_FA_FILTER, "Filter by tag (matches any selected)");
+    int chipId = 0;
+    for (const auto &t : allTags) {
+      ImGui::PushID(chipId++);
+      float thisW = ImGui::CalcTextSize(t.c_str()).x +
+                    style.FramePadding.x * 2.0f + 8.0f * scale;
+      if (ImGui::GetItemRectMax().x + style.ItemSpacing.x + thisW < rightEdge)
+        ImGui::SameLine();
+      bool active = activeTagFilters.count(t) != 0;
+      if (DrawTagChip(t.c_str(), active)) {
+        if (active)
+          activeTagFilters.erase(t);
+        else
+          activeTagFilters.insert(t);
+      }
+      ImGui::PopID();
+    }
+    if (!activeTagFilters.empty()) {
+      ImGui::SameLine();
+      if (ImGui::SmallButton("Clear filters"))
+        activeTagFilters.clear();
+    }
+  }
+
+  ImGui::Spacing();
+
   int toRestore = -1;
   int toDelete = -1;
+
+  // Inline editor state. `editingIndex` indexes into the live snapshot vector;
+  // it is cleared whenever the vector is mutated (delete) so it can't dangle.
+  static int editingIndex = -1;
+  static char editName[128] = "";
+  static char editTags[256] = "";
+  static bool editHasColor = false;
+  static glm::vec3 editColor = glm::vec3(0.40f, 0.65f, 1.0f);
+
+  int visibleCount = 0;
 
   ImGui::BeginChild("SnapshotList", ImVec2(0, 0), false);
   for (int i = 0; i < static_cast<int>(snaps.size()); ++i) {
     Core::Snapshot &s = snaps[i];
+
+    // Apply the search box and tag filters.
+    if (searchBuf[0] != '\0' &&
+        !snapshotFuzzyMatch(searchBuf, snapshotSearchText(s)))
+      continue;
+    if (!activeTagFilters.empty()) {
+      bool anyMatch = false;
+      for (const auto &t : s.tags)
+        if (activeTagFilters.count(t)) {
+          anyMatch = true;
+          break;
+        }
+      if (!anyMatch)
+        continue;
+    }
+    ++visibleCount;
+
     ImGui::PushID(i);
 
     const float thumbW = 170 * scale;
@@ -6668,6 +6851,15 @@ void renderSnapshotsWindow() {
     ImGui::SameLine();
     ImGui::BeginGroup();
 
+    // Optional color marker, then the name.
+    if (s.hasColor) {
+      ImGui::ColorButton("##marker",
+                         ImVec4(s.color.r, s.color.g, s.color.b, 1.0f),
+                         ImGuiColorEditFlags_NoTooltip |
+                             ImGuiColorEditFlags_NoPicker,
+                         ImVec2(14 * scale, 14 * scale));
+      ImGui::SameLine();
+    }
     if (g_Fonts.bold)
       ImGui::PushFont(g_Fonts.bold);
     ImGui::TextUnformatted(s.name.c_str());
@@ -6690,25 +6882,87 @@ void renderSnapshotsWindow() {
     }
     ImGui::NewLine();
 
+    // Tag chips: click one to toggle it as a filter.
+    if (!s.tags.empty()) {
+      DrawSnapshotIcon(ICON_FA_TAGS, "Tags");
+      for (size_t ti = 0; ti < s.tags.size(); ++ti) {
+        ImGui::SameLine();
+        ImGui::PushID(static_cast<int>(ti));
+        bool active = activeTagFilters.count(s.tags[ti]) != 0;
+        if (DrawTagChip(s.tags[ti].c_str(), active)) {
+          if (active)
+            activeTagFilters.erase(s.tags[ti]);
+          else
+            activeTagFilters.insert(s.tags[ti]);
+        }
+        ImGui::PopID();
+      }
+    }
+
     if (ImGui::Button(ICON_FA_HISTORY " Restore"))
       toRestore = i;
+    ImGui::SameLine();
+    if (ImGui::Button(ICON_FA_PEN " Edit")) {
+      editingIndex = (editingIndex == i) ? -1 : i;
+      if (editingIndex == i) {
+        std::snprintf(editName, sizeof(editName), "%s", s.name.c_str());
+        std::string joined = joinSnapshotTags(s.tags);
+        std::snprintf(editTags, sizeof(editTags), "%s", joined.c_str());
+        editHasColor = s.hasColor;
+        editColor = s.color;
+      }
+    }
     ImGui::SameLine();
     ImGui::PushStyleColor(ImGuiCol_Button, g_StyleColors.danger);
     if (ImGui::Button(ICON_FA_TRASH " Delete"))
       toDelete = i;
     ImGui::PopStyleColor();
 
+    // Inline editor for name / tags / color.
+    if (editingIndex == i) {
+      ImGui::Spacing();
+      ImGui::SetNextItemWidth(-1);
+      ImGui::InputTextWithHint("##editName", "Name", editName,
+                               IM_ARRAYSIZE(editName));
+      ImGui::SetNextItemWidth(-1);
+      ImGui::InputTextWithHint("##editTags", "Tags (comma-separated)", editTags,
+                               IM_ARRAYSIZE(editTags));
+      ImGui::Checkbox("Color marker", &editHasColor);
+      if (editHasColor) {
+        ImGui::SameLine();
+        ImGui::ColorEdit3("##editColor", &editColor.x,
+                          ImGuiColorEditFlags_NoInputs |
+                              ImGuiColorEditFlags_NoLabel);
+      }
+      if (ImGui::Button(ICON_FA_CHECK " Save")) {
+        if (editName[0] != '\0')
+          s.name = editName;
+        s.tags = parseSnapshotTags(editTags);
+        s.hasColor = editHasColor;
+        s.color = editColor;
+        editingIndex = -1;
+      }
+      ImGui::SameLine();
+      if (ImGui::Button(ICON_FA_TIMES " Cancel"))
+        editingIndex = -1;
+    }
+
     ImGui::EndGroup();
     ImGui::PopID();
     ImGui::Separator();
   }
+  if (visibleCount == 0)
+    ImGui::TextDisabled("No snapshots match the current search / filters.");
   ImGui::EndChild();
 
   // Apply deferred actions after the loop so the list isn't mutated mid-draw.
   if (toRestore >= 0)
     Core::RestoreSnapshot(toRestore);
-  if (toDelete >= 0)
+  if (toDelete >= 0) {
     mgr.remove(toDelete);
+    // Indices shift after a delete; close any open editor to avoid dangling.
+    editingIndex = -1;
+  }
 
   ImGui::End();
 }


### PR DESCRIPTION
Extend the Snapshot system with lightweight organization tools in the
Snapshots panel:

- Data model: each Snapshot now carries freeform `tags` (labels/categories)
  and an optional `color` marker (hasColor + glm::vec3), persisted with the
  scene via snapshots.json and reloaded with it.
- Fuzzy search box: case-insensitive subsequence match across name,
  timestamp, tags and aspect names (camera/scene/tools).
- Tag filter chips: collected from the live tag set; click to toggle. A
  snapshot is shown when it carries any selected tag. Stale filters are
  pruned automatically.
- Inline editor per snapshot: rename, edit comma-separated tags, and pick a
  color marker.
- Each list row shows its color swatch and clickable tag chips.

No changes to the capture glue in main.cpp; tags/color are edited after
capture. Restore/persistence behavior is otherwise unchanged.