### PR TITLE
Fix 3D cursor jumping when ending a gizmo rotation drag

### DIFF
--- a/StereoVista/headers/Cursors/Base/CursorManager.h
+++ b/StereoVista/headers/Cursors/Base/CursorManager.h
@@ -139,6 +139,22 @@ public:
     return m_keepLastDepthOnBackground;
   }
 
+  // How the cached depth expires while the mouse is over the background.
+  // Mode values mirror GUI::CursorBackgroundCacheMode (0 = indefinite,
+  // 1 = timed, 2 = distance); kept as an int so this class stays free of the
+  // GUI headers. Time is in seconds off geometry, distance in screen pixels of
+  // mouse travel from the last geometry hit.
+  void setBackgroundCacheMode(int mode) { m_backgroundCacheMode = mode; }
+  int getBackgroundCacheMode() const { return m_backgroundCacheMode; }
+  void setBackgroundCacheTime(float seconds) {
+    m_backgroundCacheTime = seconds;
+  }
+  float getBackgroundCacheTime() const { return m_backgroundCacheTime; }
+  void setBackgroundCacheDistance(float pixels) {
+    m_backgroundCacheDistance = pixels;
+  }
+  float getBackgroundCacheDistance() const { return m_backgroundCacheDistance; }
+
 private:
   std::unique_ptr<SphereCursor> m_sphereCursor;
   std::unique_ptr<FragmentCursor> m_fragmentCursor;
@@ -186,6 +202,14 @@ private:
   bool m_keepLastDepthOnBackground = false;
   float m_lastValidDepth = 0.5f; // depth buffer value of the last geometry hit
   bool m_hasLastValidDepth = false;
