### PR TITLE
Add static plugin/tool framework foundation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,10 +93,15 @@ StereoVista/
 
 ### Core Patterns
 
-- **Manager pattern:** `CursorManager`, `SceneManager`, `ShortcutManager`
+- **Manager pattern:** `CursorManager`, `SceneManager`, `ShortcutManager`, `PluginManager`
 - **Renderer pattern:** `BloomRenderer`, `SSAORenderer`, `ComputePointCloudRenderer`
+- **Plugin pattern:** tools are `Plugins::Plugin` subclasses that self-register (`REGISTER_PLUGIN`) and are driven by `Plugins::PluginManager` through a `Plugins::PluginContext` services API (`headers/Plugins/`). See **Plugin System** below.
 - **Enum-based configuration:** `SkyboxType`, `LightingMode`, `CursorScalingMode` in `headers/Gui/GuiTypes.h`
 - **JSON persistence:** Preferences, cursor presets, and scene files serialized to JSON at runtime
+
+### Plugin System
+
+New tools are added as **static (compile-time) plugins** rather than hand-wired globals. A plugin is a `Plugins::Plugin` subclass (`headers/Plugins/Plugin.h`) that overrides only the hooks it needs (lifecycle, `onRenderViewport` per eye, `onRenderUI`, `onRenderMenu`, and `bool`-returning `onMouseButton`/`onScroll`/`onKey` input hooks) and self-registers with `REGISTER_PLUGIN(Type)` in its `.cpp`. Each hook receives a `Plugins::PluginContext&` exposing common services (scene, camera, picking/3D-cursor, preferences, undo, toasts, and a `compileOverlayProgram` GL helper); the concrete context lives in `main.cpp` as `MainPluginContext` over the existing globals. `Plugins::PluginManager` (globals `g_pluginManager` / `g_pluginContext` in `main.cpp`) owns the plugins and is driven from a few integration points in `main.cpp`/`GUI.cpp`. Adding a tool = one header + one `.cpp` + a `REGISTER_PLUGIN` line + listing both files in the `.vcxproj`/`.filters` (no edits to `main.cpp`/`GUI.cpp`). `Tools::MeasurementTool` is migrated onto this system via the `Plugins::MeasurementPlugin` adapter; `CrosshairPlugin` (`headers/Plugins/Examples/`) is the copy-me template. **Full guide: `docs/PLUGINS.md`.**
 
 ### Rendering Pipeline
 

--- a/StereoVista/StereoVista.vcxproj
+++ b/StereoVista/StereoVista.vcxproj
@@ -225,6 +225,9 @@ IF %ERRORLEVEL% LEQ 7 SET ERRORLEVEL=0</Command>
     <ClCompile Include="src\Tools\ClipPlaneTool.cpp" />
     <ClCompile Include="src\Tools\MeasurementTool.cpp" />
     <ClCompile Include="src\Tools\TransformGizmo.cpp" />
+    <ClCompile Include="src\Plugins\PluginManager.cpp" />
+    <ClCompile Include="src\Plugins\MeasurementPlugin.cpp" />
+    <ClCompile Include="src\Plugins\Examples\CrosshairPlugin.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="headers\core.h" />
@@ -256,6 +259,12 @@ IF %ERRORLEVEL% LEQ 7 SET ERRORLEVEL=0</Command>
     <ClInclude Include="headers\Tools\ClipPlaneTool.h" />
     <ClInclude Include="headers\Tools\MeasurementTool.h" />
     <ClInclude Include="headers\Tools\TransformGizmo.h" />
+    <ClInclude Include="headers\Plugins\Plugin.h" />
+    <ClInclude Include="headers\Plugins\PluginContext.h" />
+    <ClInclude Include="headers\Plugins\PluginManager.h" />
+    <ClInclude Include="headers\Plugins\PluginRegistry.h" />
+    <ClInclude Include="headers\Plugins\MeasurementPlugin.h" />
+    <ClInclude Include="headers\Plugins\Examples\CrosshairPlugin.h" />
     <ClInclude Include="headers\libs\assimp\aabb.h" />
     <ClInclude Include="headers\libs\assimp\ai_assert.h" />
     <ClInclude Include="headers\libs\assimp\anim.h" />

--- a/StereoVista/StereoVista.vcxproj.filters
+++ b/StereoVista/StereoVista.vcxproj.filters
@@ -138,6 +138,15 @@
     <ClCompile Include="src\Tools\TransformGizmo.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Plugins\PluginManager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Plugins\MeasurementPlugin.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Plugins\Examples\CrosshairPlugin.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\Engine\DDGIVolume.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -504,6 +513,24 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="headers\Tools\TransformGizmo.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="headers\Plugins\Plugin.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="headers\Plugins\PluginContext.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="headers\Plugins\PluginManager.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="headers\Plugins\PluginRegistry.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="headers\Plugins\MeasurementPlugin.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="headers\Plugins\Examples\CrosshairPlugin.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="headers\Loaders\ModelLoader.h">

--- a/StereoVista/headers/Plugins/Examples/CrosshairPlugin.h
+++ b/StereoVista/headers/Plugins/Examples/CrosshairPlugin.h
@@ -1,0 +1,64 @@
+#pragma once
+
+// ============================================================================
+//  CrosshairPlugin  —  the canonical example / template plugin
+// ----------------------------------------------------------------------------
+//  Copy this pair of files (.h + .cpp) as the starting point for a new tool.
+//  It is intentionally small but exercises the whole Plugin API surface:
+//
+//    • info()             — identity + Tools-menu metadata
+//    • onInitializeGL /
+//      onShutdownGL       — create / destroy a tiny overlay shader + buffers
+//    • onRenderViewport   — draw a world-space crosshair at the 3D cursor and
+//                           at every dropped marker (called once per eye)
+//    • onRenderUI         — an ImGui settings window (color, size, list)
+//    • onMouseButton      — left-click drops a marker and raises a toast
+//    • the default menu /
+//      windowOpen() flow  — toggled from the Tools menu
+//
+//  Everything the tool needs from the host arrives through PluginContext, and
+//  it registers itself via REGISTER_PLUGIN in the .cpp — no edits to main.cpp
+//  or GUI.cpp are required to add it.
+// ============================================================================
+
+#include "Plugins/Plugin.h"
+#include <glm/glm.hpp>
+#include <vector>
+
+namespace Plugins {
+
+class CrosshairPlugin : public Plugin {
+public:
+    PluginInfo info() const override;
+
+    void onInitializeGL(PluginContext& ctx) override;
+    void onShutdownGL() override;
+
+    void onRenderViewport(PluginContext& ctx, const glm::mat4& projection,
+                          const glm::mat4& view, const glm::vec3& cameraPos) override;
+    void onRenderUI(PluginContext& ctx) override;
+
+    bool onMouseButton(PluginContext& ctx, int button, int action, int mods) override;
+
+private:
+    // Append a 3-axis crosshair (6 vertices) centred at p to the line buffer.
+    void appendCrosshair(std::vector<float>& verts, const glm::vec3& p,
+                         float size) const;
+
+    // ── Settings (exposed in the ImGui window) ──
+    glm::vec3 m_color      = glm::vec3(0.10f, 0.90f, 0.40f);
+    float     m_size       = 0.25f;   // half-length of each crosshair arm (world)
+    bool      m_showCursor = true;    // draw a crosshair at the live 3D cursor
+
+    // ── Dropped markers (the tool's own data) ──
+    std::vector<glm::vec3> m_markers;
+
+    // ── GL resources (created in onInitializeGL) ──
+    unsigned int m_program = 0;
+    unsigned int m_vao     = 0;
+    unsigned int m_vbo     = 0;
+    int          m_uViewProj = -1;
+    int          m_uColor    = -1;
+};
+
+} // namespace Plugins

--- a/StereoVista/headers/Plugins/MeasurementPlugin.h
+++ b/StereoVista/headers/Plugins/MeasurementPlugin.h
@@ -1,0 +1,46 @@
+#pragma once
+
+// ============================================================================
+//  MeasurementPlugin  —  adapter that drives the legacy MeasurementTool
+//                        through the plugin system
+// ----------------------------------------------------------------------------
+//  This is the worked migration example referenced by docs/PLUGINS.md. Rather
+//  than rewrite Tools::MeasurementTool, this thin adapter wraps the existing
+//  global instance (declared in main.cpp) and exposes it through the Plugin
+//  hooks, so all of its render / UI / menu / input now flow through the unified
+//  PluginManager pipeline:
+//
+//    onInitializeGL  → MeasurementTool::initialize()
+//    onRenderViewport→ MeasurementTool::render() (with the 3D-cursor preview)
+//    onRenderMenu    → the "Measure" Tools-menu entry
+//    onRenderUI      → the existing renderMeasurementToolWindow()
+//    onMouseButton   → left-click places a point, right-click finishes
+//    onKey           → Enter finishes, Delete cancels, Backspace undoes a point
+//
+//  The tool's editable data still lives in Engine::Scene::measurements, so
+//  scene save/load and SnapshotManager are completely unaffected.
+//
+//  This "adapter wrapping a legacy global" is the recommended low-risk pattern
+//  for migrating the remaining tools (BrushTool, ClipPlaneTool, ...).
+// ============================================================================
+
+#include "Plugins/Plugin.h"
+
+namespace Plugins {
+
+class MeasurementPlugin : public Plugin {
+public:
+    PluginInfo info() const override;
+
+    void onInitializeGL(PluginContext& ctx) override;
+
+    void onRenderViewport(PluginContext& ctx, const glm::mat4& projection,
+                          const glm::mat4& view, const glm::vec3& cameraPos) override;
+    void onRenderUI(PluginContext& ctx) override;
+    void onRenderMenu(PluginContext& ctx) override;
+
+    bool onMouseButton(PluginContext& ctx, int button, int action, int mods) override;
+    bool onKey(PluginContext& ctx, int key, int scancode, int action, int mods) override;
+};
+
+} // namespace Plugins

