### PR TITLE
Add stereo-3D screenshot export (Full SBS, Above/Below, separate)

### DIFF
--- a/StereoVista/headers/Engine/Screenshot.h
+++ b/StereoVista/headers/Engine/Screenshot.h
@@ -31,6 +31,32 @@ bool captureToMemory(int x, int y, int width, int height,
 bool captureToPNG(const std::string &path, int x, int y, int width, int height,
                   unsigned int readBuffer);
 
+// Layout for combining a stereo (two-eye) capture into the output image(s).
+enum class StereoLayout {
+  SideBySide, // left | right, one image of size (2*width x height)
+  AboveBelow, // left on top, right below, one image of size (width x 2*height)
+  Separate    // two images: "<name>_L.png" and "<name>_R.png"
+};
+
+// Combine two equally-sized RGB(A) images into a single buffer. SideBySide
+// places `left` then `right` horizontally; AboveBelow places `left` above
+// `right`. `outWidth`/`outHeight` receive the combined dimensions. Both inputs
+// must be `width*height*channels` bytes, rows top-to-bottom. (Not valid for
+// Separate, which produces two files rather than one buffer.)
+std::vector<unsigned char>
+combineStereo(const std::vector<unsigned char> &left,
+              const std::vector<unsigned char> &right, int width, int height,
+              int channels, StereoLayout layout, int &outWidth, int &outHeight);
+
+// Capture both eyes from the default framebuffer and write a stereo-3D image.
+// `leftBuffer`/`rightBuffer` select the source color buffers (e.g.
+// GL_BACK_LEFT / GL_BACK_RIGHT). For SideBySide/AboveBelow a single combined
+// PNG is written to `path`; for Separate two PNGs are written with "_L"/"_R"
+// inserted before the extension of `path`. Returns true on success.
+bool captureStereoToPNG(const std::string &path, int x, int y, int width,
+                        int height, unsigned int leftBuffer,
+                        unsigned int rightBuffer, StereoLayout layout);
+
 // Build a unique, timestamped PNG path inside `directory` (created if it does
 // not exist), e.g. "screenshots/StereoVista_2026-06-14_08-22-38.png".
 std::string makeTimestampedPath(const std::string &directory);

--- a/StereoVista/headers/Gui/GuiTypes.h
+++ b/StereoVista/headers/Gui/GuiTypes.h
@@ -65,6 +65,16 @@ enum SceneLoadingBehavior {
   SCENE_LOAD_ALWAYS_MERGE    // Always keep existing scene
 };
 
+// How a screenshot is captured on a quad-buffer stereo window. MONO keeps the
+// legacy behavior (single/left-eye image); the others read both eyes and write
+// a stereo-3D image either combined into one file or as two separate files.
+enum StereoScreenshotMode {
+  STEREO_SHOT_MONO,        // Single (left) eye only - default, legacy behavior
+  STEREO_SHOT_FULL_SBS,    // Full side-by-side: left | right (2*width x height)
+  STEREO_SHOT_ABOVE_BELOW, // Above/below: left on top, right below (width x 2*height)
+  STEREO_SHOT_SEPARATE     // Two separate image files (_L / _R suffixes)
+};
+
 // Structure definitions
 struct SkyboxConfig {
   SkyboxType type = SKYBOX_HDR;
@@ -291,6 +301,12 @@ struct ApplicationPreferences {
   // Screenshot export: when true the GUI overlay is included in saved
   // screenshots; when false only the rendered 3D scene is captured.
   bool screenshotIncludeUI = false;
+
+  // Stereo-3D screenshot layout. On a quad-buffer stereo window the screenshot
+  // can capture both eyes and write them as a Full Side-by-Side, Above/Below,
+  // or two separate images. MONO (default) keeps the legacy single-eye capture.
+  // Stereo modes always capture the clean 3D viewer (UI is excluded).
+  StereoScreenshotMode stereoScreenshotMode = STEREO_SHOT_MONO;
 
   bool enableSpawnAnimation = true;
 

--- a/StereoVista/src/Engine/Screenshot.cpp
+++ b/StereoVista/src/Engine/Screenshot.cpp
@@ -207,6 +207,88 @@ bool captureToPNG(const std::string &path, int x, int y, int width, int height,
   return writePNG(path, w, h, 3, flipped.data());
 }
 
+std::vector<unsigned char>
+combineStereo(const std::vector<unsigned char> &left,
+              const std::vector<unsigned char> &right, int width, int height,
+              int channels, StereoLayout layout, int &outWidth,
+              int &outHeight) {
+  std::vector<unsigned char> out;
+  if (width <= 0 || height <= 0 || (channels != 3 && channels != 4))
+    return out;
+
+  const size_t rowBytes = static_cast<size_t>(width) * channels;
+
+  if (layout == StereoLayout::AboveBelow) {
+    // Left image stacked above the right image: same width, double height.
+    outWidth = width;
+    outHeight = height * 2;
+    out.resize(static_cast<size_t>(outWidth) * outHeight * channels);
+    std::copy(left.begin(), left.end(), out.begin());
+    std::copy(right.begin(), right.end(),
+              out.begin() + static_cast<size_t>(height) * rowBytes);
+    return out;
+  }
+
+  // SideBySide: left image then right image per scanline; double width.
+  outWidth = width * 2;
+  outHeight = height;
+  out.resize(static_cast<size_t>(outWidth) * outHeight * channels);
+  const size_t outRowBytes = static_cast<size_t>(outWidth) * channels;
+  for (int row = 0; row < height; ++row) {
+    const size_t srcOff = static_cast<size_t>(row) * rowBytes;
+    const size_t dstOff = static_cast<size_t>(row) * outRowBytes;
+    std::copy(left.begin() + srcOff, left.begin() + srcOff + rowBytes,
+              out.begin() + dstOff);
+    std::copy(right.begin() + srcOff, right.begin() + srcOff + rowBytes,
+              out.begin() + dstOff + rowBytes);
+  }
+  return out;
+}
+
+namespace {
+// Insert a suffix before the file extension, e.g. ("a/b.png", "_L") ->
+// "a/b_L.png". If there is no extension the suffix is simply appended.
+std::string insertSuffix(const std::string &path, const std::string &suffix) {
+  std::filesystem::path p(path);
+  std::filesystem::path stem = p.stem();
+  std::string ext = p.extension().string();
+  std::filesystem::path out = p.parent_path();
+  out /= (stem.string() + suffix + ext);
+  return out.string();
+}
+} // namespace
+
+bool captureStereoToPNG(const std::string &path, int x, int y, int width,
+                        int height, unsigned int leftBuffer,
+                        unsigned int rightBuffer, StereoLayout layout) {
+  std::vector<unsigned char> left, right;
+  int lw = 0, lh = 0, rw = 0, rh = 0;
+  if (!captureToMemory(x, y, width, height, leftBuffer, left, lw, lh))
+    return false;
+  if (!captureToMemory(x, y, width, height, rightBuffer, right, rw, rh))
+    return false;
+  if (lw != rw || lh != rh) {
+    std::cerr << "captureStereoToPNG: eye dimensions differ" << std::endl;
+    return false;
+  }
+
+  const int channels = 3; // captureToMemory returns RGB
+
+  if (layout == StereoLayout::Separate) {
+    bool okL = writePNG(insertSuffix(path, "_L"), lw, lh, channels, left.data());
+    bool okR =
+        writePNG(insertSuffix(path, "_R"), rw, rh, channels, right.data());
+    return okL && okR;
+  }
+
+  int outW = 0, outH = 0;
+  std::vector<unsigned char> combined =
+      combineStereo(left, right, lw, lh, channels, layout, outW, outH);
+  if (combined.empty())
+    return false;
+  return writePNG(path, outW, outH, channels, combined.data());
+}
+
 std::string makeTimestampedPath(const std::string &directory) {
   std::error_code ec;
   std::filesystem::create_directories(directory, ec);

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -1625,6 +1625,38 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
       ImGui::MenuItem("Include UI in Screenshot", nullptr,
                       &preferences.screenshotIncludeUI);
 
+      // Stereo-3D screenshot layout. On a quad-buffer stereo window the
+      // screenshot can capture both eyes and write a Full Side-by-Side,
+      // Above/Below, or two separate (_L/_R) images. "Single (Left Eye)" keeps
+      // the legacy single-eye capture. Stereo modes always capture the clean 3D
+      // viewer (the "Include UI" option is ignored for them).
+      if (ImGui::BeginMenu("Stereo-3D Screenshot")) {
+        if (ImGui::MenuItem("Single (Left Eye)", nullptr,
+                            preferences.stereoScreenshotMode ==
+                                GUI::STEREO_SHOT_MONO)) {
+          preferences.stereoScreenshotMode = GUI::STEREO_SHOT_MONO;
+        }
+        if (ImGui::MenuItem("Full Side-by-Side (SBS)", nullptr,
+                            preferences.stereoScreenshotMode ==
+                                GUI::STEREO_SHOT_FULL_SBS)) {
+          preferences.stereoScreenshotMode = GUI::STEREO_SHOT_FULL_SBS;
+        }
+        if (ImGui::MenuItem("Above/Below", nullptr,
+                            preferences.stereoScreenshotMode ==
+                                GUI::STEREO_SHOT_ABOVE_BELOW)) {
+          preferences.stereoScreenshotMode = GUI::STEREO_SHOT_ABOVE_BELOW;
+        }
+        if (ImGui::MenuItem("Two Separate Images (_L / _R)", nullptr,
+                            preferences.stereoScreenshotMode ==
+                                GUI::STEREO_SHOT_SEPARATE)) {
+          preferences.stereoScreenshotMode = GUI::STEREO_SHOT_SEPARATE;
+        }
+        ImGui::Separator();
+        ImGui::TextDisabled("Stereo modes require a stereo (quad-buffer)\n"
+                            "window and capture both eyes without UI.");
+        ImGui::EndMenu();
+      }
+
       ImGui::Separator();
 
       if (ImGui::MenuItem("Exit", "Esc")) {

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -207,6 +207,34 @@ bool showFPS = true;
 // Screenshot) and the keyboard shortcut set these.
 bool g_requestScreenshot = false;
 std::string g_screenshotPath;
+
+// Capture a screenshot honoring the configured stereo screenshot mode. For
+// MONO (or any non-stereo window) this is the legacy single-eye capture. The
+// stereo modes read both back buffers and write a combined Full-SBS /
+// Above-Below image, or two separate "_L"/"_R" files. `flipEyes` accounts for
+// the left/right buffer swap so the saved image always has the true left eye on
+// the left (or top). Returns true on success.
+static bool captureScreenshotForMode(const std::string &path, int x, int width,
+                                     int height, bool isStereoWindow,
+                                     bool flipEyes,
+                                     GUI::StereoScreenshotMode mode) {
+  if (!isStereoWindow || mode == GUI::STEREO_SHOT_MONO) {
+    GLenum buf = isStereoWindow ? GL_BACK_LEFT : GL_BACK;
+    return Engine::Screenshot::captureToPNG(path, x, 0, width, height, buf);
+  }
+
+  GLenum leftBuf = flipEyes ? GL_BACK_RIGHT : GL_BACK_LEFT;
+  GLenum rightBuf = flipEyes ? GL_BACK_LEFT : GL_BACK_RIGHT;
+  Engine::Screenshot::StereoLayout layout =
+      Engine::Screenshot::StereoLayout::SideBySide;
+  if (mode == GUI::STEREO_SHOT_ABOVE_BELOW)
+    layout = Engine::Screenshot::StereoLayout::AboveBelow;
+  else if (mode == GUI::STEREO_SHOT_SEPARATE)
+    layout = Engine::Screenshot::StereoLayout::Separate;
+  return Engine::Screenshot::captureStereoToPNG(path, x, 0, width, height,
+                                                leftBuf, rightBuf, layout);
+}
+
 // ---- Snapshots ----
 // Set by the GUI to request a snapshot capture on the next clean (GUI-free)
 // frame. The flags select which aspects (camera/scene/tools) to store; the
@@ -2047,6 +2075,8 @@ void savePreferences() {
   j["ui"]["enableSpawnAnimation"] = preferences.enableSpawnAnimation;
   j["ui"]["guiScaleFactor"] = preferences.guiScaleFactor;
   j["ui"]["screenshotIncludeUI"] = preferences.screenshotIncludeUI;
+  j["ui"]["stereoScreenshotMode"] =
+      static_cast<int>(preferences.stereoScreenshotMode);
 
   // Radar settings
   j["radar"]["enabled"] = preferences.radarEnabled;
@@ -2515,6 +2545,9 @@ void loadPreferences() {
       preferences.guiScaleFactor = j["ui"].value("guiScaleFactor", 1.0f);
       preferences.screenshotIncludeUI =
           j["ui"].value("screenshotIncludeUI", false);
+      preferences.stereoScreenshotMode = static_cast<GUI::StereoScreenshotMode>(
+          j["ui"].value("stereoScreenshotMode",
+                        static_cast<int>(GUI::STEREO_SHOT_MONO)));
     }
 
     // Radar settings
@@ -4387,8 +4420,13 @@ int main() {
       // UI-included screenshot is taken after the GUI is drawn (below). Because
       // the GUI stays visible, the viewport is not resized for the capture, so
       // the HDR/bloom/SSAO targets are not rebuilt (no flash, no black frames).
+      // Stereo-3D screenshots always read both eyes here (UI is excluded), since
+      // both back buffers hold the freshly composited per-eye scene.
+      bool stereoShot = isStereoWindow &&
+                        preferences.stereoScreenshotMode != GUI::STEREO_SHOT_MONO;
       if (captureSnapshotThisFrame ||
-          (captureThisFrame && !preferences.screenshotIncludeUI)) {
+          (captureThisFrame &&
+           (stereoShot || !preferences.screenshotIncludeUI))) {
         GLenum capBuffer = isStereoWindow ? GL_BACK_LEFT : GL_BACK;
 
         if (captureSnapshotThisFrame) {
@@ -4413,9 +4451,10 @@ int main() {
           std::string path = captureThisFramePath;
           if (path.empty())
             path = Engine::Screenshot::makeTimestampedPath("screenshots");
-          if (Engine::Screenshot::captureToPNG(path, g_viewportX, 0,
-                                               g_viewportWidth, g_viewportHeight,
-                                               capBuffer)) {
+          if (captureScreenshotForMode(path, g_viewportX, g_viewportWidth,
+                                       g_viewportHeight, isStereoWindow,
+                                       preferences.flipEyes,
+                                       preferences.stereoScreenshotMode)) {
             std::cout << "Screenshot saved: " << path << std::endl;
             GUI::ShowToast("Screenshot saved: " +
                                std::filesystem::path(path).filename().string(),
@@ -4502,19 +4541,31 @@ int main() {
     // and, in the non-HDR fallback path, for UI-excluded screenshots that the
     // pre-GUI capture above did not handle (viewer sub-rectangle).
     if (captureThisFrame) {
-      // Read the left/primary color buffer (GL_BACK is invalid on a
-      // quad-buffer stereo window, so pick the left eye there).
-      GLenum readBuffer = isStereoWindow ? GL_BACK_LEFT : GL_BACK;
       std::string path = captureThisFramePath;
       if (path.empty()) {
         path = Engine::Screenshot::makeTimestampedPath("screenshots");
       }
-      bool includeUI = preferences.screenshotIncludeUI;
-      int cx = includeUI ? 0 : g_viewportX;
-      int cw = includeUI ? windowWidth : g_viewportWidth;
-      int ch = includeUI ? windowHeight : g_viewportHeight;
-      bool ok =
-          Engine::Screenshot::captureToPNG(path, cx, 0, cw, ch, readBuffer);
+      bool stereoShot =
+          isStereoWindow &&
+          preferences.stereoScreenshotMode != GUI::STEREO_SHOT_MONO;
+      bool ok;
+      if (stereoShot) {
+        // Stereo modes always capture the clean 3D viewer sub-rectangle
+        // (UI excluded) from both eyes.
+        ok = captureScreenshotForMode(path, g_viewportX, g_viewportWidth,
+                                      g_viewportHeight, isStereoWindow,
+                                      preferences.flipEyes,
+                                      preferences.stereoScreenshotMode);
+      } else {
+        // Read the left/primary color buffer (GL_BACK is invalid on a
+        // quad-buffer stereo window, so pick the left eye there).
+        GLenum readBuffer = isStereoWindow ? GL_BACK_LEFT : GL_BACK;
+        bool includeUI = preferences.screenshotIncludeUI;
+        int cx = includeUI ? 0 : g_viewportX;
+        int cw = includeUI ? windowWidth : g_viewportWidth;
+        int ch = includeUI ? windowHeight : g_viewportHeight;
+        ok = Engine::Screenshot::captureToPNG(path, cx, 0, cw, ch, readBuffer);
+      }
       if (ok) {
         std::cout << "Screenshot saved: " << path << std::endl;
         GUI::ShowToast("Screenshot saved: " +


### PR DESCRIPTION
Extend the screenshot system so a quad-buffer stereo window can capture
both eyes and write a stereo-3D image. Adds a StereoScreenshotMode
preference selectable from File > Stereo-3D Screenshot:

- Single (Left Eye): legacy single-eye capture (default)
- Full Side-by-Side (SBS): left | right in one image
- Above/Below: left on top, right below in one image
- Two Separate Images: writes <name>_L.png and <name>_R.png

Screenshot module gains combineStereo() and captureStereoToPNG(); the
main loop routes both the GUI and shortcut (F12) capture paths through a
mode-aware helper. flipEyes is honored so the true left eye always ends
up on the left/top. Stereo modes capture the clean 3D viewer (UI
excluded) and require a stereo window; otherwise capture falls back to
single-eye. The mode is persisted in preferences.json.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011aLiRk7o7UhvN5SLMsvZ7E