+  // Cache-expiry policy + the reference state captured at the last geometry hit
+  // so the timed / distance modes can decide when to give up the cached depth.
+  int m_backgroundCacheMode = 0;          // GUI::CursorBackgroundCacheMode
+  float m_backgroundCacheTime = 1.0f;     // seconds (timed mode)
+  float m_backgroundCacheDistance = 250.0f; // screen pixels (distance mode)
+  double m_lastHitTime = 0.0;             // glfwGetTime() at the last hit
+  float m_lastHitScreenX = 0.0f;          // window-space mouse pos at last hit
+  float m_lastHitScreenY = 0.0f;
 
   // Helper function to calculate background cursor position
   glm::vec3 calculateBackgroundCursorPosition(GLFWwindow *window,

--- a/StereoVista/headers/Gui/GuiTypes.h
+++ b/StereoVista/headers/Gui/GuiTypes.h
@@ -47,6 +47,17 @@ enum CursorScalingMode {
   CURSOR_LOGARITHMIC
 };
 
+// When the 3D cursor would fall off geometry onto the background (skybox /
+// empty space), this controls how long it keeps following the mouse at the
+// last valid depth before giving up and reverting to the Windows cursor.
+// Avoids the cursor flickering between 2D and 3D over sparse models / point
+// clouds where the depth buffer is mostly background.
+enum CursorBackgroundCacheMode {
+  CURSOR_CACHE_INDEFINITE, // Never give up; stay at last depth until a new hit
+  CURSOR_CACHE_TIMED,      // Give up after a time limit (seconds off geometry)
+  CURSOR_CACHE_DISTANCE    // Give up after the mouse travels too far (pixels)
+};
+
 enum SpaceMouseAnchorMode {
   SPACEMOUSE_ANCHOR_DISABLED,   // Use scene center (default)
   SPACEMOUSE_ANCHOR_ON_START,   // Set anchor when navigation starts, keep it
@@ -130,8 +141,14 @@ struct ApplicationPreferences {
   bool show3DCursor = true;
   // Keep the 3D cursor at the last valid depth when the mouse is over the
   // background instead of switching to the Windows cursor (helps with sparse
-  // point clouds).
+  // point clouds). Master enable for the depth-cache behavior below.
   bool cursorKeepLastDepthOnBackground = false;
+  // How the cached depth expires while the mouse stays over the background
+  // (see CursorBackgroundCacheMode) and the limits used by the timed / distance
+  // modes. Ignored when cursorKeepLastDepthOnBackground is false.
+  int cursorBackgroundCacheMode = CURSOR_CACHE_INDEFINITE;
+  float cursorBackgroundCacheTime = 1.0f;       // seconds (TIMED mode)
+  float cursorBackgroundCacheDistance = 250.0f; // screen pixels (DISTANCE mode)
   bool useNewStereoMethod = true;
   float fov = 45.0f;
 

--- a/StereoVista/src/Cursors/Base/CursorManager.cpp
+++ b/StereoVista/src/Cursors/Base/CursorManager.cpp
@@ -1,5 +1,7 @@
 #include "Cursors/Base/CursorManager.h"
+#include "Gui/GuiTypes.h"
 #include <GLFW/glfw3.h>
+#include <cmath>
 #include <imgui.h>
 #include <iostream>
 
@@ -159,18 +161,39 @@ void CursorManager::updateCursorPosition(
   if (isHit) {
     // Remember the depth of the last geometry hit so the cursor can stay at
     // this depth while the mouse passes over the background (sparse point
-    // clouds would otherwise make it flicker between 2D and 3D).
+    // clouds would otherwise make it flicker between 2D and 3D). Also capture
+    // the mouse position and time so the timed / distance cache modes can
+    // measure how long / how far we've been off geometry.
     m_lastValidDepth = depth;
     m_hasLastValidDepth = true;
+    m_lastHitTime = glfwGetTime();
+    m_lastHitScreenX = m_lastX;
+    m_lastHitScreenY = m_lastY;
   } else if (m_keepLastDepthOnBackground && m_hasLastValidDepth &&
              anyCursorVisible) {
-    // Over background: re-project the mouse position at the cached depth so
-    // the 3D cursor keeps following the mouse at the last known distance from
-    // the camera until it hits geometry again.
-    ndc.z = m_lastValidDepth * 2.0f - 1.0f;
-    worldPosH = vpInv * ndc;
-    worldPos = worldPosH / worldPosH.w;
-    isHit = true;
+    // Over background: decide whether the cached depth is still "fresh" enough
+    // to keep using, based on the configured expiry mode. INDEFINITE always
+    // keeps it; TIMED expires after a number of seconds off geometry; DISTANCE
+    // expires once the mouse has travelled too far from the last hit point.
+    bool cacheValid = true;
+    if (m_backgroundCacheMode == GUI::CURSOR_CACHE_TIMED) {
+      cacheValid =
+          (glfwGetTime() - m_lastHitTime) <= m_backgroundCacheTime;
+    } else if (m_backgroundCacheMode == GUI::CURSOR_CACHE_DISTANCE) {
+      float dx = m_lastX - m_lastHitScreenX;
+      float dy = m_lastY - m_lastHitScreenY;
+      cacheValid =
+          std::sqrt(dx * dx + dy * dy) <= m_backgroundCacheDistance;
+    }
+    if (cacheValid) {
+      // Re-project the mouse position at the cached depth so the 3D cursor
+      // keeps following the mouse at the last known distance from the camera
+      // until it hits geometry again (or the cache expires).
+      ndc.z = m_lastValidDepth * 2.0f - 1.0f;
+      worldPosH = vpInv * ndc;
+      worldPos = worldPosH / worldPosH.w;
+      isHit = true;
+    }
   }
 
   // Update cursor properties based on whether it hit geometry

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -5750,7 +5750,63 @@ void renderCursorSettingsWindow() {
         "Instead of switching to the Windows cursor over the background,\n"
         "the 3D cursor stays at the last valid depth and follows the mouse\n"
         "at that distance until it hits geometry again.\n"
-        "Useful for sparse point clouds.");
+        "Useful for sparse models and point clouds.");
+  }
+
+  // Cache-expiry options for the behavior above. Only relevant while it's on.
+  if (keepLastDepth) {
+    ImGui::Indent();
+
+    const char *cacheModes[] = {"Indefinite", "Timed", "Distance"};
+    int cacheMode = cursorManager.getBackgroundCacheMode();
+    ImGui::SetNextItemWidth(220.0f);
+    if (ImGui::Combo("Cache Duration", &cacheMode, cacheModes,
+                     IM_ARRAYSIZE(cacheModes))) {
+      cursorManager.setBackgroundCacheMode(cacheMode);
+      preferences.cursorBackgroundCacheMode = cacheMode;
+      savePreferences();
+    }
+    if (ImGui::IsItemHovered()) {
+      ImGui::SetTooltip(
+          "How long the cursor stays at the cached depth over the background:\n"
+          "  Indefinite - never give up; hold the depth until geometry is hit\n"
+          "  Timed      - revert to the Windows cursor after a time limit\n"
+          "  Distance   - revert once the mouse travels too far from the\n"
+          "               point where it left the geometry");
+    }
+
+    if (cacheMode == GUI::CURSOR_CACHE_TIMED) {
+      float cacheTime = cursorManager.getBackgroundCacheTime();
+      ImGui::SetNextItemWidth(220.0f);
+      if (ImGui::SliderFloat("Cache Time (s)", &cacheTime, 0.1f, 10.0f,
+                             "%.1f")) {
+        cursorManager.setBackgroundCacheTime(cacheTime);
+        preferences.cursorBackgroundCacheTime = cacheTime;
+        savePreferences();
+      }
+      if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip(
+            "Seconds the cursor keeps the cached depth after leaving geometry\n"
+            "before reverting to the Windows cursor.");
+      }
+    } else if (cacheMode == GUI::CURSOR_CACHE_DISTANCE) {
+      float cacheDist = cursorManager.getBackgroundCacheDistance();
+      ImGui::SetNextItemWidth(220.0f);
+      if (ImGui::SliderFloat("Cache Distance (px)", &cacheDist, 20.0f, 2000.0f,
+                             "%.0f")) {
+        cursorManager.setBackgroundCacheDistance(cacheDist);
+        preferences.cursorBackgroundCacheDistance = cacheDist;
+        savePreferences();
+      }
+      if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip(
+            "How far (in screen pixels) the mouse may travel over the\n"
+            "background from where it left the geometry before the cursor\n"
+            "reverts to the Windows cursor.");
+      }
+    }
+
+    ImGui::Unindent();
   }
 
   ImGui::Spacing();