--- a/StereoVista/headers/Plugins/Plugin.h
+++ b/StereoVista/headers/Plugins/Plugin.h
@@ -1,0 +1,117 @@
+#pragma once
+
+// ============================================================================
+//  Plugin  —  base class for every StereoVista tool/plugin
+// ----------------------------------------------------------------------------
+//  A plugin is a self-contained tool compiled into the application. It opts in
+//  to whichever host hooks it needs by overriding the corresponding virtual
+//  method below; every hook has a no-op default, so a minimal plugin overrides
+//  only info() plus the one or two hooks it cares about.
+//
+//  All per-frame and event hooks receive a Plugins::PluginContext& giving safe
+//  access to the scene, picking, preferences, undo, toasts and a GL helper.
+//
+//  Registration is automatic: drop REGISTER_PLUGIN(MyPlugin) in the plugin's
+//  .cpp (see PluginRegistry.h) and the PluginManager will instantiate it at
+//  startup — no edits to main.cpp or GUI.cpp required.
+//
+//  See docs/PLUGINS.md for the lifecycle diagram and a step-by-step guide.
+// ============================================================================
+
+#include "PluginContext.h"
+#include <glm/glm.hpp>
+#include <string>
+
+namespace Plugins {
+
+// Loose grouping used for menu organisation / filtering. Purely cosmetic.
+enum class PluginCategory {
+    Tool,           // interactive editing tool (default)
+    Visualization,  // overlays / debug draws
+    Import,         // data ingestion
+    Export,         // data output
+    Utility,        // helpers, generators
+    Experimental
+};
+
+// Static metadata describing a plugin. Returned by Plugin::info().
+struct PluginInfo {
+    std::string    id;                 // stable unique id, e.g. "stereovista.crosshair"
+    std::string    name;               // menu / window label, e.g. "Crosshair"
+    std::string    description;        // one-line summary (tooltip)
+    std::string    version  = "1.0.0";
+    PluginCategory category = PluginCategory::Tool;
+    std::string    shortcut;           // optional display hint, e.g. "Ctrl+H"
+                                       // (binding itself stays external)
+};
+
+class Plugin {
+public:
+    virtual ~Plugin() = default;
+
+    // Identity / metadata. The only mandatory override.
+    virtual PluginInfo info() const = 0;
+
+    // ── Lifecycle ───────────────────────────────────────────────────────────
+    // onRegister     : called once when the plugin is added to the manager,
+    //                  before any GL context work. Good for wiring scene data.
+    // onInitializeGL : called once with a valid GL context; create VAOs/shaders.
+    // onShutdownGL   : called once at exit (GL context still valid); free them.
+    virtual void onRegister(PluginContext&)     {}
+    virtual void onInitializeGL(PluginContext&) {}
+    virtual void onShutdownGL()                 {}
+
+    // ── Enabled (active) state ──────────────────────────────────────────────
+    // "Enabled" means the tool is actively capturing interaction (e.g. clicks
+    // place points). Toggled by the host or the plugin's own UI. onEnable /
+    // onDisable fire only on an actual transition.
+    bool isEnabled() const { return m_enabled; }
+    void setEnabled(bool enabled) {
+        if (enabled == m_enabled) return;
+        m_enabled = enabled;
+        if (enabled) onEnable(); else onDisable();
+    }
+    virtual void onEnable()  {}
+    virtual void onDisable() {}
+
+    // ── Per-frame ───────────────────────────────────────────────────────────
+    // Logic update, once per frame before rendering. dt is seconds.
+    virtual void onUpdate(PluginContext&, float /*dt*/) {}
+
+    // World-space overlay. Called once PER EYE with that eye's matrices, during
+    // the scene render. Draw 3D gizmos / annotations here. Never assume this is
+    // the only eye — keep it stateless w.r.t. the matrices passed in.
+    virtual void onRenderViewport(PluginContext&, const glm::mat4& /*projection*/,
+                                  const glm::mat4& /*view*/,
+                                  const glm::vec3& /*cameraPos*/) {}
+
+    // ImGui pass. Called once per frame (left-eye GUI build). Draw your own
+    // ImGui windows here; gate them on windowOpen() if you use the default
+    // menu entry below.
+    virtual void onRenderUI(PluginContext&) {}
+
+    // Tools-menu entry. Default implementation adds a checkbox menu item that
+    // toggles windowOpen(). Override for a custom submenu.
+    virtual void onRenderMenu(PluginContext&);
+
+    // ── Input hooks (return true to CONSUME the event) ──────────────────────
+    // The manager queries plugins before the host's built-in handling; the
+    // first plugin to return true stops propagation. Arguments mirror GLFW.
+    virtual bool onMouseButton(PluginContext&, int /*button*/, int /*action*/,
+                               int /*mods*/)                       { return false; }
+    virtual bool onScroll(PluginContext&, double /*xoffset*/,
+                          double /*yoffset*/)                      { return false; }
+    virtual bool onKey(PluginContext&, int /*key*/, int /*scancode*/,
+                       int /*action*/, int /*mods*/)               { return false; }
+
+    // Window-visibility flag the default menu entry toggles and onRenderUI can
+    // read. Plugins without a window can simply ignore it.
+    bool&       windowOpen()       { return m_windowOpen; }
+    const bool& windowOpen() const { return m_windowOpen; }
+
+protected:
+    bool m_enabled    = false;
+    bool m_windowOpen = false;
+};
+
+} // namespace Plugins

--- a/StereoVista/headers/Plugins/PluginContext.h
+++ b/StereoVista/headers/Plugins/PluginContext.h
@@ -1,0 +1,93 @@
+#pragma once
+
+// ============================================================================
+//  PluginContext  —  the services API handed to every StereoVista plugin
+// ----------------------------------------------------------------------------
+//  A plugin never talks to the application's globals directly. Instead, every
+//  hook on Plugins::Plugin receives a PluginContext& through which it can reach
+//  the common, frequently-needed functionality of the host:
+//
+//      • the active scene and camera
+//      • picking (the mouse ray, the 3D-cursor world position, scene raycasts)
+//      • user preferences and the undo system
+//      • input state (mouse position, modifier keys, viewport size)
+//      • user-facing toast notifications
+//      • a helper to compile self-contained overlay shaders
+//
+//  PluginContext is an abstract interface. The concrete implementation lives in
+//  main.cpp and simply forwards to the existing application globals, so the
+//  plugin layer stays decoupled from the 7,000-line main translation unit.
+//
+//  See docs/PLUGINS.md for the full API reference and worked examples.
+// ============================================================================
+
+#include "Engine/Core.h"   // GL types (GLuint) + GLFW + glm, exactly like Tools/
+#include <glm/glm.hpp>
+#include <string>
+
+// Forward declarations keep this header light: plugins only pull in the heavy
+// types they actually use.
+namespace Engine { struct Scene; class UndoManager; }
+class Camera;
+namespace GUI { struct ApplicationPreferences; }
+
+namespace Plugins {
+
+// Severity for PluginContext::toast(); maps onto GUI::ToastType in the host.
+enum class ToastLevel { Success, Info, Warning, Error };
+
+// A picking ray through the current OS-cursor position, in world space.
+struct PickRay {
+    glm::vec3 origin    = glm::vec3(0.0f);
+    glm::vec3 direction = glm::vec3(0.0f, 0.0f, -1.0f);
+};
+
+// Nearest intersection of the mouse ray with model geometry in the scene.
+struct RayHit {
+    bool      hit        = false;
+    float     distance   = 0.0f;
+    glm::vec3 position    = glm::vec3(0.0f);
+    glm::vec3 normal      = glm::vec3(0.0f, 1.0f, 0.0f);
+    int       modelIndex  = -1;   // index into scene().models, or -1
+};
+
+class PluginContext {
+public:
+    virtual ~PluginContext() = default;
+
+    // ── Scene, camera & core services ───────────────────────────────────────
+    virtual Engine::Scene&               scene()           = 0;
+    virtual const Camera&                camera()    const = 0;
+    virtual glm::vec3                    cameraPosition() const = 0;
+    virtual GUI::ApplicationPreferences& preferences()     = 0;
+    virtual Engine::UndoManager&         undo()            = 0;
+
+    // ── Picking / 3D cursor ─────────────────────────────────────────────────
+    // mouseRay():        world-space ray under the OS cursor (uses the same
+    //                    projection the renderer used this frame).
+    // cursorWorldPos():  the synchronized 3D-cursor world position; returns
+    //                    false when the cursor is not over valid geometry.
+    // raycastModels():   nearest hit of mouseRay() against scene model meshes.
+    virtual PickRay mouseRay()                       const = 0;
+    virtual bool    cursorWorldPos(glm::vec3& out)   const = 0;
+    virtual RayHit  raycastModels()                  const = 0;
+
+    // ── Input / viewport state ──────────────────────────────────────────────
+    virtual glm::vec2 mousePos()      const = 0;   // pixels, window space
+    virtual int       keyMods()       const = 0;   // current GLFW_MOD_* bitmask
+    virtual glm::vec2 viewportSize()  const = 0;   // 3D viewport, pixels
+
+    // ── User feedback ───────────────────────────────────────────────────────
+    virtual void toast(const std::string& message,
+                       ToastLevel level = ToastLevel::Info) = 0;
+
+    // ── GL convenience (shared implementation, not overridable) ─────────────
+    // Compile + link a tiny vertex/fragment shader program from source strings.
+    // Returns the program name, or 0 on failure (errors are logged to stderr).
+    // Use this for the self-contained overlay shaders an overlay tool needs,
+    // instead of copy-pasting the glCreateShader/link boilerplate.
+    GLuint compileOverlayProgram(const char* vertexSrc, const char* fragmentSrc,
+                                 const char* label = "plugin");
+};
+
+} // namespace Plugins

