### PR TITLE
Run CI build check on pull requests

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -3,6 +3,8 @@ name: MSBuild
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 env:
   SOLUTION_FILE_PATH: .
@@ -28,6 +30,14 @@ jobs:
       id: check_changes
       shell: pwsh
       run: |
+        # On pull requests we always build to verify the change compiles; no
+        # release is produced (the release steps are gated to push events).
+        if ($env:GITHUB_EVENT_NAME -eq 'pull_request') {
+            Write-Host "Pull request: building to verify compilation."
+            echo "changed=true" >> $env:GITHUB_OUTPUT
+            exit 0
+        }
+
         # Try to find the latest tag. Suppress error if none exists.
         $tag = git describe --tags --abbrev=0 2>$null
         
@@ -81,7 +91,7 @@ jobs:
     # (StereoVista\) and must be shipped alongside the executable, with their
     # directory structure preserved, or the app fails to start / render.
     - name: Stage release files
-      if: steps.check_changes.outputs.changed == 'true'
+      if: github.event_name == 'push' && steps.check_changes.outputs.changed == 'true'
       shell: pwsh
       run: |
         $stage = "release_stage"
@@ -159,7 +169,7 @@ jobs:
     # Create Release
     # ---------------------------
     - name: Create Release
-      if: steps.check_changes.outputs.changed == 'true'
+      if: github.event_name == 'push' && steps.check_changes.outputs.changed == 'true'
       uses: softprops/action-gh-release@v1
       with:
         tag_name: v0.0.${{ github.run_number }}


### PR DESCRIPTION
## What

Add a `pull_request` trigger to `.github/workflows/msbuild.yml` so PRs targeting `main` get a Windows `Release|x64` MSBuild that verifies the change compiles **before** it merges.

## Why

The workflow previously only ran on `push` to `main`, so the project's only build happened *after* code was already merged. That meant pull requests had no status check to gate on — making CI-gated auto-merge impossible and letting build breaks reach `main` (and the auto-published release) unverified.

## Changes

1. **`pull_request` trigger** added (base `main`).
2. **PR runs always build** — the "Check for changes" step short-circuits to `changed=true` on `pull_request` events, independent of the tag-diff logic used for releases.
3. **Release steps gated to `push`** — "Stage release files" and "Create Release" now run only when `github.event_name == 'push'`, so opening/merging a PR builds but does **not** publish a release. Release behavior on `main` is unchanged.

## Follow-up (repo settings — not in this PR)

To actually enforce this for auto-merge, on the GitHub side:
- Enable **Settings → General → Pull Requests → Allow auto-merge**
- Add a **branch protection rule** on `main` requiring the `build` check to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tuekgpz1V6m3ewp1WtksP8)_