--- a/StereoVista/src/Tools/TransformGizmo.cpp
+++ b/StereoVista/src/Tools/TransformGizmo.cpp
@@ -477,9 +477,13 @@ void TransformGizmo::updateDrag(const glm::vec3& o, const glm::vec3& d,
 void TransformGizmo::endDrag() {
     m_activeHandle = Handle::None;
     m_dragAxisIndex = -1;
-    // Drop the snap so the 3D cursor falls back to scene depth until the next
-    // hover re-establishes a handle.
-    m_hasInteractionPoint = false;
+    // Keep the last interaction point latched so the 3D cursor stays exactly
+    // where the handle was when the drag finished, rather than snapping back to
+    // scene-geometry depth. updateHover() refreshes (or clears) it on the next
+    // idle frame, but when hover is suppressed -- e.g. the right mouse button is
+    // held for a camera rotate -- the latch prevents the cursor from jumping on
+    // release.
+    // (m_hasInteractionPoint / m_interactionPoint intentionally preserved.)
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -2072,6 +2072,12 @@ void savePreferences() {
   j["ui"]["show3DCursor"] = preferences.show3DCursor;
   j["ui"]["cursorKeepLastDepthOnBackground"] =
       preferences.cursorKeepLastDepthOnBackground;
+  j["ui"]["cursorBackgroundCacheMode"] =
+      preferences.cursorBackgroundCacheMode;
+  j["ui"]["cursorBackgroundCacheTime"] =
+      preferences.cursorBackgroundCacheTime;
+  j["ui"]["cursorBackgroundCacheDistance"] =
+      preferences.cursorBackgroundCacheDistance;
   j["ui"]["enableSpawnAnimation"] = preferences.enableSpawnAnimation;
   j["ui"]["guiScaleFactor"] = preferences.guiScaleFactor;
   j["ui"]["screenshotIncludeUI"] = preferences.screenshotIncludeUI;
@@ -2369,6 +2375,10 @@ void applyPreferencesToProgram() {
   show3DCursor = preferences.show3DCursor;
   cursorManager.setKeepLastDepthOnBackground(
       preferences.cursorKeepLastDepthOnBackground);
+  cursorManager.setBackgroundCacheMode(preferences.cursorBackgroundCacheMode);
+  cursorManager.setBackgroundCacheTime(preferences.cursorBackgroundCacheTime);
+  cursorManager.setBackgroundCacheDistance(
+      preferences.cursorBackgroundCacheDistance);
   g_GuiScale.userScaleFactor = preferences.guiScaleFactor;
 
   // Apply radiance/BVH preferences to the globals the renderer reads.
@@ -2540,6 +2550,13 @@ void loadPreferences() {
       preferences.show3DCursor = j["ui"].value("show3DCursor", true);
       preferences.cursorKeepLastDepthOnBackground =
           j["ui"].value("cursorKeepLastDepthOnBackground", false);
+      preferences.cursorBackgroundCacheMode = j["ui"].value(
+          "cursorBackgroundCacheMode",
+          static_cast<int>(GUI::CURSOR_CACHE_INDEFINITE));
+      preferences.cursorBackgroundCacheTime =
+          j["ui"].value("cursorBackgroundCacheTime", 1.0f);
+      preferences.cursorBackgroundCacheDistance =
+          j["ui"].value("cursorBackgroundCacheDistance", 250.0f);
       preferences.enableSpawnAnimation =
           j["ui"].value("enableSpawnAnimation", true);
       preferences.guiScaleFactor = j["ui"].value("guiScaleFactor", 1.0f);


### PR DESCRIPTION
When a transform-gizmo drag finished, endDrag() cleared the cached
interaction point, dropping the forced 3D-cursor snap so the cursor fell
back to scene-geometry depth. In the normal case updateHover() runs on the
next idle frame and immediately re-grabs the handle, hiding the jump. But
when hover is suppressed -- e.g. the right mouse button is held for a camera
rotate (main.cpp:3808) -- nothing re-establishes the point, so the cursor
visibly jumped away from the ring on release.

Latch the last interaction point in endDrag() instead of discarding it, so
the cursor stays exactly where the handle was. updateHover() still refreshes
or clears it on the next idle frame when it does run, preserving the prior
fall-back-to-scene-depth behaviour for the non-suppressed case.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016gvMtJu9MWoaoYJQhsbg2L