--- a/StereoVista/headers/Plugins/PluginManager.h
+++ b/StereoVista/headers/Plugins/PluginManager.h
@@ -1,0 +1,77 @@
+#pragma once
+
+// ============================================================================
+//  PluginManager  —  owns plugins and drives every host-integration point
+// ----------------------------------------------------------------------------
+//  A single PluginManager instance lives in main.cpp. The host calls into it
+//  at a handful of well-defined points (init, shutdown, per-eye render, ImGui
+//  pass, Tools menu, and the GLFW input callbacks); the manager fans each call
+//  out to the registered plugins.
+//
+//  Two kinds of plugins:
+//    • Registered (owned)  — created from the static REGISTER_PLUGIN registry
+//                            by loadRegisteredPlugins(); owned by the manager.
+//    • External (borrowed) — an existing global tool migrated onto the Plugin
+//                            interface; added with registerExternal(), still
+//                            owned by whoever declared it.
+//
+//  Event dispatch (mouse/scroll/key) returns true when a plugin CONSUMED the
+//  event, so the host can early-out and skip its built-in handling.
+// ============================================================================
+
+#include "Plugin.h"
+#include "PluginContext.h"
+#include <glm/glm.hpp>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace Plugins {
+
+class PluginManager {
+public:
+    PluginManager() = default;
+
+    // ── Population ──────────────────────────────────────────────────────────
+    // Instantiate every statically-registered plugin (REGISTER_PLUGIN) and call
+    // onRegister on each. Call once, after the GL context exists.
+    void loadRegisteredPlugins(PluginContext& ctx);
+
+    // Add an externally-owned plugin (e.g. a migrated global tool). The manager
+    // does NOT take ownership; the pointer must outlive the manager. onRegister
+    // is invoked immediately.
+    void registerExternal(Plugin* plugin, PluginContext& ctx);
+
+    // ── Lifecycle dispatch ──────────────────────────────────────────────────
+    void initializeAllGL(PluginContext& ctx);   // onInitializeGL for all
+    void shutdownAllGL();                        // onShutdownGL for all
+    void update(PluginContext& ctx, float dt);   // onUpdate for all
+
+    void renderViewport(PluginContext& ctx, const glm::mat4& projection,
+                        const glm::mat4& view, const glm::vec3& cameraPos);
+    void renderUI(PluginContext& ctx);           // onRenderUI for all
+    void renderMenu(PluginContext& ctx);         // onRenderMenu for all
+
+    // ── Input dispatch (true == consumed by some plugin) ────────────────────
+    bool dispatchMouseButton(PluginContext& ctx, int button, int action, int mods);
+    bool dispatchScroll(PluginContext& ctx, double xoffset, double yoffset);
+    bool dispatchKey(PluginContext& ctx, int key, int scancode, int action, int mods);
+
+    // ── Access ──────────────────────────────────────────────────────────────
+    Plugin* find(const std::string& id);
+    const std::vector<Plugin*>& all() const { return m_all; }
+
+    // Typed lookup, e.g. manager.get<MeasurementPlugin>().
+    template <class T> T* get() {
+        for (Plugin* p : m_all)
+            if (auto* typed = dynamic_cast<T*>(p)) return typed;
+        return nullptr;
+    }
+
+private:
+    std::vector<std::unique_ptr<Plugin>> m_owned; // registered plugins
+    std::vector<Plugin*>                 m_all;    // owned + external, in order
+    bool m_glInitialized = false;
+};
+
+} // namespace Plugins

--- a/StereoVista/headers/Plugins/PluginRegistry.h
+++ b/StereoVista/headers/Plugins/PluginRegistry.h
@@ -1,0 +1,52 @@
+#pragma once
+
+// ============================================================================
+//  PluginRegistry  —  compile-time self-registration for plugins
+// ----------------------------------------------------------------------------
+//  Each plugin .cpp ends with:
+//
+//      REGISTER_PLUGIN(MyPlugin);
+//
+//  This places a factory for MyPlugin into a global list at static-init time.
+//  PluginManager::loadRegisteredPlugins() walks that list and instantiates one
+//  of each. No central list of plugins to maintain — adding a tool is a purely
+//  local change to its own files (plus listing them in the .vcxproj).
+//
+//  Note (MSVC): because the application is built as a single executable (not a
+//  static library), object files are always linked in and their static
+//  initializers run. If the plugins are ever moved into a separate static lib,
+//  the linker may discard the unreferenced objects — use /WHOLEARCHIVE (or an
+//  explicit reference) for that lib so the registrars survive.
+// ============================================================================
+
+#include "Plugin.h"
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace Plugins {
+
+// A function that produces a fresh plugin instance.
+using PluginFactory = std::function<std::unique_ptr<Plugin>()>;
+
+// The global registry. A function-local static (Meyers singleton) so it is
+// safe to use from other static initializers regardless of init order.
+std::vector<PluginFactory>& pluginFactoryRegistry();
+
+// Helper whose constructor appends a factory to the registry. One static
+// instance is created per REGISTER_PLUGIN use.
+struct PluginRegistrar {
+    explicit PluginRegistrar(PluginFactory factory);
+};
+
+} // namespace Plugins
+
+// Register a Plugin subclass so the PluginManager instantiates it at startup.
+// Use in the plugin's .cpp, at file scope, e.g.  REGISTER_PLUGIN(CrosshairPlugin);
+#define REGISTER_PLUGIN(Type)                                                  \
+    namespace {                                                                \
+    const ::Plugins::PluginRegistrar s_pluginRegistrar_##Type(                 \
+        []() -> std::unique_ptr<::Plugins::Plugin> {                           \
+            return std::make_unique<Type>();                                   \
+        });                                                                    \
+    }

--- a/StereoVista/headers/Plugins/PluginRegistry.h
+++ b/StereoVista/headers/Plugins/PluginRegistry.h
@@ -41,12 +41,22 @@ struct PluginRegistrar {
 
 } // namespace Plugins
 
+// Token-paste helpers: build a unique registrar name from __LINE__. The extra
+// indirection is required so __LINE__ is expanded before pasting. Pasting the
+// line number (not the type) lets REGISTER_PLUGIN accept a namespace-qualified
+// type, e.g. REGISTER_PLUGIN(Plugins::CrosshairPlugin), without producing an
+// invalid identifier.
+#define PLUGIN_REGISTRY_CONCAT_(a, b) a##b
+#define PLUGIN_REGISTRY_CONCAT(a, b) PLUGIN_REGISTRY_CONCAT_(a, b)
+
 // Register a Plugin subclass so the PluginManager instantiates it at startup.
-// Use in the plugin's .cpp, at file scope, e.g.  REGISTER_PLUGIN(CrosshairPlugin);
+// Use in the plugin's .cpp, at file scope, e.g.
+//   REGISTER_PLUGIN(Plugins::CrosshairPlugin);
 #define REGISTER_PLUGIN(Type)                                                  \
     namespace {                                                                \
-    const ::Plugins::PluginRegistrar s_pluginRegistrar_##Type(                 \
-        []() -> std::unique_ptr<::Plugins::Plugin> {                           \
-            return std::make_unique<Type>();                                   \
-        });                                                                    \
+    const ::Plugins::PluginRegistrar                                           \
+        PLUGIN_REGISTRY_CONCAT(s_pluginRegistrar_, __LINE__)(                  \
+            []() -> std::unique_ptr<::Plugins::Plugin> {                       \
+                return std::make_unique<Type>();                              \
+            });                                                                \
     }

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -15,6 +15,7 @@
 #include "Tools/ClipPlaneTool.h"
 #include "Tools/MeasurementTool.h"
 #include "Tools/TransformGizmo.h"
