### PR TITLE
Polish GUI: coherent panel titles, smarter search, menu hints

### DIFF
--- a/StereoVista/headers/Gui/GuiTypes.h
+++ b/StereoVista/headers/Gui/GuiTypes.h
@@ -101,6 +101,9 @@ struct PlaneCursor {
 
 struct ApplicationPreferences {
   bool isDarkTheme = true;
+  // Index into the GuiTheme enum (imgui_sytle.h). Authoritative theme selection;
+  // isDarkTheme is kept in sync for legacy code paths and font handling.
+  int guiTheme = 0;
   float guiScaleFactor =
       1.0f; // User-controlled GUI scale multiplier (0.5x - 2.0x)
   float separation = 0.5f;

--- a/StereoVista/headers/libs/imgui/imgui_style.cpp
+++ b/StereoVista/headers/libs/imgui/imgui_style.cpp
@@ -10,6 +10,115 @@
 ImGuiFonts g_Fonts;
 GuiScaleSettings g_GuiScale;
 CustomStyleColors g_StyleColors;
+int g_currentTheme = GUI_THEME_MODERN_DARK;
+
+// ===========================================================================
+// Color themes
+// ===========================================================================
+
+// A theme is described by a compact palette. The four background levels are
+// ordered from the primary surface outward: for DARK themes lvl0 is the
+// darkest (title bars / scrollbar track) and lvl3 the lightest (frames,
+// buttons, borders); for LIGHT themes lvl0 is the lightest (window) and lvl3
+// the darkest (strong borders / active grabs). The accent drives all the
+// interactive highlights; status colors feed toasts and the FPS overlay.
+struct ThemePalette {
+  const char *name;
+  bool isDark;
+  ImVec4 lvl0, lvl1, lvl2, lvl3;
+  ImVec4 textPrimary, textSecondary, textDisabled;
+  ImVec4 accent, accentHover, accentActive;
+  ImVec4 success, warning, danger, info;
+};
+
+// 0xRRGGBB -> ImVec4 helper for authoring palettes from hex codes.
+static ImVec4 Hex(unsigned int rgb, float a = 1.0f) {
+  return ImVec4(((rgb >> 16) & 0xFF) / 255.0f, ((rgb >> 8) & 0xFF) / 255.0f,
+                (rgb & 0xFF) / 255.0f, a);
+}
+
+static const ThemePalette &GetPalette(int theme) {
+  // Function-local static: built once, on first use. Keep this array in the
+  // same order as the GuiTheme enum.
+  static const ThemePalette palettes[GUI_THEME_COUNT] = {
+      // GUI_THEME_MODERN_DARK -- the original cool indigo dark theme (exact
+      // float values preserved so the default look is unchanged).
+      {"Modern Dark", true,
+       ImVec4(0.085f, 0.090f, 0.105f, 1.00f), ImVec4(0.115f, 0.122f, 0.140f, 1.00f),
+       ImVec4(0.155f, 0.165f, 0.190f, 1.00f), ImVec4(0.205f, 0.217f, 0.245f, 1.00f),
+       ImVec4(0.95f, 0.96f, 0.98f, 1.00f), ImVec4(0.65f, 0.68f, 0.72f, 1.00f),
+       ImVec4(0.46f, 0.49f, 0.55f, 1.00f),
+       ImVec4(0.33f, 0.56f, 1.00f, 1.00f), ImVec4(0.45f, 0.66f, 1.00f, 1.00f),
+       ImVec4(0.25f, 0.46f, 0.92f, 1.00f),
+       ImVec4(0.26f, 0.73f, 0.42f, 1.00f), ImVec4(0.96f, 0.69f, 0.13f, 1.00f),
+       ImVec4(0.86f, 0.28f, 0.29f, 1.00f), ImVec4(0.20f, 0.65f, 0.87f, 1.00f)},
+
+      // GUI_THEME_MODERN_LIGHT -- the original clean light theme (preserved).
+      {"Modern Light", false,
+       ImVec4(0.98f, 0.98f, 0.99f, 1.00f), ImVec4(0.94f, 0.95f, 0.96f, 1.00f),
+       ImVec4(0.88f, 0.89f, 0.91f, 1.00f), ImVec4(0.82f, 0.84f, 0.86f, 1.00f),
+       ImVec4(0.10f, 0.10f, 0.12f, 1.00f), ImVec4(0.40f, 0.42f, 0.46f, 1.00f),
+       ImVec4(0.60f, 0.62f, 0.66f, 1.00f),
+       ImVec4(0.26f, 0.50f, 0.98f, 1.00f), ImVec4(0.36f, 0.60f, 1.00f, 1.00f),
+       ImVec4(0.20f, 0.42f, 0.90f, 1.00f),
+       ImVec4(0.20f, 0.70f, 0.35f, 1.00f), ImVec4(0.90f, 0.65f, 0.10f, 1.00f),
+       ImVec4(0.85f, 0.25f, 0.25f, 1.00f), ImVec4(0.15f, 0.60f, 0.85f, 1.00f)},
+
+      // GUI_THEME_SCHNEIDER_DIGITAL -- the Schneider Digital brand: clean white
+      // surfaces, near-black text and the signature golden-yellow accent (matched
+      // to the logo / call-to-action yellow on schneider-digital.com).
+      {"Schneider Digital", false,
+       Hex(0xFCFCFC), Hex(0xEFF0F1), Hex(0xDDDFE2), Hex(0xC0C3C7),
+       Hex(0x1B1B1B), Hex(0x565A5E), Hex(0x9AA0A6),
+       Hex(0xF3C218), Hex(0xFFD23D), Hex(0xD9A50A),
+       Hex(0x2FA15A), Hex(0xE0900F), Hex(0xD63A3A), Hex(0x1F8FCF)},
+
+      // GUI_THEME_NORD -- the popular muted arctic blue-gray palette; very easy
+      // on the eyes for long sessions.
+      {"Nord", true,
+       Hex(0x2E3440), Hex(0x343C4A), Hex(0x3B4252), Hex(0x4C566A),
+       Hex(0xECEFF4), Hex(0xC2CAD8), Hex(0x808C9E),
+       Hex(0x88C0D0), Hex(0x9FD3E0), Hex(0x5E81AC),
+       Hex(0xA3BE8C), Hex(0xEBCB8B), Hex(0xBF616A), Hex(0x81A1C1)},
+
+      // GUI_THEME_FOREST -- warm olive/green with a cream foreground.
+      {"Forest", true,
+       Hex(0x141711), Hex(0x1B211A), Hex(0x252D1F), Hex(0x3A4630),
+       Hex(0xEBD5AB), Hex(0xA8B58C), Hex(0x6E7A5A),
+       Hex(0x8BAE66), Hex(0xA6C683), Hex(0x628141),
+       Hex(0x6FBF73), Hex(0xE0A93B), Hex(0xD9694E), Hex(0x6FA8C9)},
+
+      // GUI_THEME_LAGOON -- deep teal with a mint accent and cream text.
+      {"Lagoon", true,
+       Hex(0x122420), Hex(0x1A312C), Hex(0x214139), Hex(0x2F5A4F),
+       Hex(0xFFF4E1), Hex(0xA7C5BB), Hex(0x6F8A82),
+       Hex(0x89D7B7), Hex(0xA6E6CC), Hex(0x428475),
+       Hex(0x5FC79A), Hex(0xE8B85C), Hex(0xE07A6A), Hex(0x5FB0C9)},
+
+      // GUI_THEME_AMETHYST -- neutral near-black with a soft violet accent.
+      {"Amethyst", true,
+       Hex(0x15131C), Hex(0x1C1925), Hex(0x272234), Hex(0x352E47),
+       Hex(0xECE9F2), Hex(0xA79FB8), Hex(0x6E667E),
+       Hex(0xA579F0), Hex(0xB994F5), Hex(0x8A5BE0),
+       Hex(0x56C596), Hex(0xE9B44C), Hex(0xE5616E), Hex(0x6FA8DC)},
+  };
+  if (theme < 0 || theme >= GUI_THEME_COUNT)
+    theme = GUI_THEME_MODERN_DARK;
+  return palettes[theme];
+}
+
+int GetGuiThemeCount() { return GUI_THEME_COUNT; }
+const char *GetGuiThemeName(int theme) { return GetPalette(theme).name; }
+bool IsGuiThemeDark(int theme) { return GetPalette(theme).isDark; }
+
+int GetGuiThemeSwatches(int theme, ImVec4 *out, int maxColors) {
+  const ThemePalette &p = GetPalette(theme);
+  const ImVec4 colors[4] = {p.lvl1, p.accent, p.textPrimary, p.lvl3};
+  int n = maxColors < 4 ? maxColors : 4;
+  for (int i = 0; i < n; ++i)
+    out[i] = colors[i];
+  return n;
+}
 
 bool InitializeImGuiWithFonts(GLFWwindow *window, bool isDarkTheme) {
   IMGUI_CHECKVERSION();
@@ -315,9 +424,10 @@ void RescaleImGuiFonts(GLFWwindow *window, bool isDarkTheme) {
     g_GuiScale.needsFontRebuild = false;
   }
 
-  // Always update style to match current scale
+  // Always update style to match current scale. Re-apply the active theme
+  // (not the dark/light boolean) so a custom theme survives a window resize.
   if (g_GuiScale.needsRescale) {
-    SetupImGuiStyle(isDarkTheme, 1.0f);
+    ApplyGuiTheme(g_currentTheme, 1.0f);
     g_GuiScale.needsRescale = false;
   }
 }
@@ -565,8 +675,8 @@ void RebuildImGuiFontAtlas(bool isDarkTheme) {
             << std::endl;
 }
 
-void SetupImGuiStyle(bool bStyleDark_, float alpha_) {
-  ImGuiStyle &style = ImGui::GetStyle();
+// Shared geometry (spacing, rounding, sizes). Applied for every theme.
+static void ApplyStyleGeometry(ImGuiStyle &style) {
   float scale = g_GuiScale.currentScale;
 
   // Modern style parameters with improved spacing
@@ -600,43 +710,26 @@ void SetupImGuiStyle(bool bStyleDark_, float alpha_) {
   style.ColorButtonPosition = ImGuiDir_Right;
   style.ButtonTextAlign = ImVec2(0.5f, 0.5f);
   style.SelectableTextAlign = ImVec2(0.0f, 0.0f);
+}
 
-  // Apply modern color schemes
-  if (bStyleDark_) {
-    // Modern Dark Theme with blue accents
+// Dark-theme color engine. Reads the four background levels and accents from
+// the palette (lvl0 darkest .. lvl3 lightest) and lays out every ImGui color
+// the same way the original dark theme did, so any dark palette gets a
+// consistent, tuned result.
+static void ApplyDarkColors(ImGuiStyle &style, const ThemePalette &p) {
     ImVec4 *colors = style.Colors;
 
-    // Define color palette - deeper, cooler neutrals for a premium feel
-    const ImVec4 bgDark = ImVec4(0.085f, 0.090f, 0.105f, 1.00f);     // #16171B
-    const ImVec4 bgMedium = ImVec4(0.115f, 0.122f, 0.140f, 1.00f);   // #1D1F24
-    const ImVec4 bgLight = ImVec4(0.155f, 0.165f, 0.190f, 1.00f);    // #282A30
-    const ImVec4 bgVeryLight = ImVec4(0.205f, 0.217f, 0.245f, 1.00f);// #34373E
+    const ImVec4 bgDark = p.lvl0;
+    const ImVec4 bgMedium = p.lvl1;
+    const ImVec4 bgLight = p.lvl2;
+    const ImVec4 bgVeryLight = p.lvl3;
 
-    const ImVec4 textPrimary = ImVec4(0.95f, 0.96f, 0.98f, 1.00f);
-    const ImVec4 textSecondary = ImVec4(0.65f, 0.68f, 0.72f, 1.00f);
-    const ImVec4 textDisabled = ImVec4(0.46f, 0.49f, 0.55f, 1.00f);
+    const ImVec4 textPrimary = p.textPrimary;
+    const ImVec4 textDisabled = p.textDisabled;
 
-    // Modern indigo-blue accent colors
-    const ImVec4 accentPrimary = ImVec4(0.33f, 0.56f, 1.00f, 1.00f); // #548FFF
-    const ImVec4 accentHover = ImVec4(0.45f, 0.66f, 1.00f, 1.00f);   // #73A8FF
-    const ImVec4 accentActive = ImVec4(0.25f, 0.46f, 0.92f, 1.00f);  // #4076EB
-    const ImVec4 accentDim = ImVec4(0.33f, 0.56f, 1.00f, 0.40f);
-
-    // Success, Warning, Danger colors
-    const ImVec4 success = ImVec4(0.26f, 0.73f, 0.42f, 1.00f); // #43BB6C
-    const ImVec4 warning = ImVec4(0.96f, 0.69f, 0.13f, 1.00f); // #F5B021
-    const ImVec4 danger = ImVec4(0.86f, 0.28f, 0.29f, 1.00f);  // #DC474A
-
-    // Store custom colors
-    g_StyleColors.primary = accentPrimary;
-    g_StyleColors.primaryHover = accentHover;
-    g_StyleColors.primaryActive = accentActive;
-    g_StyleColors.secondary = bgVeryLight;
-    g_StyleColors.accent = accentPrimary;
-    g_StyleColors.success = success;
-    g_StyleColors.warning = warning;
-    g_StyleColors.danger = danger;
-    g_StyleColors.info = ImVec4(0.20f, 0.65f, 0.87f, 1.00f);
+    const ImVec4 accentPrimary = p.accent;
+    const ImVec4 accentHover = p.accentHover;
+    const ImVec4 accentActive = p.accentActive;
 
     // Background colors
     colors[ImGuiCol_WindowBg] = bgMedium;
@@ -745,35 +838,25 @@ void SetupImGuiStyle(bool bStyleDark_, float alpha_) {
     colors[ImGuiCol_NavWindowingHighlight] = ImVec4(1.00f, 1.00f, 1.00f, 0.70f);
     colors[ImGuiCol_NavWindowingDimBg] = ImVec4(0.80f, 0.80f, 0.80f, 0.20f);
     colors[ImGuiCol_ModalWindowDimBg] = ImVec4(0.00f, 0.00f, 0.00f, 0.50f);
-  } else {
-    // Modern Light Theme
+}
+
+// Light-theme color engine. Reads the four background levels from the palette
+// (lvl0 lightest .. lvl3 darkest) and the accents, reproducing the original
+// light theme's layout for any light palette.
+static void ApplyLightColors(ImGuiStyle &style, const ThemePalette &p) {
     ImVec4 *colors = style.Colors;
 
-    // Light color palette
-    const ImVec4 bgWhite = ImVec4(0.98f, 0.98f, 0.99f, 1.00f);  // #FAFAFC
-    const ImVec4 bgLight = ImVec4(0.94f, 0.95f, 0.96f, 1.00f);  // #F0F2F5
-    const ImVec4 bgMedium = ImVec4(0.88f, 0.89f, 0.91f, 1.00f); // #E0E3E8
-    const ImVec4 bgDark = ImVec4(0.82f, 0.84f, 0.86f, 1.00f);   // #D1D5DB
+    const ImVec4 bgWhite = p.lvl0;
+    const ImVec4 bgLight = p.lvl1;
+    const ImVec4 bgMedium = p.lvl2;
+    const ImVec4 bgDark = p.lvl3;
 
-    const ImVec4 textPrimary = ImVec4(0.10f, 0.10f, 0.12f, 1.00f);
-    const ImVec4 textSecondary = ImVec4(0.40f, 0.42f, 0.46f, 1.00f);
-    const ImVec4 textDisabled = ImVec4(0.60f, 0.62f, 0.66f, 1.00f);
+    const ImVec4 textPrimary = p.textPrimary;
+    const ImVec4 textDisabled = p.textDisabled;
 
-    // Indigo-blue accent for light theme (matches the dark theme accent)
-    const ImVec4 accentPrimary = ImVec4(0.26f, 0.50f, 0.98f, 1.00f);
-    const ImVec4 accentHover = ImVec4(0.36f, 0.60f, 1.00f, 1.00f);
-    const ImVec4 accentActive = ImVec4(0.20f, 0.42f, 0.90f, 1.00f);
-
-    // Store custom colors
-    g_StyleColors.primary = accentPrimary;
-    g_StyleColors.primaryHover = accentHover;
-    g_StyleColors.primaryActive = accentActive;
-    g_StyleColors.secondary = bgMedium;
-    g_StyleColors.accent = accentPrimary;
-    g_StyleColors.success = ImVec4(0.20f, 0.70f, 0.35f, 1.00f);
-    g_StyleColors.warning = ImVec4(0.90f, 0.65f, 0.10f, 1.00f);
-    g_StyleColors.danger = ImVec4(0.85f, 0.25f, 0.25f, 1.00f);
-    g_StyleColors.info = ImVec4(0.15f, 0.60f, 0.85f, 1.00f);
+    const ImVec4 accentPrimary = p.accent;
+    const ImVec4 accentHover = p.accentHover;
+    const ImVec4 accentActive = p.accentActive;
 
     // Background colors
     colors[ImGuiCol_WindowBg] = bgWhite;
@@ -867,15 +950,52 @@ void SetupImGuiStyle(bool bStyleDark_, float alpha_) {
     colors[ImGuiCol_NavWindowingHighlight] = ImVec4(0.70f, 0.70f, 0.70f, 0.70f);
     colors[ImGuiCol_NavWindowingDimBg] = ImVec4(0.20f, 0.20f, 0.20f, 0.20f);
     colors[ImGuiCol_ModalWindowDimBg] = ImVec4(0.00f, 0.00f, 0.00f, 0.35f);
-  }
+}
+
+// Apply a full color theme: shared geometry, the palette-derived colors via the
+// matching (dark/light) engine, and the published g_StyleColors used across the
+// GUI. Records the theme so GUI-scale restyles keep the user's choice.
+void ApplyGuiTheme(int theme, float alpha) {
+  if (theme < 0 || theme >= GUI_THEME_COUNT)
+    theme = GUI_THEME_MODERN_DARK;
+  g_currentTheme = theme;
+
+  const ThemePalette &p = GetPalette(theme);
+  ImGuiStyle &style = ImGui::GetStyle();
+
+  ApplyStyleGeometry(style);
+
+  // Publish accent/status colors consumed throughout the GUI (section headers,
+  // toasts, the performance overlay, etc.).
+  g_StyleColors.primary = p.accent;
+  g_StyleColors.primaryHover = p.accentHover;
+  g_StyleColors.primaryActive = p.accentActive;
+  g_StyleColors.secondary = p.lvl3;
+  g_StyleColors.accent = p.accent;
+  g_StyleColors.success = p.success;
+  g_StyleColors.warning = p.warning;
+  g_StyleColors.danger = p.danger;
+  g_StyleColors.info = p.info;
+
+  if (p.isDark)
+    ApplyDarkColors(style, p);
+  else
+    ApplyLightColors(style, p);
 
   // Apply alpha if needed
-  if (alpha_ < 1.0f) {
+  if (alpha < 1.0f) {
     ImVec4 *colors = style.Colors;
     for (int i = 0; i < ImGuiCol_COUNT; i++) {
-      colors[i].w *= alpha_;
+      colors[i].w *= alpha;
     }
   }
+}
+
+// Backward-compatible entry point: maps the old dark/light boolean onto the two
+// built-in themes.
+void SetupImGuiStyle(bool bStyleDark_, float alpha_) {
+  ApplyGuiTheme(bStyleDark_ ? GUI_THEME_MODERN_DARK : GUI_THEME_MODERN_LIGHT,
+                alpha_);
 }
 
 // Custom widget styling functions

--- a/StereoVista/headers/libs/imgui/imgui_style.cpp
+++ b/StereoVista/headers/libs/imgui/imgui_style.cpp
@@ -666,13 +666,14 @@ void SetupImGuiStyle(bool bStyleDark_, float alpha_) {
     colors[ImGuiCol_ButtonActive] =
         ImVec4(accentPrimary.x, accentPrimary.y, accentPrimary.z, 0.50f);
 
-    // Frame backgrounds
+    // Frame backgrounds. Kept solid enough that input boxes, combos and
+    // sliders read as distinct controls against the window background.
     colors[ImGuiCol_FrameBg] =
-        ImVec4(bgVeryLight.x, bgVeryLight.y, bgVeryLight.z, 0.30f);
+        ImVec4(bgVeryLight.x, bgVeryLight.y, bgVeryLight.z, 0.52f);
     colors[ImGuiCol_FrameBgHovered] =
-        ImVec4(bgVeryLight.x, bgVeryLight.y, bgVeryLight.z, 0.40f);
+        ImVec4(bgVeryLight.x, bgVeryLight.y, bgVeryLight.z, 0.68f);
     colors[ImGuiCol_FrameBgActive] =
-        ImVec4(bgVeryLight.x, bgVeryLight.y, bgVeryLight.z, 0.50f);
+        ImVec4(bgVeryLight.x, bgVeryLight.y, bgVeryLight.z, 0.80f);
 
     // Tabs
     colors[ImGuiCol_Tab] = bgLight;

--- a/StereoVista/headers/libs/imgui/imgui_sytle.h
+++ b/StereoVista/headers/libs/imgui/imgui_sytle.h
@@ -55,6 +55,20 @@ enum class GuiStylePreset {
     MINIMAL
 };
 
+// Selectable color themes. The index of each entry doubles as the value
+// persisted in preferences ("ui.theme"), so only ever append new themes to the
+// end -- never reorder or remove -- to keep saved preferences stable.
+enum GuiTheme {
+    GUI_THEME_MODERN_DARK = 0,
+    GUI_THEME_MODERN_LIGHT,
+    GUI_THEME_SCHNEIDER_DIGITAL,
+    GUI_THEME_NORD,
+    GUI_THEME_FOREST,
+    GUI_THEME_LAGOON,
+    GUI_THEME_AMETHYST,
+    GUI_THEME_COUNT
+};
+
 // Custom style colors
 struct CustomStyleColors {
     ImVec4 primary;
@@ -72,6 +86,9 @@ struct CustomStyleColors {
 extern ImGuiFonts g_Fonts;
 extern GuiScaleSettings g_GuiScale;
 extern CustomStyleColors g_StyleColors;
+// Index (GuiTheme) of the theme currently applied. Authoritative for restyles
+// triggered by GUI-scale changes, so a custom theme survives a window resize.
+extern int g_currentTheme;
 
 // Function declarations
 bool InitializeImGuiWithFonts(GLFWwindow* window, bool isDarkTheme);
@@ -80,3 +97,14 @@ float CalculateGuiScale(int windowWidth, int windowHeight);
 void RescaleImGuiFonts(GLFWwindow* window, bool isDarkTheme);
 void RebuildImGuiFontAtlas(bool isDarkTheme);
 void ApplyStylePreset(GuiStylePreset preset);
+
+// Theme system. ApplyGuiTheme() applies a full color theme (and the shared
+// geometry/spacing) and records it as the current theme. The helpers expose
+// theme metadata for building the picker UI.
+void ApplyGuiTheme(int theme, float alpha);
+int GetGuiThemeCount();
+const char *GetGuiThemeName(int theme);
+bool IsGuiThemeDark(int theme);
+// Fills up to `maxColors` swatch colors (background, accent, two text/surface
+// tones) for a compact preview in the picker. Returns the count written.
+int GetGuiThemeSwatches(int theme, ImVec4 *out, int maxColors);

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -4135,14 +4135,47 @@ void renderSettingsWindow() {
       ImGui::PushID("DisplayTab");
       DrawSectionHeader("Interface");
 
-      if (ImGui::Checkbox("Dark Theme", &isDarkTheme)) {
-        SetupImGuiStyle(isDarkTheme, 1.0f);
-        preferences.isDarkTheme = isDarkTheme;
-        settingsChanged = true;
+      // Color theme picker
+      {
+        int themeIndex = preferences.guiTheme;
+        if (themeIndex < 0 || themeIndex >= GetGuiThemeCount())
+          themeIndex = 0;
+
+        if (ImGui::BeginCombo("Theme", GetGuiThemeName(themeIndex))) {
+          for (int i = 0; i < GetGuiThemeCount(); ++i) {
+            bool selected = (i == themeIndex);
+            if (ImGui::Selectable(GetGuiThemeName(i), selected)) {
+              ApplyGuiTheme(i, 1.0f);
+              themeIndex = i;
+              preferences.guiTheme = i;
+              isDarkTheme = IsGuiThemeDark(i);
+              preferences.isDarkTheme = isDarkTheme;
+              settingsChanged = true;
+            }
+            if (selected)
+              ImGui::SetItemDefaultFocus();
+          }
+          ImGui::EndCombo();
+        }
+        ImGui::SameLine();
+        DrawHelpMarker("Color theme for the entire interface. \"Schneider "
+                       "Digital\" is the white & golden-yellow brand theme; the "
+                       "rest are modern, easy-on-the-eyes light and dark palettes.");
+
+        // Live swatch preview of the selected theme's palette
+        ImVec4 swatches[4];
+        int swatchCount = GetGuiThemeSwatches(themeIndex, swatches, 4);
+        for (int i = 0; i < swatchCount; ++i) {
+          std::string id = "##themesw" + std::to_string(i);
+          ImGui::ColorButton(id.c_str(), swatches[i],
+                             ImGuiColorEditFlags_NoTooltip |
+                                 ImGuiColorEditFlags_NoPicker |
+                                 ImGuiColorEditFlags_NoDragDrop,
+                             ImVec2(34 * scale, 16 * scale));
+          if (i < swatchCount - 1)
+            ImGui::SameLine();
+        }
       }
-      ImGui::SameLine();
-      DrawHelpMarker(
-          "Switches between light and dark color themes for the interface");
 
       if (ImGui::Checkbox("Show Performance Overlay", &showFPS)) {
         preferences.showFPS = showFPS;

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -374,11 +374,9 @@ extern const int MAX_LIGHTS;
 // ===========================================================================
 
 // Categories for the redesigned, sidebar-navigated Settings window. Declared at
-// file scope so the main menu bar can deep-link straight to a category (e.g.
-// the "AI Assistant" shortcut).
+// file scope so the main menu bar can deep-link straight to a category.
 enum SettingsCategory {
-  SETTINGS_CAT_AI = 0,
-  SETTINGS_CAT_RENDERING,
+  SETTINGS_CAT_RENDERING = 0,
   SETTINGS_CAT_CAMERA,
   SETTINGS_CAT_ENVIRONMENT,
   SETTINGS_CAT_DISPLAY,
@@ -386,7 +384,7 @@ enum SettingsCategory {
   SETTINGS_CAT_IMPORT,
   SETTINGS_CAT_SHORTCUTS
 };
-static int g_settingsCategory = SETTINGS_CAT_AI;
+static int g_settingsCategory = SETTINGS_CAT_RENDERING;
 
 // Docked-region insets published to the render loop (see Gui.h). Updated each
 // frame in renderGUI so the 3D viewport can be sized to the free area.
@@ -2032,16 +2030,6 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
     }
     menuButtonTooltip("Save and restore camera viewpoints of the scene");
 
-    // AI Assistant quick access (accent-highlighted, deep-links into Settings)
-    ImGui::PushStyleColor(ImGuiCol_Text, g_StyleColors.accent);
-    if (ImGui::MenuItem("AI Assistant")) {
-      showSettingsWindow = true;
-      g_settingsCategory = SETTINGS_CAT_AI;
-    }
-    ImGui::PopStyleColor();
-    menuButtonTooltip("Adjust your scene and settings by describing what you "
-                      "want in plain language");
-
     ImGui::EndMainMenuBar();
   }
 
@@ -2874,7 +2862,6 @@ void renderSettingsWindow() {
     const char *label;
   };
   static const SettingsNavEntry kNavEntries[] = {
-      {SETTINGS_CAT_AI, ICON_FA_ROBOT, "AI Assistant"},
       {SETTINGS_CAT_RENDERING, ICON_FA_LIGHTBULB, "Rendering"},
       {SETTINGS_CAT_CAMERA, ICON_FA_VIDEO, "Camera & 3D"},
       {SETTINGS_CAT_ENVIRONMENT, ICON_FA_MOUNTAIN, "Environment"},
@@ -2905,176 +2892,6 @@ void renderSettingsWindow() {
 
   ImGui::SameLine();
   ImGui::BeginChild("##SettingsContent", ImVec2(0, 0), false);
-
-  // ===========================
-  // AI ASSISTANT TAB (scaffold)
-  // ===========================
-  if (g_settingsCategory == SETTINGS_CAT_AI) {
-    ImGui::PushID("AITab");
-
-    DrawInlineIcon(ICON_FA_ROBOT, g_StyleColors.accent);
-    ImGui::TextUnformatted("AI Assistant");
-    ImGui::PushStyleColor(ImGuiCol_Text,
-                          ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-    ImGui::TextWrapped(
-        "Describe what you want in plain language and the assistant will "
-        "adjust your scene and settings for you — change the lighting, "
-        "add objects, tune the look, and more.");
-    ImGui::PopStyleColor();
-    ImGui::Spacing();
-
-    // Connection state (scaffold-only: no network transport yet).
-    static bool aiConnected = false;
-    static char aiApiKey[256] = "";
-    static char aiModel[128] = "claude-opus-4-8";
-    static char aiEndpoint[256] = "https://api.anthropic.com/v1/messages";
-    static int aiProvider = 0;
-    static std::vector<std::pair<bool, std::string>> aiHistory; // {isUser,text}
-    static char aiInput[1024] = "";
-
-    // Status banner
-    {
-      ImVec4 col = aiConnected ? g_StyleColors.success : g_StyleColors.warning;
-      ImGui::PushStyleColor(ImGuiCol_ChildBg,
-                            ImVec4(col.x, col.y, col.z, 0.12f));
-      ImGui::BeginChild("##aistatus", ImVec2(0, ImGui::GetFrameHeight() * 2.2f),
-                        true);
-      DrawInlineIcon(aiConnected ? ICON_FA_CHECK : ICON_FA_EXCLAMATION_TRIANGLE,
-                     col);
-      ImGui::AlignTextToFramePadding();
-      ImGui::TextWrapped(
-          "%s",
-          aiConnected
-              ? "Connected. The assistant can read and modify your scene."
-              : "Not connected. Add an API key under Connection to enable "
-                "live requests.");
-      ImGui::EndChild();
-      ImGui::PopStyleColor();
-    }
-
-    ImGui::Spacing();
-    DrawSectionHeader("Conversation");
-
-    // Chat transcript
-    ImGui::BeginChild("##aichat", ImVec2(0, 260 * scale), true);
-    if (aiHistory.empty()) {
-      ImGui::PushStyleColor(ImGuiCol_Text,
-                            ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-      ImGui::Spacing();
-      ImGui::TextWrapped("No messages yet. Try one of the suggestions below, "
-                         "or type your own request.");
-      ImGui::PopStyleColor();
-    } else {
-      for (const auto &msg : aiHistory) {
-        const bool isUser = msg.first;
-        ImGui::PushStyleColor(
-            ImGuiCol_Text,
-            isUser ? ImGui::GetStyleColorVec4(ImGuiCol_Text)
-                   : g_StyleColors.accent);
-        DrawInlineIcon(isUser ? ICON_FA_COMMENT : ICON_FA_ROBOT,
-                       isUser ? ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)
-                              : g_StyleColors.accent);
-        ImGui::TextUnformatted(isUser ? "You" : "Assistant");
-        ImGui::PopStyleColor();
-        ImGui::PushTextWrapPos(0.0f);
-        ImGui::TextWrapped("%s", msg.second.c_str());
-        ImGui::PopTextWrapPos();
-        ImGui::Spacing();
-        ImGui::Separator();
-        ImGui::Spacing();
-      }
-      ImGui::SetScrollHereY(1.0f);
-    }
-    ImGui::EndChild();
-
-    // Lambda to "submit" a prompt. Scaffold only: echoes the prompt and an
-    // honest placeholder until a transport + apply layer is wired up.
-    auto submitPrompt = [&](const std::string &prompt) {
-      if (prompt.empty())
-        return;
-      aiHistory.emplace_back(true, prompt);
-      aiHistory.emplace_back(
-          false,
-          aiConnected
-              ? "(Live requests are not wired up in this build yet.)"
-              : "I can't act on this yet — add an API key under "
-                "Connection to enable live requests. Once connected I'll be "
-                "able to apply changes like this directly to your scene.");
-      aiInput[0] = '\0';
-    };
-
-    // Suggestion chips
-    ImGui::Spacing();
-    const char *suggestions[] = {"Make the lighting warmer",
-                                 "Add a cube to the scene",
-                                 "Enable soft shadows",
-                                 "Switch to a sunset sky"};
-    const float rightEdge =
-        ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x;
-    const float spacing = ImGui::GetStyle().ItemSpacing.x;
-    for (int i = 0; i < IM_ARRAYSIZE(suggestions); ++i) {
-      // Keep the chip on the current row only if it actually fits.
-      if (i > 0) {
-        float chipW = ImGui::CalcTextSize(suggestions[i]).x +
-                      ImGui::GetStyle().FramePadding.x * 2.0f;
-        float nextX = ImGui::GetItemRectMax().x + spacing + chipW;
-        if (nextX < rightEdge)
-          ImGui::SameLine();
-      }
-      if (ImGui::Button(suggestions[i]))
-        submitPrompt(suggestions[i]);
-    }
-
-    // Input row
-    ImGui::Spacing();
-    float sendW = 90.0f * scale;
-    ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x - sendW -
-                         ImGui::GetStyle().ItemSpacing.x);
-    bool entered = ImGui::InputTextWithHint(
-        "##aiinput", "Ask the assistant to change your scene…", aiInput,
-        sizeof(aiInput), ImGuiInputTextFlags_EnterReturnsTrue);
-    ImGui::PopItemWidth();
-    ImGui::SameLine();
-    bool sendClicked = ImGui::Button("Send", ImVec2(sendW, 0));
-    if (entered || sendClicked)
-      submitPrompt(std::string(aiInput));
-
-    if (!aiHistory.empty()) {
-      if (ImGui::SmallButton("Clear conversation"))
-        aiHistory.clear();
-    }
-
-    // Connection / configuration
-    ImGui::Spacing();
-    if (ImGui::CollapsingHeader("Connection")) {
-      DrawToggleSwitch("Enable live requests", &aiConnected);
-      ImGui::SameLine();
-      DrawHelpMarker("When connected, the assistant sends your prompts to the "
-                     "configured provider. Networking is not implemented in "
-                     "this build — this is the UI scaffold.");
-
-      const char *providers[] = {"Anthropic (Claude)", "OpenAI", "Custom"};
-      ImGui::Combo("Provider", &aiProvider, providers,
-                   IM_ARRAYSIZE(providers));
-
-      ImGui::InputText("API Key", aiApiKey, sizeof(aiApiKey),
-                       ImGuiInputTextFlags_Password);
-      ImGui::SameLine();
-      DrawHelpMarker("Stored only for this session in this scaffold build.");
-
-      ImGui::InputText("Model", aiModel, sizeof(aiModel));
-      ImGui::InputText("Endpoint", aiEndpoint, sizeof(aiEndpoint));
-    }
-
-    if (ImGui::CollapsingHeader("What the assistant can do")) {
-      ImGui::BulletText("Adjust rendering, camera and environment settings");
-      ImGui::BulletText("Create primitives and lights");
-      ImGui::BulletText("Tune materials and the overall look");
-      ImGui::BulletText("Explain what each setting does");
-    }
-
-    ImGui::PopID();
-  }
 
   // ===========================
   // RENDERING TAB

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -473,6 +473,16 @@ static void DrawSectionHeader(const char *label) {
   ImGui::Separator();
 }
 
+// Title row for an object's properties panel: an accent-colored icon (drawn
+// through the reliable dedicated icon font) followed by the object name, then a
+// separator. Keeps every manipulation panel header visually consistent instead
+// of relying on raw emoji glyphs that may be missing from the system fonts.
+static void DrawPanelTitle(const char *icon, const std::string &title) {
+  DrawInlineIcon(icon, g_StyleColors.accent);
+  ImGui::TextUnformatted(title.c_str());
+  ImGui::Separator();
+}
+
 // Vertical sidebar navigation entry (icon + label). Returns true when clicked.
 // The icon is rendered through the dedicated icon font via the draw list so it
 // is reliable regardless of whether the merged-font path succeeded.
@@ -1135,6 +1145,18 @@ static void importLASFiles(const std::vector<std::string> &lasFiles) {
         static_cast<int>(currentScene.pointClouds.size()) - 1);
   }
   updateSpaceMouseBounds();
+}
+
+// Case-insensitive substring test used by the Scene Hierarchy search filter.
+// An empty needle matches everything (so the unfiltered list shows in full).
+static bool searchMatches(const std::string &haystack, const char *needle) {
+  if (needle == nullptr || needle[0] == '\0')
+    return true;
+  std::string h = haystack;
+  std::string n = needle;
+  std::transform(h.begin(), h.end(), h.begin(), ::tolower);
+  std::transform(n.begin(), n.end(), n.begin(), ::tolower);
+  return h.find(n) != std::string::npos;
 }
 
 void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
@@ -1970,30 +1992,45 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
       ImGui::EndMenu();
     }
 
+    // Tooltip helper for the bare tool buttons in the menu bar, so first-time
+    // users can tell what each one opens without clicking.
+    auto menuButtonTooltip = [](const char *desc) {
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+        ImGui::SetTooltip("%s", desc);
+    };
+
     // Settings Menu
     if (ImGui::MenuItem("Settings")) {
       showSettingsWindow = true;
     }
+    menuButtonTooltip("Application settings: rendering, camera, environment, "
+                      "input and shortcuts");
 
     // Brush Tool Menu
     if (ImGui::MenuItem("Brush Tool")) {
       showBrushToolWindow = true;
     }
+    menuButtonTooltip("Scatter copies of a model across surfaces with the "
+                      "paint brush");
 
     // Measurement Tool Menu
     if (ImGui::MenuItem("Measure")) {
       showMeasurementToolWindow = true;
     }
+    menuButtonTooltip("Measure distances, angles and coordinates in the scene");
 
     // Section / Clip Plane Tool Menu
     if (ImGui::MenuItem("Section Planes")) {
       showClipPlaneToolWindow = true;
     }
+    menuButtonTooltip("Slice the scene with clipping planes to inspect "
+                      "interiors");
 
     // Snapshots Menu
     if (ImGui::MenuItem("Snapshots")) {
       showSnapshotsWindow = true;
     }
+    menuButtonTooltip("Save and restore camera viewpoints of the scene");
 
     // AI Assistant quick access (accent-highlighted, deep-links into Settings)
     ImGui::PushStyleColor(ImGuiCol_Text, g_StyleColors.accent);
@@ -2002,6 +2039,8 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
       g_settingsCategory = SETTINGS_CAT_AI;
     }
     ImGui::PopStyleColor();
+    menuButtonTooltip("Adjust your scene and settings by describing what you "
+                      "want in plain language");
 
     ImGui::EndMainMenuBar();
   }
@@ -2030,10 +2069,29 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
   static char searchBuffer[128] = "";
   DrawInlineIcon(ICON_FA_SEARCH,
                  ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-  ImGui::PushItemWidth(-1);
+  const bool hasSearchText = (searchBuffer[0] != '\0');
+  const float clearBtnSize = ImGui::GetFrameHeight();
+  ImGui::SetNextItemWidth(
+      ImGui::GetContentRegionAvail().x -
+      (hasSearchText ? (clearBtnSize + ImGui::GetStyle().ItemSpacing.x) : 0.0f));
   ImGui::InputTextWithHint("##Search", "Search objects...", searchBuffer,
                            sizeof(searchBuffer));
-  ImGui::PopItemWidth();
+  if (hasSearchText) {
+    ImGui::SameLine();
+    // Force a square button so the icon font's smaller glyph stays aligned
+    // with the input box height.
+    if (g_Fonts.icons)
+      ImGui::PushFont(g_Fonts.icons);
+    bool clearClicked = ImGui::Button(
+        g_Fonts.icons ? ICON_FA_TIMES "##clearsearch" : "x##clearsearch",
+        ImVec2(clearBtnSize, clearBtnSize));
+    if (g_Fonts.icons)
+      ImGui::PopFont();
+    if (clearClicked)
+      searchBuffer[0] = '\0';
+    if (ImGui::IsItemHovered())
+      ImGui::SetTooltip("Clear search");
+  }
   ImGui::Separator();
 
   if (ImGui::BeginChild("ObjectList", ImVec2(0, 250 * g_GuiScale.currentScale),
@@ -2041,30 +2099,37 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
     ImGui::Columns(2, "ObjectColumns", false);
     ImGui::SetColumnWidth(0, 60 * g_GuiScale.currentScale);
 
-    // Sun Object (always at top, ungrouped)
-    ImGui::PushID("sun");
-    bool sunVisible = sun.enabled;
-    if (ImGui::Checkbox("##visible", &sunVisible))
-      sun.enabled = sunVisible;
-    ImGui::NextColumn();
+    // Tracks whether the active search matched any object, so the list can
+    // show a friendly "no results" hint instead of appearing empty.
+    bool anyMatch = false;
 
-    bool isSunSelected = (currentSelectedType == SelectedType::Sun);
-    ImGui::AlignTextToFramePadding();
-    // Render Sun with FontAwesome icon to avoid missing glyphs in fonts
-    if (g_Fonts.icons) {
-      ImGui::PushFont(g_Fonts.icons);
-      ImGui::Text(ICON_FA_SUN);
-      ImGui::PopFont();
-      ImGui::SameLine();
+    // Sun Object (always at top, ungrouped)
+    if (searchMatches("Sun", searchBuffer)) {
+      anyMatch = true;
+      ImGui::PushID("sun");
+      bool sunVisible = sun.enabled;
+      if (ImGui::Checkbox("##visible", &sunVisible))
+        sun.enabled = sunVisible;
+      ImGui::NextColumn();
+
+      bool isSunSelected = (currentSelectedType == SelectedType::Sun);
+      ImGui::AlignTextToFramePadding();
+      // Render Sun with FontAwesome icon to avoid missing glyphs in fonts
+      if (g_Fonts.icons) {
+        ImGui::PushFont(g_Fonts.icons);
+        ImGui::Text(ICON_FA_SUN);
+        ImGui::PopFont();
+        ImGui::SameLine();
+      }
+      if (ImGui::Selectable("Sun", isSunSelected,
+                            ImGuiSelectableFlags_SpanAllColumns)) {
+        currentSelectedType = SelectedType::Sun;
+        currentSelectedIndex = -1;
+        currentSelectedMeshIndex = -1;
+      }
+      ImGui::NextColumn();
+      ImGui::PopID();
     }
-    if (ImGui::Selectable("Sun", isSunSelected,
-                          ImGuiSelectableFlags_SpanAllColumns)) {
-      currentSelectedType = SelectedType::Sun;
-      currentSelectedIndex = -1;
-      currentSelectedMeshIndex = -1;
-    }
-    ImGui::NextColumn();
-    ImGui::PopID();
 
     // Group objects by sourceScenePath
     std::map<std::string, std::vector<int>> sceneModels;
@@ -2107,9 +2172,9 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
     // Helper lambda to render a model
     auto renderModel = [&](int i) {
       std::string modelName = currentScene.models[i].name;
-      if (strlen(searchBuffer) > 0 &&
-          modelName.find(searchBuffer) == std::string::npos)
+      if (!searchMatches(modelName, searchBuffer))
         return;
+      anyMatch = true;
 
       ImGui::PushID(i);
       ImGui::AlignTextToFramePadding();
@@ -2204,9 +2269,9 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
     // Helper lambda to render a point cloud
     auto renderPointCloud = [&](int i) {
       std::string pcName = currentScene.pointClouds[i].name;
-      if (strlen(searchBuffer) > 0 &&
-          pcName.find(searchBuffer) == std::string::npos)
+      if (!searchMatches(pcName, searchBuffer))
         return;
+      anyMatch = true;
 
       ImGui::PushID(i + currentScene.models.size());
       bool isSelected = (currentSelectedIndex == i &&
@@ -2237,6 +2302,11 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
 
     // Helper lambda to render a point light
     auto renderPointLight = [&](int i) {
+      std::string lightText = "Point Light " + std::to_string(i + 1);
+      if (!searchMatches(lightText, searchBuffer))
+        return;
+      anyMatch = true;
+
       ImGui::PushID(i + currentScene.models.size() + 1000);
       bool isSelected = (currentSelectedIndex == i &&
                          currentSelectedType == SelectedType::PointLight);
@@ -2252,7 +2322,6 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
         ImGui::PopFont();
         ImGui::SameLine();
       }
-      std::string lightText = "Point Light " + std::to_string(i + 1);
       if (ImGui::Selectable(lightText.c_str(), isSelected,
                             ImGuiSelectableFlags_SpanAllColumns)) {
         currentSelectedType = SelectedType::PointLight;
@@ -2265,6 +2334,11 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
 
     // Helper lambda to render a spot light
     auto renderSpotLight = [&](int i) {
+      std::string spotText = "Spot Light " + std::to_string(i + 1);
+      if (!searchMatches(spotText, searchBuffer))
+        return;
+      anyMatch = true;
+
       ImGui::PushID(i + currentScene.models.size() + 2000);
       bool isSelected = (currentSelectedIndex == i &&
                          currentSelectedType == SelectedType::SpotLight);
@@ -2276,7 +2350,6 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
         ImGui::PopFont();
         ImGui::SameLine();
       }
-      std::string spotText = "Spot Light " + std::to_string(i + 1);
       if (ImGui::Selectable(spotText.c_str(), isSelected,
                             ImGuiSelectableFlags_SpanAllColumns)) {
         currentSelectedType = SelectedType::SpotLight;
@@ -2485,9 +2558,9 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
         continue;
 
       std::string clusterName = cluster->name;
-      if (strlen(searchBuffer) > 0 &&
-          clusterName.find(searchBuffer) == std::string::npos)
+      if (!searchMatches(clusterName, searchBuffer))
         continue;
+      anyMatch = true;
 
       ImGui::PushID(i + currentScene.models.size() +
                     currentScene.pointClouds.size() + 5000);
@@ -2519,6 +2592,15 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
     }
 
     ImGui::Columns(1);
+
+    // Friendly hint when a search filters everything out.
+    if (!anyMatch && hasSearchText) {
+      ImGui::Spacing();
+      ImGui::PushStyleColor(ImGuiCol_Text,
+                            ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+      ImGui::TextWrapped("No objects match \"%s\".", searchBuffer);
+      ImGui::PopStyleColor();
+    }
     ImGui::EndChild();
   }
 
@@ -2564,9 +2646,8 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
         Tools::BrushCluster *cluster =
             brushTool.getCluster(currentSelectedIndex);
         if (cluster) {
-          DrawSectionHeader("Brush Cluster Properties");
+          DrawPanelTitle(ICON_FA_PAINT_BRUSH, cluster->name);
 
-          ImGui::Text("Name: %s", cluster->name.c_str());
           if (cluster->sourceModelIndex >= 0 &&
               cluster->sourceModelIndex < currentScene.models.size()) {
             ImGui::Text(
@@ -7191,7 +7272,7 @@ static void drawMeasurementLabels() {
 void renderSunManipulationPanel() {
   const Engine::Sun sunPreFrame = sun;
 
-  DrawSectionHeader("Sun Light");
+  DrawPanelTitle(ICON_FA_SUN, "Sun");
 
   ImGui::Checkbox("Enabled", &sun.enabled);
   ImGui::ColorEdit3("Color", glm::value_ptr(sun.color));
@@ -7228,8 +7309,7 @@ void renderModelManipulationPanel(Engine::Model &model,
   const Engine::Undo::ModelEditState modelStatePreFrame =
       Engine::Undo::ModelEditState::capture(model);
 
-  ImGui::Text("📦 %s", model.name.c_str());
-  ImGui::Separator();
+  DrawPanelTitle(ICON_FA_CUBE, model.name);
 
   if (ImGui::CollapsingHeader("Transform", ImGuiTreeNodeFlags_DefaultOpen)) {
     bool transformChanged = false;
@@ -7421,8 +7501,8 @@ void renderMeshManipulationPanel(Engine::Model &model, int meshIndex,
   const Engine::Undo::ModelEditState modelStatePreFrame =
       Engine::Undo::ModelEditState::capture(model);
 
-  ImGui::Text("📦 %s - Mesh %d", model.name.c_str(), meshIndex + 1);
-  ImGui::Separator();
+  DrawPanelTitle(ICON_FA_CUBE,
+                 model.name + "  -  Mesh " + std::to_string(meshIndex + 1));
 
   ImGui::Checkbox("Visible", &mesh.visible);
 
@@ -7588,7 +7668,7 @@ void renderMeshManipulationPanel(Engine::Model &model, int meshIndex,
 }
 
 void renderPointCloudManipulationPanel(Engine::PointCloud &pointCloud) {
-  ImGui::Text("☁ %s", pointCloud.name.c_str());
+  DrawPanelTitle(ICON_FA_CLOUD, pointCloud.name);
 
   // isLoaded() returns true when compute SSBOs are ready (numBatches > 0)
   // or when a legacy CPU-side points vector is still populated.
@@ -7778,17 +7858,8 @@ void renderPointLightManipulationPanel() {
   auto &light = pointLights[currentSelectedIndex];
   const Engine::PointLight lightStatePreFrame = light;
 
-  // Render icon and text with PushFont/PopFont approach
-  if (g_Fonts.icons) {
-    ImGui::PushFont(g_Fonts.icons);
-    ImGui::Text(ICON_FA_LIGHTBULB);
-    ImGui::PopFont();
-    ImGui::SameLine();
-    ImGui::Text("Point Light %d", currentSelectedIndex + 1);
-  } else {
-    ImGui::Text("? Point Light %d", currentSelectedIndex + 1);
-  }
-  ImGui::Separator();
+  DrawPanelTitle(ICON_FA_LIGHTBULB,
+                 "Point Light " + std::to_string(currentSelectedIndex + 1));
 
   if (ImGui::CollapsingHeader("Transform", ImGuiTreeNodeFlags_DefaultOpen)) {
     ImGui::DragFloat3("Position", glm::value_ptr(light.position), 0.1f);
@@ -7857,8 +7928,8 @@ void renderSpotLightManipulationPanel() {
   auto &light = spotLights[currentSelectedIndex];
   const Engine::SpotLight lightStatePreFrame = light;
 
-  ImGui::Text("🔦 Spot Light %d", currentSelectedIndex + 1);
-  ImGui::Separator();
+  DrawPanelTitle(ICON_FA_BULLSEYE,
+                 "Spot Light " + std::to_string(currentSelectedIndex + 1));
 
   if (ImGui::CollapsingHeader("Transform", ImGuiTreeNodeFlags_DefaultOpen)) {
     ImGui::DragFloat3("Position", glm::value_ptr(light.position), 0.1f);

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -1632,6 +1632,7 @@ void savePreferences() {
 
   // UI preferences
   j["ui"]["darkTheme"] = preferences.isDarkTheme;
+  j["ui"]["theme"] = preferences.guiTheme;
   j["ui"]["showFPS"] = preferences.showFPS;
   j["ui"]["vsync"] = preferences.vsyncEnabled;
   j["ui"]["show3DCursor"] = preferences.show3DCursor;
@@ -1916,8 +1917,9 @@ void savePreferences() {
 
 void applyPreferencesToProgram() {
   // Apply UI preferences
-  isDarkTheme = preferences.isDarkTheme;
-  SetupImGuiStyle(isDarkTheme, 1.0f);
+  ApplyGuiTheme(preferences.guiTheme, 1.0f);
+  isDarkTheme = IsGuiThemeDark(preferences.guiTheme);
+  preferences.isDarkTheme = isDarkTheme;
   showFPS = preferences.showFPS;
   show3DCursor = preferences.show3DCursor;
   cursorManager.setKeepLastDepthOnBackground(
@@ -2083,6 +2085,10 @@ void loadPreferences() {
     // UI preferences
     if (j.contains("ui")) {
       preferences.isDarkTheme = j["ui"].value("darkTheme", true);
+      // Fall back to the matching built-in theme for configs saved before the
+      // multi-theme picker existed (0 = Modern Dark, 1 = Modern Light).
+      preferences.guiTheme =
+          j["ui"].value("theme", preferences.isDarkTheme ? 0 : 1);
       preferences.showFPS = j["ui"].value("showFPS", true);
       preferences.vsyncEnabled = j["ui"].value("vsync", false);
       preferences.show3DCursor = j["ui"].value("show3DCursor", true);
@@ -2645,7 +2651,8 @@ void InitializeDefaults() {
   }
 
   // Set ImGui style
-  SetupImGuiStyle(isDarkTheme, 1.0f);
+  ApplyGuiTheme(preferences.guiTheme, 1.0f);
+  isDarkTheme = IsGuiThemeDark(preferences.guiTheme);
 }
 
 void PerspectiveProjection(GLfloat *frustum, GLfloat dir, GLfloat fovy,


### PR DESCRIPTION
Make the interface easier to use and more consistent throughout:

- Scene Hierarchy search is now case-insensitive and also filters the
  Sun and lights, with a "no objects match" hint and an inline clear (x)
  button so it's obvious how to reset the filter.
- Replace the raw emoji headers in the object property panels (model,
  mesh, point cloud, sun, point/spot light, brush cluster) with a shared
  DrawPanelTitle helper that uses the reliable FontAwesome icon font, so
  every panel header looks the same and never shows a missing glyph.
- Add hover tooltips to the bare menu-bar tool buttons (Settings, Brush
  Tool, Measure, Section Planes, Snapshots, AI Assistant) so first-time
  users can tell what each one does without clicking.
- Stylesheet: raise dark-theme frame-background contrast so input boxes,
  combos and sliders read as distinct, discoverable controls.

https://claude.ai/code/session_016MrSJUndPYKck5xE2bVqo7