+#include "Plugins/PluginManager.h"
 #include "imgui/IconsFontAwesome5.h"
 #include "imgui/imgui_sytle.h"
 #include "libs/portable-file-dialogs.h"
@@ -80,6 +81,12 @@ extern bool showMeasurementToolWindow;
 // Section / clip plane tool
 extern Tools::ClipPlaneTool clipPlaneTool;
 extern bool showClipPlaneToolWindow;
+
+// Plugin system (owned by main.cpp). g_pluginContext is a reference to the
+// concrete services API; both are used to dispatch the Tools-menu entries and
+// the plugin ImGui windows.
+extern Plugins::PluginManager g_pluginManager;
+extern Plugins::PluginContext &g_pluginContext;
 
 // Snapshots
 extern bool showSnapshotsWindow;
@@ -2093,8 +2100,8 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
       menuButtonTooltip("Scatter copies of a model across surfaces with the "
                         "paint brush");
 
-      ImGui::MenuItem("Measure", nullptr, &showMeasurementToolWindow);
-      menuButtonTooltip("Measure distances, angles and coordinates in the scene");
+      // "Measure" is now contributed by MeasurementPlugin through the plugin
+      // menu dispatch below, alongside any other registered plugins.
 
       ImGui::MenuItem("Section Planes", nullptr, &showClipPlaneToolWindow);
       menuButtonTooltip("Slice the scene with clipping planes to inspect "
@@ -2102,6 +2109,10 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
 
       ImGui::MenuItem("Snapshots", nullptr, &showSnapshotsWindow);
       menuButtonTooltip("Save and restore camera / scene / tool snapshots");
+
+      // Plugin-contributed tool entries (each toggles its own window).
+      ImGui::Separator();
+      g_pluginManager.renderMenu(g_pluginContext);
 
       ImGui::EndMenu();
     }
@@ -2805,9 +2816,9 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
     renderBrushToolWindow();
   }
 
-  if (showMeasurementToolWindow) {
-    renderMeasurementToolWindow();
-  }
+  // Plugin ImGui windows (MeasurementPlugin draws the measurement window here,
+  // gated by showMeasurementToolWindow; other plugins draw their own windows).
+  g_pluginManager.renderUI(g_pluginContext);
 
   if (showClipPlaneToolWindow) {
     renderClipPlaneToolWindow();

--- a/StereoVista/src/Plugins/Examples/CrosshairPlugin.cpp
+++ b/StereoVista/src/Plugins/Examples/CrosshairPlugin.cpp
@@ -1,0 +1,154 @@
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
+#include "Plugins/Examples/CrosshairPlugin.h"
+#include "Plugins/PluginRegistry.h"
+
+#include "imgui/imgui.h"
+#include <glm/gtc/type_ptr.hpp>
+
+namespace Plugins {
+
+// ── Embedded overlay shaders ────────────────────────────────────────────────
+// Self-contained so the plugin has no asset-file dependency. Position-only
+// geometry; a flat colour is supplied through a uniform.
+static const char* kVertexSrc = R"(
+#version 330 core
+layout (location = 0) in vec3 aPos;
+uniform mat4 uViewProj;
+void main() { gl_Position = uViewProj * vec4(aPos, 1.0); }
+)";
+
+static const char* kFragmentSrc = R"(
+#version 330 core
+out vec4 FragColor;
+uniform vec3 uColor;
+void main() { FragColor = vec4(uColor, 1.0); }
+)";
+
+// ── Identity ────────────────────────────────────────────────────────────────
+PluginInfo CrosshairPlugin::info() const {
+    PluginInfo meta;
+    meta.id          = "stereovista.crosshair";
+    meta.name        = "Crosshair (Example)";
+    meta.description = "Example plugin: drops world-space crosshair markers.";
+    meta.version     = "1.0.0";
+    meta.category    = PluginCategory::Visualization;
+    return meta;
+}
+
+// ── GL lifecycle ────────────────────────────────────────────────────────────
+void CrosshairPlugin::onInitializeGL(PluginContext& ctx) {
+    // The host's helper compiles + links the embedded program for us.
+    m_program  = ctx.compileOverlayProgram(kVertexSrc, kFragmentSrc, "crosshair");
+    m_uViewProj = glGetUniformLocation(m_program, "uViewProj");
+    m_uColor    = glGetUniformLocation(m_program, "uColor");
+
+    glGenVertexArrays(1, &m_vao);
+    glGenBuffers(1, &m_vbo);
+    glBindVertexArray(m_vao);
+    glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
+    glEnableVertexAttribArray(0);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindVertexArray(0);
+}
+
+void CrosshairPlugin::onShutdownGL() {
+    if (m_vbo)     { glDeleteBuffers(1, &m_vbo);            m_vbo = 0; }
+    if (m_vao)     { glDeleteVertexArrays(1, &m_vao);       m_vao = 0; }
+    if (m_program) { glDeleteProgram(m_program);            m_program = 0; }
+}
+
+// ── Geometry helper ─────────────────────────────────────────────────────────
+void CrosshairPlugin::appendCrosshair(std::vector<float>& v, const glm::vec3& p,
+                                      float s) const {
+    const float pts[] = {
+        p.x - s, p.y, p.z,  p.x + s, p.y, p.z, // X arm
+        p.x, p.y - s, p.z,  p.x, p.y + s, p.z, // Y arm
+        p.x, p.y, p.z - s,  p.x, p.y, p.z + s, // Z arm
+    };
+    v.insert(v.end(), pts, pts + (sizeof(pts) / sizeof(pts[0])));
+}
+
+// ── World-space overlay (called once per eye) ───────────────────────────────
+void CrosshairPlugin::onRenderViewport(PluginContext& ctx, const glm::mat4& projection,
+                                       const glm::mat4& view, const glm::vec3& /*cameraPos*/) {
+    if (m_program == 0) return;
+
+    std::vector<float> verts;
+    for (const glm::vec3& m : m_markers) appendCrosshair(verts, m, m_size);
+
+    // A crosshair tracking the live 3D cursor while the tool is enabled.
+    glm::vec3 cursor;
+    if (m_enabled && m_showCursor && ctx.cursorWorldPos(cursor))
+        appendCrosshair(verts, cursor, m_size * 1.4f);
+
+    if (verts.empty()) return;
+
+    // Overlay must not write depth (the cursor system samples scene depth).
+    GLboolean prevDepthMask = GL_TRUE;
+    glGetBooleanv(GL_DEPTH_WRITEMASK, &prevDepthMask);
+    glDepthMask(GL_FALSE);
+
+    const glm::mat4 viewProj = projection * view;
+    glUseProgram(m_program);
+    glUniformMatrix4fv(m_uViewProj, 1, GL_FALSE, glm::value_ptr(viewProj));
+    glUniform3fv(m_uColor, 1, glm::value_ptr(m_color));
+
+    glBindVertexArray(m_vao);
+    glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+    glBufferData(GL_ARRAY_BUFFER,
+                 static_cast<GLsizeiptr>(verts.size() * sizeof(float)),
+                 verts.data(), GL_DYNAMIC_DRAW);
+    glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(verts.size() / 3));
+
+    glBindVertexArray(0);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glUseProgram(0);
+    glDepthMask(prevDepthMask);
+}
+
+// ── ImGui settings window ───────────────────────────────────────────────────
+void CrosshairPlugin::onRenderUI(PluginContext& ctx) {
+    if (!m_windowOpen) return; // toggled from the Tools menu (default entry)
+
+    if (ImGui::Begin(info().name.c_str(), &m_windowOpen)) {
+        bool enabled = m_enabled;
+        if (ImGui::Checkbox("Enabled (click to drop markers)", &enabled))
+            setEnabled(enabled);
+
+        ImGui::ColorEdit3("Color", glm::value_ptr(m_color));
+        ImGui::SliderFloat("Size", &m_size, 0.02f, 2.0f, "%.2f");
+        ImGui::Checkbox("Track 3D cursor", &m_showCursor);
+
+        ImGui::Separator();
+        ImGui::Text("Markers: %d", static_cast<int>(m_markers.size()));
+        if (ImGui::Button("Clear markers")) {
+            m_markers.clear();
+            ctx.toast("Crosshair markers cleared", ToastLevel::Info);
+        }
+    }
+    ImGui::End();
+}
+
+// ── Input: left-click drops a marker at the 3D cursor ───────────────────────
+bool CrosshairPlugin::onMouseButton(PluginContext& ctx, int button, int action,
+                                    int mods) {
+    if (!m_enabled) return false;                 // only when actively editing
+    if (button != GLFW_MOUSE_BUTTON_LEFT || action != GLFW_PRESS) return false;
+    if (mods & (GLFW_MOD_CONTROL | GLFW_MOD_ALT)) return false; // leave nav/select
+
+    glm::vec3 cursor;
+    if (!ctx.cursorWorldPos(cursor)) return false; // nothing under the cursor
+
+    m_markers.push_back(cursor);
+    ctx.toast("Marker dropped", ToastLevel::Success);
+    return true; // consume: don't also orbit / select
+}
+
+} // namespace Plugins
+
+// Self-register so the PluginManager instantiates this at startup.
+REGISTER_PLUGIN(Plugins::CrosshairPlugin);

--- a/StereoVista/src/Plugins/MeasurementPlugin.cpp
+++ b/StereoVista/src/Plugins/MeasurementPlugin.cpp
@@ -1,0 +1,105 @@
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
+#include "Plugins/MeasurementPlugin.h"
+#include "Plugins/PluginRegistry.h"
+#include "Tools/MeasurementTool.h"
+#include "Gui/Gui.h"
+
+// Legacy globals owned by main.cpp / GUI.cpp that this adapter bridges.
+extern Tools::MeasurementTool measurementTool;
+extern bool showMeasurementToolWindow;
+
+namespace Plugins {
+
+PluginInfo MeasurementPlugin::info() const {
+    PluginInfo meta;
+    meta.id          = "stereovista.measurement";
+    meta.name        = "Measure";
+    meta.description = "Measure distances, angles and coordinates in the scene.";
+    meta.version     = "1.0.0";
+    meta.category    = PluginCategory::Tool;
+    meta.shortcut    = "M";
+    return meta;
+}
+
+void MeasurementPlugin::onInitializeGL(PluginContext& /*ctx*/) {
+    // Create the overlay GL resources up front (also done lazily by render()).
+    measurementTool.initialize();
+}
+
+void MeasurementPlugin::onRenderViewport(PluginContext& ctx, const glm::mat4& projection,
+                                         const glm::mat4& view,
+                                         const glm::vec3& /*cameraPos*/) {
+    // Committed measurements always draw; the live rubber-band preview only
+    // while the tool is enabled and the 3D cursor is over geometry.
+    glm::vec3 cursor;
+    const glm::vec3* preview = nullptr;
+    if (measurementTool.isEnabled() && ctx.cursorWorldPos(cursor))
+        preview = &cursor;
+    measurementTool.render(projection, view, preview);
+}
+
+void MeasurementPlugin::onRenderMenu(PluginContext& /*ctx*/) {
+    // Mirrors the former static Tools-menu entry; keeps using the existing
+    // window-visibility flag so the "M" shortcut (which sets it) still works.
+    ImGui::MenuItem("Measure", "M", &showMeasurementToolWindow);
+    if (ImGui::IsItemHovered())
+        ImGui::SetTooltip("Measure distances, angles and coordinates in the scene");
+}
+
+void MeasurementPlugin::onRenderUI(PluginContext& /*ctx*/) {
+    if (showMeasurementToolWindow)
+        renderMeasurementToolWindow();
+}
+
+bool MeasurementPlugin::onMouseButton(PluginContext& ctx, int button, int action,
+                                      int mods) {
+    if (action != GLFW_PRESS) return false;
+
+    if (button == GLFW_MOUSE_BUTTON_LEFT) {
+        // Ctrl/Alt clicks fall through to object selection / free-move.
+        if (mods & (GLFW_MOD_CONTROL | GLFW_MOD_ALT)) return false;
+        if (!measurementTool.isEnabled()) return false;
+        glm::vec3 cursor;
+        if (ctx.cursorWorldPos(cursor))
+            measurementTool.addPoint(cursor);
+        return true; // consume: no orbiting/selection while measuring
+    }
+
+    if (button == GLFW_MOUSE_BUTTON_RIGHT) {
+        // Right-click finishes the in-progress polyline instead of rotating.
+        if (measurementTool.isEnabled() && measurementTool.hasActive()) {
+            measurementTool.finishActive();
+            return true;
+        }
+    }
+    return false;
+}
+
+bool MeasurementPlugin::onKey(PluginContext& /*ctx*/, int key, int /*scancode*/,
+                              int action, int mods) {
+    if (action != GLFW_PRESS) return false;
+    if (!(measurementTool.isEnabled() && measurementTool.hasActive())) return false;
+    (void)mods;
+
+    if (key == GLFW_KEY_ENTER || key == GLFW_KEY_KP_ENTER) {
+        measurementTool.finishActive();
+        return true;
+    }
+    if (key == GLFW_KEY_DELETE) {
+        measurementTool.cancelActive();
+        return true;
+    }
+    if (key == GLFW_KEY_BACKSPACE) {
+        measurementTool.undoLastPoint();
+        return true;
+    }
+    return false;
+}
+
+} // namespace Plugins
+
+// Self-register so the PluginManager instantiates the adapter at startup.
+REGISTER_PLUGIN(Plugins::MeasurementPlugin);

--- a/StereoVista/src/Plugins/PluginManager.cpp
+++ b/StereoVista/src/Plugins/PluginManager.cpp
@@ -1,0 +1,156 @@
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
+#include "Plugins/PluginManager.h"
+#include "Plugins/PluginRegistry.h"
+#include "imgui/imgui.h"
+
+#include <iostream>
+
+namespace Plugins {
+
+// ───────────────────────────── Static registry ─────────────────────────────
+
+std::vector<PluginFactory>& pluginFactoryRegistry() {
+    // Function-local static: constructed on first use, so it is safe to append
+    // to from other translation units' static initializers (REGISTER_PLUGIN).
+    static std::vector<PluginFactory> registry;
+    return registry;
+}
+
+PluginRegistrar::PluginRegistrar(PluginFactory factory) {
+    pluginFactoryRegistry().push_back(std::move(factory));
+}
+
+// ──────────────────────────── Plugin defaults ──────────────────────────────
+
+void Plugin::onRenderMenu(PluginContext& /*ctx*/) {
+    // Default Tools-menu entry: a checkbox toggling this plugin's window.
+    const PluginInfo meta = info();
+    const char* shortcut = meta.shortcut.empty() ? nullptr : meta.shortcut.c_str();
+    if (ImGui::MenuItem(meta.name.c_str(), shortcut, &m_windowOpen)) {
+        // toggled; the plugin's onRenderUI reads windowOpen()
+    }
+    if (!meta.description.empty() && ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("%s", meta.description.c_str());
+    }
+}
+
+// ───────────────────────── PluginContext GL helper ─────────────────────────
+
+GLuint PluginContext::compileOverlayProgram(const char* vertexSrc,
+                                            const char* fragmentSrc,
+                                            const char* label) {
+    auto compile = [&](GLenum type, const char* src, const char* stage) -> GLuint {
+        GLuint shader = glCreateShader(type);
+        glShaderSource(shader, 1, &src, nullptr);
+        glCompileShader(shader);
+        GLint ok = GL_FALSE;
+        glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
+        if (!ok) {
+            char log[1024];
+            glGetShaderInfoLog(shader, sizeof(log), nullptr, log);
+            std::cerr << "[Plugin:" << (label ? label : "?") << "] " << stage
+                      << " shader compile error: " << log << std::endl;
+        }
+        return shader;
+    };
+
+    GLuint vs = compile(GL_VERTEX_SHADER, vertexSrc, "vertex");
+    GLuint fs = compile(GL_FRAGMENT_SHADER, fragmentSrc, "fragment");
+
+    GLuint program = glCreateProgram();
+    glAttachShader(program, vs);
+    glAttachShader(program, fs);
+    glLinkProgram(program);
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+
+    GLint ok = GL_FALSE;
+    glGetProgramiv(program, GL_LINK_STATUS, &ok);
+    if (!ok) {
+        char log[1024];
+        glGetProgramInfoLog(program, sizeof(log), nullptr, log);
+        std::cerr << "[Plugin:" << (label ? label : "?") << "] program link error: "
+                  << log << std::endl;
+        glDeleteProgram(program);
+        return 0;
+    }
+    return program;
+}
+
+// ──────────────────────────── PluginManager ────────────────────────────────
+
+void PluginManager::loadRegisteredPlugins(PluginContext& ctx) {
+    for (PluginFactory& factory : pluginFactoryRegistry()) {
+        std::unique_ptr<Plugin> plugin = factory();
+        if (!plugin) continue;
+        plugin->onRegister(ctx);
+        m_all.push_back(plugin.get());
+        m_owned.push_back(std::move(plugin));
+    }
+}
+
+void PluginManager::registerExternal(Plugin* plugin, PluginContext& ctx) {
+    if (!plugin) return;
+    plugin->onRegister(ctx);
+    m_all.push_back(plugin);
+    // Already-initialised manager: bring the latecomer up to GL state too.
+    if (m_glInitialized) plugin->onInitializeGL(ctx);
+}
+
+void PluginManager::initializeAllGL(PluginContext& ctx) {
+    for (Plugin* p : m_all) p->onInitializeGL(ctx);
+    m_glInitialized = true;
+}
+
+void PluginManager::shutdownAllGL() {
+    for (Plugin* p : m_all) p->onShutdownGL();
+    m_glInitialized = false;
+}
+
+void PluginManager::update(PluginContext& ctx, float dt) {
+    for (Plugin* p : m_all) p->onUpdate(ctx, dt);
+}
+
+void PluginManager::renderViewport(PluginContext& ctx, const glm::mat4& projection,
+                                   const glm::mat4& view, const glm::vec3& cameraPos) {
+    for (Plugin* p : m_all) p->onRenderViewport(ctx, projection, view, cameraPos);
+}
+
+void PluginManager::renderUI(PluginContext& ctx) {
+    for (Plugin* p : m_all) p->onRenderUI(ctx);
+}
+
+void PluginManager::renderMenu(PluginContext& ctx) {
+    for (Plugin* p : m_all) p->onRenderMenu(ctx);
+}
+
+bool PluginManager::dispatchMouseButton(PluginContext& ctx, int button,
+                                        int action, int mods) {
+    for (Plugin* p : m_all)
+        if (p->onMouseButton(ctx, button, action, mods)) return true;
+    return false;
+}
+
+bool PluginManager::dispatchScroll(PluginContext& ctx, double xoffset, double yoffset) {
+    for (Plugin* p : m_all)
+        if (p->onScroll(ctx, xoffset, yoffset)) return true;
+    return false;
+}
+
+bool PluginManager::dispatchKey(PluginContext& ctx, int key, int scancode,
+                                int action, int mods) {
+    for (Plugin* p : m_all)
+        if (p->onKey(ctx, key, scancode, action, mods)) return true;
+    return false;
+}
+
+Plugin* PluginManager::find(const std::string& id) {
+    for (Plugin* p : m_all)
+        if (p->info().id == id) return p;
+    return nullptr;
+}
+
+} // namespace Plugins

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -36,6 +36,7 @@
 #include "Tools/MeasurementTool.h"
 #include "Tools/ClipPlaneTool.h"
 #include "Tools/TransformGizmo.h"
+#include "Plugins/PluginManager.h"
 
 // ---- OpenXR (Windows only; zero overhead when disabled) ----
 #ifdef _WIN32
@@ -392,6 +393,95 @@ int g_viewportHeight = 1080;
 // Last size the offscreen render targets were sized to, for change detection.
 static int g_lastViewportW = -1;
 static int g_lastViewportH = -1;
+
+// ── Plugin system ───────────────────────────────────────────────────────────
+// The PluginManager owns every plugin/tool and is driven from the handful of
+// integration points below (init, shutdown, per-eye render, ImGui pass, Tools
+// menu and the GLFW input callbacks). MainPluginContext is the concrete
+// services API handed to plugins: it simply forwards to the application globals
+// declared above, keeping the plugin layer decoupled from this translation
+// unit. Both g_pluginManager and g_pluginContext are referenced from GUI.cpp
+// (see the externs there).
+struct MainPluginContext : public Plugins::PluginContext {
+  Engine::Scene &scene() override { return currentScene; }
+  const Camera &camera() const override { return ::camera; }
+  glm::vec3 cameraPosition() const override { return ::camera.Position; }
+  GUI::ApplicationPreferences &preferences() override { return ::preferences; }
+  Engine::UndoManager &undo() override { return Engine::UndoManager::instance(); }
+
+  Plugins::PickRay mouseRay() const override {
+    Plugins::PickRay r;
+    glm::vec3 rayNear, rayFar;
+    calculateMouseRay(lastX, lastY, r.origin, r.direction, rayNear, rayFar,
+                      aspectRatio);
+    return r;
+  }
+  bool cursorWorldPos(glm::vec3 &out) const override {
+    if (!cursorManager.isCursorPositionValid())
+      return false;
+    out = cursorManager.getCursorPosition();
+    return true;
+  }
+  Plugins::RayHit raycastModels() const override {
+    Plugins::RayHit best;
+    const Plugins::PickRay ray = mouseRay();
+    float closest = FLT_MAX;
+    for (int i = 0; i < static_cast<int>(currentScene.models.size()); i++) {
+      float distance;
+      glm::vec3 normal;
+      if (rayIntersectsModel(ray.origin, ray.direction, currentScene.models[i],
+                             distance, normal) &&
+          distance < closest) {
+        closest = distance;
+        best.hit = true;
+        best.distance = distance;
+        best.position = ray.origin + ray.direction * distance;
+        best.normal = normal;
+        best.modelIndex = i;
+      }
+    }
+    return best;
+  }
+
+  glm::vec2 mousePos() const override {
+    return glm::vec2(static_cast<float>(lastX), static_cast<float>(lastY));
+  }
+  int keyMods() const override {
+    int mods = 0;
+    GLFWwindow *w = Engine::Window::nativeWindow;
+    if (!w)
+      return 0;
+    if (glfwGetKey(w, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS ||
+        glfwGetKey(w, GLFW_KEY_RIGHT_CONTROL) == GLFW_PRESS)
+      mods |= GLFW_MOD_CONTROL;
+    if (glfwGetKey(w, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS ||
+        glfwGetKey(w, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS)
+      mods |= GLFW_MOD_SHIFT;
+    if (glfwGetKey(w, GLFW_KEY_LEFT_ALT) == GLFW_PRESS ||
+        glfwGetKey(w, GLFW_KEY_RIGHT_ALT) == GLFW_PRESS)
+      mods |= GLFW_MOD_ALT;
+    return mods;
+  }
+  glm::vec2 viewportSize() const override {
+    return glm::vec2(static_cast<float>(g_viewportWidth),
+                     static_cast<float>(g_viewportHeight));
+  }
+
+  void toast(const std::string &message, Plugins::ToastLevel level) override {
+    GUI::ToastType type = GUI::ToastType::Info;
+    switch (level) {
+    case Plugins::ToastLevel::Success: type = GUI::ToastType::Success; break;
+    case Plugins::ToastLevel::Warning: type = GUI::ToastType::Warning; break;
+    case Plugins::ToastLevel::Error:   type = GUI::ToastType::Error;   break;
+    case Plugins::ToastLevel::Info:    type = GUI::ToastType::Info;    break;
+    }
+    GUI::ShowToast(message, type);
+  }
+};
+
+Plugins::PluginManager g_pluginManager;
+static MainPluginContext g_pluginContextImpl;
+Plugins::PluginContext &g_pluginContext = g_pluginContextImpl;
 
 // Map an OS cursor position (window pixels, top-left origin) to viewport NDC.
 static inline glm::vec2 WindowToViewportNDC(double mx, double my) {
@@ -3769,6 +3859,14 @@ int main() {
   glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
   glfwSwapInterval(preferences.vsyncEnabled ? 1 : 0);
 
+  // ---- Plugins ----
+  // Instantiate every statically-registered plugin (REGISTER_PLUGIN), bridge
+  // the legacy MeasurementTool onto the same pipeline, then create their GL
+  // resources now that a context exists. After this point new tools are driven
+  // entirely through g_pluginManager from the integration points below.
+  g_pluginManager.loadRegisteredPlugins(g_pluginContext);
+  g_pluginManager.initializeAllGL(g_pluginContext);
+
   // ---- Main Loop ----
   // Screenshot capture is deferred by one frame: when a request comes in we
   // arm a capture for the *next* frame. That way the captured back buffer never
@@ -3876,6 +3974,9 @@ int main() {
 
     // Keep the clip-plane tool bound to the current scene's plane storage.
     clipPlaneTool.setPlanes(&currentScene.clipPlanes);
+
+    // ---- Plugins: per-frame logic update ----
+    g_pluginManager.update(g_pluginContext, deltaTime);
 
     // ---- Transform Gizmo: bind target + process hover / constrained drag ----
     // Safety net: if the mouse-up landed over an ImGui panel (whose callback
@@ -4972,6 +5073,9 @@ void cleanup() {
 
   // Clean up cursor preview before GUI shutdown
   cursorPreview3D.cleanup();
+
+  // Clean up plugin GL resources while the context is still valid.
+  g_pluginManager.shutdownAllGL();
 
   // Clean up measurement tool GL resources while the context is still valid
   measurementTool.cleanup();
@@ -6447,17 +6551,12 @@ void renderEye(GLenum drawBuffer, const glm::mat4 &projection,
     cursorManager.renderCursors(projection, view);
   }
 
-  // Render measurement overlay (committed measurements always; rubber-band
-  // preview only while the tool is active and the cursor is on geometry)
-  {
-    glm::vec3 measurePreviewPos;
-    const glm::vec3 *measurePreview = nullptr;
-    if (measurementTool.isEnabled() && cursorManager.isCursorPositionValid()) {
-      measurePreviewPos = cursorManager.getCursorPosition();
-      measurePreview = &measurePreviewPos;
-    }
-    measurementTool.render(projection, view, measurePreview);
-  }
+  // Plugin world-space overlays (called once per eye with this eye's matrices).
+  // The migrated MeasurementTool draws its measurement overlay here via its
+  // MeasurementPlugin adapter; other plugins (e.g. the Crosshair example) draw
+  // alongside it.
+  g_pluginManager.renderViewport(g_pluginContext, projection, view,
+                                 camera.Position);
 
   // Render the transform gizmo overlay for the selected object (per eye).
   // Only shown while Ctrl is held (or while an in-progress drag keeps it alive).
@@ -7833,6 +7932,11 @@ void framebuffer_size_callback(GLFWwindow *window, int width, int height) {
 
 void scroll_callback(GLFWwindow *window, double xoffset, double yoffset) {
   if (!ImGui::GetIO().WantCaptureMouse && !spaceMouseActive) {
+    // Offer the scroll to plugins first; a plugin that consumes it stops the
+    // host's built-in scroll handling (clip-plane nudge, model depth, zoom).
+    if (g_pluginManager.dispatchScroll(g_pluginContext, xoffset, yoffset))
+      return;
+
     // Clip-plane scrubbing: while the tool is active with a selected plane,
     // scroll nudges the plane along its normal (mirrors model scroll-to-depth)
     // so the user can quickly slice through the model.
@@ -8151,6 +8255,12 @@ void mouse_button_callback(GLFWwindow *window, int button, int action,
     return;
   }
 
+  // Offer the event to plugins first; a plugin that consumes it (e.g. the
+  // MeasurementTool placing a point, or the Crosshair example dropping a
+  // marker) stops the host's built-in selection / navigation handling.
+  if (g_pluginManager.dispatchMouseButton(g_pluginContext, button, action, mods))
+    return;
+
   if (button == GLFW_MOUSE_BUTTON_LEFT) {
     if (action == GLFW_PRESS) {
       // Check if Ctrl or Alt is held down
@@ -8177,15 +8287,8 @@ void mouse_button_callback(GLFWwindow *window, int button, int action,
         }
       }
 
-      // Measurement tool: place a point at the 3D cursor position and consume
-      // the click (no orbiting/selection while measuring). Ctrl/Alt clicks
-      // still fall through to object selection.
-      if (!ctrlPressed && !altPressed && measurementTool.isEnabled()) {
-        if (cursorManager.isCursorPositionValid()) {
-          measurementTool.addPoint(cursorManager.getCursorPosition());
-        }
-        return;
-      }
+      // (Measurement-tool point placement is now handled by MeasurementPlugin
+      // via the plugin mouse-button dispatch at the top of this callback.)
 
       // Handle brush tool painting (when enabled and no modifiers pressed)
       if (!ctrlPressed && !altPressed &&
@@ -8735,12 +8838,8 @@ void mouse_button_callback(GLFWwindow *window, int button, int action,
     }
   } else if (button == GLFW_MOUSE_BUTTON_RIGHT) {
     if (action == GLFW_PRESS) {
-      // Measurement tool: right-click finishes the in-progress polyline
-      // instead of starting a camera rotation.
-      if (measurementTool.isEnabled() && measurementTool.hasActive()) {
-        measurementTool.finishActive();
-        return;
-      }
+      // (Measurement-tool right-click finish is now handled by MeasurementPlugin
+      // via the plugin mouse-button dispatch at the top of this callback.)
 
       rightMousePressed = true;
 
@@ -8882,23 +8981,13 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
     return; // Only handle PRESS actions below for other keys
   }
 
-  // Measurement tool editing keys (only while a measurement is in progress).
+  // Offer the (PRESS) key event to plugins. MeasurementPlugin consumes its
+  // editing keys (Enter finishes, Delete cancels, Backspace removes the last
+  // point) while a measurement is in progress.
   // Note: Escape can't be used to cancel — Input::handleKeyInput closes the
   // application on Escape.
-  if (measurementTool.isEnabled() && measurementTool.hasActive()) {
-    if (key == GLFW_KEY_ENTER || key == GLFW_KEY_KP_ENTER) {
-      measurementTool.finishActive();
-      return;
-    }
-    if (key == GLFW_KEY_DELETE) {
-      measurementTool.cancelActive();
-      return;
-    }
-    if (key == GLFW_KEY_BACKSPACE) {
-      measurementTool.undoLastPoint();
-      return;
-    }
-  }
+  if (g_pluginManager.dispatchKey(g_pluginContext, key, scancode, action, mods))
+    return;
 
   // Check if this key press matches any shortcut action. Translate the physical
   // key to its layout label first so letter/number shortcuts trigger on the key

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,0 +1,262 @@
+# StereoVista Plugin System
+
+StereoVista's interactive tools are built on a lightweight, **compile-time
+plugin framework**. A plugin is a self-contained C++ class that opts in to the
+host hooks it needs and registers itself with one macro. Adding a new tool is a
+local change — **one header + one source file + one `REGISTER_PLUGIN` line** —
+with no edits to `main.cpp` or `GUI.cpp` (the only project-wide step is listing
+the two files in the Visual Studio project).
+
+> **Loading model:** plugins are statically compiled into the executable (no
+> DLLs). This gives them safe, direct access to the shared OpenGL context, the
+> ImGui context and the scene state — none of which survive a DLL boundary
+> cleanly on MSVC.
+
+---
+
+## 1. Architecture at a glance
+
+```
+                       ┌──────────────────────────────┐
+   main.cpp  ────────▶ │        PluginManager         │ owns/borrows plugins
+   (integration        │  init / render / UI / menu / │ and fans every host
+    points)            │  input dispatch              │ call out to them
+                       └──────────────┬───────────────┘
+                                      │ passes a
+                                      ▼
+                       ┌──────────────────────────────┐
+                       │        PluginContext         │ services API:
+                       │  scene / camera / picking /  │ implemented in main.cpp
+                       │  preferences / undo / toast  │ over the app globals
+                       │  / compileOverlayProgram     │
+                       └──────────────┬───────────────┘
+                                      │ handed to every hook
+                                      ▼
+                       ┌──────────────────────────────┐
+   REGISTER_PLUGIN ──▶ │           Plugin             │ your tool: override
+   (self-register)     │  info() + lifecycle/render/  │ the hooks you need
+                       │  ui/menu/input hooks         │
+                       └──────────────────────────────┘
+```
+
+| File | Role |
+|---|---|
+| `headers/Plugins/Plugin.h` | Abstract `Plugin` base + `PluginInfo`. All hooks have no-op defaults. |
+| `headers/Plugins/PluginContext.h` | The services API handed to every hook. Concrete impl is in `main.cpp`. |
+| `headers/Plugins/PluginRegistry.h` | `REGISTER_PLUGIN(Type)` macro + the static factory registry. |
+| `headers/Plugins/PluginManager.h` | Owns plugins; the host calls into it at the integration points. |
+| `src/Plugins/PluginManager.cpp` | Manager + registry + `compileOverlayProgram` + default menu entry. |
+| `headers/Plugins/Examples/CrosshairPlugin.*` | **Copy-me** example exercising the whole API. |
+| `headers/Plugins/MeasurementPlugin.*` | Worked migration of the existing MeasurementTool (adapter pattern). |
+
+---
+
+## 2. Plugin lifecycle
+
+Hooks fire in this order; **every one is optional** except `info()`.
+
+```
+onRegister(ctx)            once, when added to the manager (no GL work yet)
+onInitializeGL(ctx)        once, GL context valid — create VAOs/shaders here
+   ── per frame ──
+onUpdate(ctx, dt)          once per frame, before rendering
+onRenderViewport(ctx, …)   ONCE PER EYE, with that eye's projection/view
+onRenderUI(ctx)            once per frame (ImGui pass) — draw your windows
+onRenderMenu(ctx)          once per frame, inside the Tools menu
+   ── on input ──
+onMouseButton/onScroll/onKey(ctx, …)   return true to CONSUME the event
+   ── enable toggling ──
+onEnable() / onDisable()   on an actual isEnabled() transition
+   ── shutdown ──
+onShutdownGL()             once at exit, GL context still valid — free resources
+```
+
+`onRenderViewport` is called **twice per frame** (once per stereo eye). Keep it
+stateless with respect to the matrices passed in.
+
+---
+
+## 3. The `PluginContext` API
+
+Every hook receives a `Plugins::PluginContext&`. Highlights:
+
+```cpp
+// Scene & core services
+Engine::Scene&               scene();
+const Camera&                camera();
+glm::vec3                    cameraPosition();
+GUI::ApplicationPreferences& preferences();
+Engine::UndoManager&         undo();
+
+// Picking / 3D cursor
+PickRay  mouseRay();                 // world-space ray under the OS cursor
+bool     cursorWorldPos(glm::vec3&); // synchronized 3D cursor (false if invalid)
+RayHit   raycastModels();            // nearest model hit along mouseRay()
+
+// Input / viewport
+glm::vec2 mousePos();                // window pixels
+int       keyMods();                 // current GLFW_MOD_* bitmask
+glm::vec2 viewportSize();            // 3D viewport, pixels
+
+// Feedback
+void toast(const std::string&, ToastLevel = ToastLevel::Info);
+
+// GL convenience — compile+link a tiny overlay program (0 on failure)
+GLuint compileOverlayProgram(const char* vs, const char* fs, const char* label);
+```
+
+---
+
+## 4. Add a new tool in 3 steps
+
+**Step 1 — Header** (`headers/Plugins/Examples/MyToolPlugin.h`):
+
+```cpp
+#pragma once
+#include "Plugins/Plugin.h"
+namespace Plugins {
+class MyToolPlugin : public Plugin {
+public:
+    PluginInfo info() const override;
+    void onRenderUI(PluginContext& ctx) override;
+    // …override only the hooks you need…
+};
+}
+```
+
+**Step 2 — Source** (`src/Plugins/Examples/MyToolPlugin.cpp`):
+
+```cpp
+#include "Plugins/Examples/MyToolPlugin.h"
+#include "Plugins/PluginRegistry.h"
+#include "imgui/imgui.h"
+
+namespace Plugins {
+PluginInfo MyToolPlugin::info() const {
+    PluginInfo m;
+    m.id = "stereovista.mytool";
+    m.name = "My Tool";
+    m.description = "Does a useful thing.";
+    return m;
+}
+void MyToolPlugin::onRenderUI(PluginContext& ctx) {
+    if (!windowOpen()) return;            // toggled by the default menu entry
+    if (ImGui::Begin(info().name.c_str(), &windowOpen())) {
+        if (ImGui::Button("Hi")) ctx.toast("Hello!", ToastLevel::Success);
+    }
+    ImGui::End();
+}
+}
+REGISTER_PLUGIN(Plugins::MyToolPlugin);   // ← self-registration
+```
+
+**Step 3 — Project file.** Add the two files to `StereoVista/StereoVista.vcxproj`
+(a `<ClCompile>` and a `<ClInclude>` item) and to `…vcxproj.filters`. MSBuild
+only compiles files listed in the project; this is the **one** non-local step.
+
+Rebuild — "My Tool" now appears in the **Tools** menu, with its window, automatically.
+
+> The default `onRenderMenu` adds a checkbox menu item bound to `windowOpen()`.
+> Override `onRenderMenu` for a custom submenu.
+
+---
+
+## 5. Input & event consumption
+
+- The host queries plugins **before** its own built-in handling in the GLFW
+  mouse-button, scroll and key callbacks.
+- The **first** plugin whose hook returns `true` consumes the event; the host
+  then early-outs and skips selection / navigation / shortcuts.
+- Return `false` for events you don't handle so they propagate normally.
+- Key events are dispatched on **`GLFW_PRESS`** (matching where the dispatch is
+  wired in `key_callback`). Mouse-button and scroll events are dispatched for
+  all actions; filter on `action` inside your hook.
+- Respect modifiers: by convention Ctrl/Alt clicks are reserved for the
+  gizmo / object selection, so bail out (`return false`) when those are held
+  unless your tool specifically wants them.
+
+---
+
+## 6. Rendering notes
+
+- World-space overlays go in `onRenderViewport` and must **not write depth**
+  (`glDepthMask(GL_FALSE)`), because the 3D-cursor system samples scene depth
+  from the same buffer. Save/restore any GL state you change.
+- Build self-contained shaders with `ctx.compileOverlayProgram(...)` instead of
+  duplicating the `glCreateShader`/link boilerplate. Free the program (and your
+  VAOs/VBOs) in `onShutdownGL`.
+- All GL hooks run on the render thread with a current context. Don't touch GL
+  from `onRegister` (no context guaranteed yet).
+
+---
+
+## 7. Migrating an existing tool (worked example)
+
+`MeasurementPlugin` (`headers/Plugins/MeasurementPlugin.*`) shows the
+recommended **adapter** pattern: rather than rewriting `Tools::MeasurementTool`,
+it wraps the existing global instance and forwards the Plugin hooks to it.
+
+- The tool's editable data already lives in `Engine::Scene::measurements`, so
+  scene save/load and `SnapshotManager` are untouched by the migration.
+- `main.cpp` keeps the `measurementTool` global; the adapter references it via
+  `extern`. The adapter self-registers with `REGISTER_PLUGIN`, so it joins the
+  pipeline like any other plugin.
+- All of the tool's former hand-wired call sites — the per-eye render, the Tools
+  menu item, the ImGui window dispatch, and the left/right-click + Enter/Delete/
+  Backspace input handling — were removed from `main.cpp`/`GUI.cpp` and now flow
+  through the manager via the adapter's hooks.
+
+Use the same approach to migrate `BrushTool`, `ClipPlaneTool`, etc.: create a
+`*Plugin` adapter, `REGISTER_PLUGIN` it, route its render/UI/menu/input through
+the hooks, and delete the now-duplicated direct call sites.
+
+---
+
+## 8. Host integration points (for reference)
+
+The manager is driven from these spots in `main.cpp` / `GUI.cpp`:
+
+| Where | Call |
+|---|---|
+| After GL init, before the main loop (`main.cpp`) | `loadRegisteredPlugins`, `initializeAllGL` |
+| Per frame (`main.cpp` loop) | `update` |
+| Per eye, in `renderEye` (`main.cpp`) | `renderViewport` |
+| GLFW callbacks (`main.cpp`) | `dispatchMouseButton` / `dispatchScroll` / `dispatchKey` |
+| Tools menu (`GUI.cpp`) | `renderMenu` |
+| ImGui window pass (`GUI.cpp`) | `renderUI` |
+| At shutdown (`main.cpp`) | `shutdownAllGL` |
+
+`g_pluginManager` and `g_pluginContext` are globals in `main.cpp` (the context
+is a `MainPluginContext` forwarding to the app globals), `extern`-declared where
+GUI.cpp needs them.
+
+---
+
+## 9. Build & manual test checklist
+
+There is no automated test suite (Windows/MSVC, visual verification).
+
+1. Build `Release | x64`; confirm the new `Plugins\*` files compile and link.
+2. Launch the app → **Tools** menu lists **"Crosshair (Example)"** and
+   **"Measure"** below the built-in tool entries.
+3. **Crosshair:** open it, tick *Enabled*; a crosshair tracks the 3D cursor.
+   Left-click drops a marker (+ "Marker dropped" toast). Color/size sliders
+   update live. *Clear markers* empties the list.
+4. **Measurement (regression):** place points (left-click), finish (right-click
+   / Enter), undo a point (Backspace), cancel (Delete); labels, CSV export,
+   scene save+reload, and undo/redo snapshots all behave as before.
+5. Confirm **Brush**, **Section Planes** and the **transform gizmo** are
+   unaffected (Ctrl/Alt interactions still work).
+
+---
+
+## 10. Notes & future work
+
+- **MSVC self-registration:** the app is one executable, so plugin object files
+  are always linked and their `REGISTER_PLUGIN` initializers run. If the plugins
+  are ever moved into a separate static library, use `/WHOLEARCHIVE` (or an
+  explicit symbol reference) so the registrars aren't stripped.
+- Reserved but not yet wired: per-plugin JSON persistence hooks
+  (`onSceneSave`/`onSceneLoad`) — today plugins persist via the scene itself.
+- Dynamic DLL hot-loading is intentionally **not** supported (see the loading
+  model note at the top).


### PR DESCRIPTION
Introduce a compile-time plugin system so new tools can be added by
dropping in one header + one source file + a REGISTER_PLUGIN line, with
commonly-needed host functionality exposed through a single services API.

Framework (headers/Plugins, src/Plugins):
- Plugin: abstract base with no-op-default lifecycle/render/UI/menu/input
  hooks; only info() is mandatory.
- PluginContext: services API (scene, camera, picking/3D-cursor,
  preferences, undo, toasts, compileOverlayProgram GL helper); concrete
  impl (MainPluginContext) lives in main.cpp over the existing globals.
- PluginRegistry: REGISTER_PLUGIN self-registration via a static factory list.
- PluginManager: owns plugins, drives every host integration point and
  consume-aware input dispatch.

Integration: g_pluginManager/g_pluginContext wired into main.cpp
(load/init, per-frame update, per-eye renderViewport, GLFW mouse/scroll/key
dispatch, shutdown) and GUI.cpp (Tools menu + ImGui window pass).

Examples & migration:
- CrosshairPlugin: fully-commented copy-me template exercising the whole API.
- MeasurementPlugin: adapter migrating the existing MeasurementTool onto the
  system (render/UI/menu/input now flow through the manager); its scene data
  and SnapshotManager behaviour are unchanged.

Docs: docs/PLUGINS.md (architecture, API reference, add-a-tool guide,
migration guide, test checklist) + CLAUDE.md plugin section. New files added
to the .vcxproj/.filters.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YK35Na6MjpdN57JH8rXSmX