### PR TITLE
Improve 3D cursor preview for all cursor types

### DIFF
--- a/StereoVista/headers/Gui/CursorPreview3D.h
+++ b/StereoVista/headers/Gui/CursorPreview3D.h
@@ -11,9 +11,17 @@ namespace Engine {
 
 namespace Cursor {
     class BaseCursor;
+    class SphereCursor;
+    class FragmentCursor;
+    class PlaneCursor;
 }
 
 namespace GUI {
+    // Renders a small, self-contained 3D preview of the active cursor sitting on
+    // a lit reference cube. The preview is independent of the main scene: it owns
+    // its own framebuffer (multisampled for smooth edges), geometry and shaders,
+    // so it faithfully reproduces every cursor type and every appearance value
+    // without disturbing the live render state.
     class CursorPreview3D {
     public:
         CursorPreview3D();
@@ -31,48 +39,49 @@ namespace GUI {
         void updateRotation(float deltaX, float deltaY);
 
     private:
+        // Setup helpers
         void generateCubeGeometry();
         void generateSphereGeometry();
-        void generatePlaneGeometry();
+        void generateQuadGeometry();
         void setupFramebuffer();
-        void renderCube();
-        void renderFallbackReference();
         void setupCamera();
-        void renderPreviewSphere(const glm::vec4& color, float radius, bool showInner, const glm::vec4& innerColor, float innerFactor, const glm::vec3& position, float transparency, float edgeSoftness, float centerTransparency);
-        void renderPreviewFragmentCursor(float radius, const glm::vec4& color, const glm::vec3& position);
-        void renderPreviewPlaneCursor(float diameter, const glm::vec4& color, const glm::vec3& position);
+        bool compileShaders();
 
-        // OpenGL objects
-        GLuint m_framebuffer;
+        // Per-frame drawing
+        void drawBackground();
+        void drawReferenceCube(const glm::mat4& modelRotation);
+        void drawSphereCursor(Cursor::SphereCursor* cursor, const glm::mat4& modelRotation);
+        void drawFragmentCursor(Cursor::FragmentCursor* cursor);
+        void drawPlaneCursor(Cursor::PlaneCursor* cursor);
+
+        // Framebuffer (multisampled -> resolved color texture for ImGui)
+        GLuint m_msaaFBO;
+        GLuint m_msaaColorRBO;
+        GLuint m_msaaDepthRBO;
+        GLuint m_resolveFBO;
         GLuint m_colorTexture;
-        GLuint m_depthTexture;
+        int m_samples;
+
+        // Geometry
         GLuint m_cubeVAO, m_cubeVBO, m_cubeEBO;
         GLuint m_sphereVAO, m_sphereVBO, m_sphereEBO;
-        GLuint m_planeVAO, m_planeVBO, m_planeEBO;
+        GLuint m_quadVAO, m_quadVBO;
+        GLsizei m_cubeIndexCount;
+        GLsizei m_sphereIndexCount;
 
-        // Cube geometry
-        std::vector<float> m_cubeVertices;
-        std::vector<unsigned int> m_cubeIndices;
-
-        // Sphere geometry
-        std::vector<float> m_sphereVertices;
-        std::vector<unsigned int> m_sphereIndices;
-
-        // Plane geometry
-        std::vector<float> m_planeVertices;
-        std::vector<unsigned int> m_planeIndices;
-
-        // Rendering properties
+        // View / interaction
         int m_width, m_height;
         float m_rotationX, m_rotationY;
+        glm::vec3 m_cameraPosition;
         glm::mat4 m_projectionMatrix;
         glm::mat4 m_viewMatrix;
-        glm::vec3 m_cameraPosition;
 
-        // Shaders
-        Engine::Shader* m_cubeShader;
-        Engine::Shader* m_sphereShader;
-        Engine::Shader* m_planeShader;
+        // Shaders (owned; compiled from embedded source)
+        Engine::Shader* m_litShader;      // reference cube
+        Engine::Shader* m_sphereShader;   // sphere cursor
+        Engine::Shader* m_discShader;     // plane cursor (camera-facing disc)
+        Engine::Shader* m_ringShader;     // fragment cursor (concentric rings)
+        Engine::Shader* m_gradientShader; // background
 
         bool m_initialized;
     };

--- a/StereoVista/src/Gui/CursorPreview3D.cpp
+++ b/StereoVista/src/Gui/CursorPreview3D.cpp
@@ -4,8 +4,11 @@
 #include "Cursors/Types/SphereCursor.h"
 #include "Cursors/Types/FragmentCursor.h"
 #include "Cursors/Types/PlaneCursor.h"
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/type_ptr.hpp>
+#include <algorithm>
+#include <cmath>
 #include <iostream>
-#include <corecrt_math_defines.h>
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -13,27 +16,234 @@
 
 namespace GUI {
 
+// ───────────────────────────── embedded shaders ─────────────────────────────
+namespace {
+
+// Background gradient (full-screen, drawn directly in NDC).
+const char* kGradientVS = R"(#version 330 core
+layout(location = 0) in vec2 aPos;
+out vec2 vUv;
+void main() {
+    vUv = aPos * 0.5 + 0.5;
+    gl_Position = vec4(aPos, 0.0, 1.0);
+})";
+
+const char* kGradientFS = R"(#version 330 core
+in vec2 vUv;
+out vec4 FragColor;
+uniform vec3 uTop;
+uniform vec3 uBottom;
+void main() {
+    vec3 c = mix(uBottom, uTop, vUv.y);
+    // gentle radial vignette so the cube reads against the backdrop
+    float d = distance(vUv, vec2(0.5));
+    c *= 1.0 - smoothstep(0.45, 0.95, d) * 0.35;
+    FragColor = vec4(c, 1.0);
+})";
+
+// Lit reference cube (simple two-light Phong with a fresnel rim).
+const char* kLitVS = R"(#version 330 core
+layout(location = 0) in vec3 aPos;
+layout(location = 1) in vec3 aNormal;
+out vec3 vWorldPos;
+out vec3 vNormal;
+uniform mat4 model;
+uniform mat4 view;
+uniform mat4 projection;
+uniform mat3 normalMatrix;
+void main() {
+    vec4 wp = model * vec4(aPos, 1.0);
+    vWorldPos = wp.xyz;
+    vNormal = normalMatrix * aNormal;
+    gl_Position = projection * view * wp;
+})";
+
+const char* kLitFS = R"(#version 330 core
+in vec3 vWorldPos;
+in vec3 vNormal;
+out vec4 FragColor;
+uniform vec3 uViewPos;
+uniform vec3 uBaseColor;
+void main() {
+    vec3 N = normalize(vNormal);
+    vec3 V = normalize(uViewPos - vWorldPos);
+    vec3 L1 = normalize(vec3(0.6, 0.85, 0.55));
+    vec3 L2 = normalize(vec3(-0.55, 0.25, 0.45));
+    float d1 = max(dot(N, L1), 0.0);
+    float d2 = max(dot(N, L2), 0.0) * 0.4;
+    vec3 H = normalize(L1 + V);
+    float spec = pow(max(dot(N, H), 0.0), 48.0) * 0.25;
+    float fres = pow(1.0 - max(dot(N, V), 0.0), 3.0) * 0.22;
+    vec3 color = uBaseColor * (0.28 + d1 + d2) + vec3(spec) + vec3(fres);
+    FragColor = vec4(color, 1.0);
+})";
+
+// Sphere cursor — identical maths to assets/shaders/cursors/sphere*.glsl so the
+// preview matches the in-scene cursor exactly.
+const char* kSphereVS = R"(#version 330 core
+layout(location = 0) in vec3 aPos;
+layout(location = 1) in vec3 aNormal;
+out vec3 Normal;
+out vec3 FragPos;
+out vec3 ModelPos;
+uniform mat4 model;
+uniform mat4 view;
+uniform mat4 projection;
+void main() {
+    ModelPos = aPos;
+    FragPos = vec3(model * vec4(aPos, 1.0));
+    Normal = mat3(transpose(inverse(model))) * aNormal;
+    gl_Position = projection * view * model * vec4(aPos, 1.0);
+})";
+
+const char* kSphereFS = R"(#version 330 core
+out vec4 FragColor;
+in vec3 Normal;
+in vec3 FragPos;
+in vec3 ModelPos;
+uniform vec3 viewPos;
+uniform vec4 sphereColor;
+uniform float transparency;
+uniform float centerTransparencyFactor;
+uniform float edgeSoftness;
+uniform bool isInnerSphere;
+uniform float innerSphereFactor;
+void main() {
+    vec3 norm = normalize(Normal);
+    vec3 viewDir = normalize(viewPos - FragPos);
+    float distFromCenter = length(ModelPos);
+    float radius = isInnerSphere ? innerSphereFactor : 1.0;
+    vec3 finalColor = sphereColor.rgb;
+    float alpha = sphereColor.a * transparency;
+    if (!isInnerSphere) {
+        float edgeFactor = pow(1.0 - abs(dot(viewDir, norm)), edgeSoftness);
+        float centerFactor = smoothstep(0.0, 1.0, distFromCenter / radius);
+        float centerAlpha = mix(centerTransparencyFactor, 1.0, centerFactor);
+        alpha *= mix(centerAlpha, 1.0, edgeFactor);
+    }
+    float rimFactor = 1.0 - max(0.0, dot(viewDir, norm));
+    finalColor += sphereColor.rgb * pow(rimFactor, 3.0) * 0.3;
+    FragColor = vec4(finalColor, alpha);
+})";
+
+// Camera-facing billboard used by both the plane disc and the fragment rings.
+const char* kBillboardVS = R"(#version 330 core
+layout(location = 0) in vec2 aPos;
+out vec2 vUv;
+uniform mat4 model;
+uniform mat4 view;
+uniform mat4 projection;
+void main() {
+    vUv = aPos;
+    gl_Position = projection * view * model * vec4(aPos, 0.0, 1.0);
+})";
+
+// Plane cursor — a filled, soft-edged disc with a brighter rim. Output is
+// premultiplied alpha (blend func GL_ONE, GL_ONE_MINUS_SRC_ALPHA).
+const char* kDiscFS = R"(#version 330 core
+in vec2 vUv;
+out vec4 FragColor;
+uniform vec4 uColor;
+void main() {
+    float r = length(vUv);
+    float aa = max(fwidth(r), 1e-4);
+    float disc = 1.0 - smoothstep(1.0 - aa * 1.5, 1.0, r);
+    if (disc <= 0.001) discard;
+    float rim = smoothstep(0.80, 0.96, r) * (1.0 - smoothstep(0.985, 1.0, r));
+    vec3 rgb = uColor.rgb + rim * 0.55;
+    float a = uColor.a * disc;
+    FragColor = vec4(rgb * a, a);
+})";
+
+// Fragment cursor — two concentric rings (outer ring + inner dot/ring) matching
+// the in-scene screen-space cursor. Output is premultiplied alpha.
+const char* kRingFS = R"(#version 330 core
+in vec2 vUv;
+out vec4 FragColor;
+uniform float uOuterR;
+uniform float uOuterT;
+uniform float uInnerR;
+uniform float uInnerT;
+uniform vec4 uOuterColor;
+uniform vec4 uInnerColor;
+float band(float r, float outer, float thick, float aa) {
+    float t = max(thick, aa);            // keep a hairline visible at thickness 0
+    float lo = outer - t;
+    return smoothstep(lo - aa, lo, r) - smoothstep(outer - aa, outer, r);
+}
+void main() {
+    float r = length(vUv);
+    float aa = max(fwidth(r), 1e-4);
+    float ob = clamp(band(r, uOuterR, uOuterT, aa), 0.0, 1.0);
+    float ib = clamp(band(r, uInnerR, uInnerT, aa), 0.0, 1.0);
+    float oa = ob * uOuterColor.a;
+    float ia = ib * uInnerColor.a;
+    // composite inner under outer (premultiplied "over")
+    vec3 rgb = uInnerColor.rgb * ia;
+    float a = ia;
+    rgb = uOuterColor.rgb * oa + rgb * (1.0 - oa);
+    a = oa + a * (1.0 - oa);
+    if (a <= 0.001) discard;
+    FragColor = vec4(rgb, a);
+})";
+
+GLuint compileStage(GLenum type, const char* src, const char* label) {
+    GLuint shader = glCreateShader(type);
+    glShaderSource(shader, 1, &src, nullptr);
+    glCompileShader(shader);
+    GLint ok = GL_FALSE;
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
+    if (!ok) {
+        char log[1024];
+        glGetShaderInfoLog(shader, sizeof(log), nullptr, log);
+        std::cerr << "[CursorPreview3D] " << label << " compile error: " << log << std::endl;
+    }
+    return shader;
+}
+
+// Compiles a vertex+fragment program from source and wraps it in an
+// Engine::Shader (which owns/destroys the GL program). Returns nullptr on error.
+Engine::Shader* buildProgram(const char* vs, const char* fs, const char* label) {
+    GLuint v = compileStage(GL_VERTEX_SHADER, vs, label);
+    GLuint f = compileStage(GL_FRAGMENT_SHADER, fs, label);
+    GLuint program = glCreateProgram();
+    glAttachShader(program, v);
+    glAttachShader(program, f);
+    glLinkProgram(program);
+    glDeleteShader(v);
+    glDeleteShader(f);
+    GLint ok = GL_FALSE;
+    glGetProgramiv(program, GL_LINK_STATUS, &ok);
+    if (!ok) {
+        char log[1024];
+        glGetProgramInfoLog(program, sizeof(log), nullptr, log);
+        std::cerr << "[CursorPreview3D] " << label << " link error: " << log << std::endl;
+        glDeleteProgram(program);
+        return nullptr;
+    }
+    return new Engine::Shader(program);
+}
+
+// Reference-cube placement.
+constexpr float kCubeScale = 1.0f;            // edge length in world units
+constexpr float kCubeHalf = kCubeScale * 0.5f; // half extent
+
+} // namespace
+
+// ───────────────────────────── lifecycle ────────────────────────────────────
+
 CursorPreview3D::CursorPreview3D() :
-    m_framebuffer(0),
-    m_colorTexture(0),
-    m_depthTexture(0),
-    m_cubeVAO(0),
-    m_cubeVBO(0),
-    m_cubeEBO(0),
-    m_sphereVAO(0),
-    m_sphereVBO(0),
-    m_sphereEBO(0),
-    m_planeVAO(0),
-    m_planeVBO(0),
-    m_planeEBO(0),
-    m_width(256),
-    m_height(256),
-    m_rotationX(20.0f),
-    m_rotationY(45.0f),
-    m_cameraPosition(0.0f, 0.0f, 3.0f),
-    m_cubeShader(nullptr),
-    m_sphereShader(nullptr),
-    m_planeShader(nullptr),
+    m_msaaFBO(0), m_msaaColorRBO(0), m_msaaDepthRBO(0),
+    m_resolveFBO(0), m_colorTexture(0), m_samples(4),
+    m_cubeVAO(0), m_cubeVBO(0), m_cubeEBO(0),
+    m_sphereVAO(0), m_sphereVBO(0), m_sphereEBO(0),
+    m_quadVAO(0), m_quadVBO(0),
+    m_cubeIndexCount(0), m_sphereIndexCount(0),
+    m_width(256), m_height(256),
+    m_rotationX(22.0f), m_rotationY(38.0f),
+    m_cameraPosition(0.0f, 0.0f, 3.6f),
+    m_litShader(nullptr), m_sphereShader(nullptr),
+    m_discShader(nullptr), m_ringShader(nullptr), m_gradientShader(nullptr),
     m_initialized(false)
 {
 }
@@ -52,739 +262,448 @@ void CursorPreview3D::initialize(int width, int height) {
 
     generateCubeGeometry();
     generateSphereGeometry();
-    generatePlaneGeometry();
+    generateQuadGeometry();
     setupFramebuffer();
     setupCamera();
 
-    // Load cube shader (using a simple basic shader for the cube)
-    try {
-        m_cubeShader = Engine::loadShader(
-            "assets/shaders/core/vertexShader.glsl",
-            "assets/shaders/core/fragmentShader.glsl"
-        );
-    } catch (const std::exception& e) {
-        std::cerr << "Failed to load cube shader: " << e.what() << std::endl;
-        m_cubeShader = nullptr;
+    m_initialized = compileShaders();
+    if (!m_initialized) {
+        std::cerr << "[CursorPreview3D] shader setup failed; preview disabled." << std::endl;
     }
-
-    // Load sphere shader (using the cursor sphere shader)
-    try {
-        m_sphereShader = Engine::loadShader(
-            "assets/shaders/cursors/sphereVertexShader.glsl",
-            "assets/shaders/cursors/sphereFragmentShader.glsl"
-        );
-    } catch (const std::exception& e) {
-        std::cerr << "Failed to load sphere shader: " << e.what() << std::endl;
-        m_sphereShader = nullptr;
-    }
-
-    // Load plane cursor shader
-    try {
-        m_planeShader = Engine::loadShader(
-            "assets/shaders/cursors/planeCursorVertexShader.glsl",
-            "assets/shaders/cursors/planeCursorFragmentShader.glsl"
-        );
-    } catch (const std::exception& e) {
-        std::cerr << "Failed to load plane cursor shader: " << e.what() << std::endl;
-        m_planeShader = nullptr;
-    }
-
-    m_initialized = true;
 }
 
+bool CursorPreview3D::compileShaders() {
+    m_gradientShader = buildProgram(kGradientVS, kGradientFS, "gradient");
+    m_litShader      = buildProgram(kLitVS, kLitFS, "lit-cube");
+    m_sphereShader   = buildProgram(kSphereVS, kSphereFS, "sphere-cursor");
+    m_discShader     = buildProgram(kBillboardVS, kDiscFS, "plane-cursor");
+    m_ringShader     = buildProgram(kBillboardVS, kRingFS, "fragment-cursor");
+
+    return m_gradientShader && m_litShader && m_sphereShader &&
+           m_discShader && m_ringShader;
+}
+
+// ───────────────────────────── geometry ─────────────────────────────────────
+
 void CursorPreview3D::generateCubeGeometry() {
-    // Use the same cube geometry as the project's createCube function
-    // Each vertex has position (3 floats), normal (3 floats), texcoord (2 floats) = 8 floats per vertex
-    m_cubeVertices = {
-        // Front face
-        -0.5f, -0.5f,  0.5f,  0.0f, 0.0f, 1.0f,  0.0f, 0.0f,  // Bottom-left
-         0.5f, -0.5f,  0.5f,  0.0f, 0.0f, 1.0f,  1.0f, 0.0f,  // Bottom-right
-         0.5f,  0.5f,  0.5f,  0.0f, 0.0f, 1.0f,  1.0f, 1.0f,  // Top-right
-        -0.5f,  0.5f,  0.5f,  0.0f, 0.0f, 1.0f,  0.0f, 1.0f,  // Top-left
-
-        // Back face
-        -0.5f, -0.5f, -0.5f,  0.0f, 0.0f, -1.0f, 1.0f, 0.0f,  // Bottom-left
-        -0.5f,  0.5f, -0.5f,  0.0f, 0.0f, -1.0f, 1.0f, 1.0f,  // Top-left
-         0.5f,  0.5f, -0.5f,  0.0f, 0.0f, -1.0f, 0.0f, 1.0f,  // Top-right
-         0.5f, -0.5f, -0.5f,  0.0f, 0.0f, -1.0f, 0.0f, 0.0f,  // Bottom-right
-
-        // Top face
-        -0.5f,  0.5f, -0.5f,  0.0f, 1.0f, 0.0f,  0.0f, 0.0f,  // Back-left
-        -0.5f,  0.5f,  0.5f,  0.0f, 1.0f, 0.0f,  0.0f, 1.0f,  // Front-left
-         0.5f,  0.5f,  0.5f,  0.0f, 1.0f, 0.0f,  1.0f, 1.0f,  // Front-right
-         0.5f,  0.5f, -0.5f,  0.0f, 1.0f, 0.0f,  1.0f, 0.0f,  // Back-right
-
-        // Bottom face
-        -0.5f, -0.5f, -0.5f,  0.0f, -1.0f, 0.0f, 0.0f, 1.0f,  // Back-left
-         0.5f, -0.5f, -0.5f,  0.0f, -1.0f, 0.0f, 1.0f, 1.0f,  // Back-right
-         0.5f, -0.5f,  0.5f,  0.0f, -1.0f, 0.0f, 1.0f, 0.0f,  // Front-right
-        -0.5f, -0.5f,  0.5f,  0.0f, -1.0f, 0.0f, 0.0f, 0.0f,  // Front-left
-
-        // Right face
-         0.5f, -0.5f, -0.5f,  1.0f, 0.0f, 0.0f,  0.0f, 0.0f,  // Bottom-back
-         0.5f,  0.5f, -0.5f,  1.0f, 0.0f, 0.0f,  0.0f, 1.0f,  // Top-back
-         0.5f,  0.5f,  0.5f,  1.0f, 0.0f, 0.0f,  1.0f, 1.0f,  // Top-front
-         0.5f, -0.5f,  0.5f,  1.0f, 0.0f, 0.0f,  1.0f, 0.0f,  // Bottom-front
-
-        // Left face
-        -0.5f, -0.5f, -0.5f,  -1.0f, 0.0f, 0.0f, 1.0f, 0.0f,  // Bottom-back
-        -0.5f, -0.5f,  0.5f,  -1.0f, 0.0f, 0.0f, 0.0f, 0.0f,  // Bottom-front
-        -0.5f,  0.5f,  0.5f,  -1.0f, 0.0f, 0.0f, 0.0f, 1.0f,  // Top-front
-        -0.5f,  0.5f, -0.5f,  -1.0f, 0.0f, 0.0f, 1.0f, 1.0f   // Top-back
+    // Position (3) + normal (3) per vertex, one set of 4 verts per face.
+    const float v[] = {
+        // Front (+Z)
+        -0.5f, -0.5f,  0.5f,  0, 0, 1,   0.5f, -0.5f,  0.5f,  0, 0, 1,
+         0.5f,  0.5f,  0.5f,  0, 0, 1,  -0.5f,  0.5f,  0.5f,  0, 0, 1,
+        // Back (-Z)
+         0.5f, -0.5f, -0.5f,  0, 0,-1,  -0.5f, -0.5f, -0.5f,  0, 0,-1,
+        -0.5f,  0.5f, -0.5f,  0, 0,-1,   0.5f,  0.5f, -0.5f,  0, 0,-1,
+        // Top (+Y)
+        -0.5f,  0.5f,  0.5f,  0, 1, 0,   0.5f,  0.5f,  0.5f,  0, 1, 0,
+         0.5f,  0.5f, -0.5f,  0, 1, 0,  -0.5f,  0.5f, -0.5f,  0, 1, 0,
+        // Bottom (-Y)
+        -0.5f, -0.5f, -0.5f,  0,-1, 0,   0.5f, -0.5f, -0.5f,  0,-1, 0,
+         0.5f, -0.5f,  0.5f,  0,-1, 0,  -0.5f, -0.5f,  0.5f,  0,-1, 0,
+        // Right (+X)
+         0.5f, -0.5f,  0.5f,  1, 0, 0,   0.5f, -0.5f, -0.5f,  1, 0, 0,
+         0.5f,  0.5f, -0.5f,  1, 0, 0,   0.5f,  0.5f,  0.5f,  1, 0, 0,
+        // Left (-X)
+        -0.5f, -0.5f, -0.5f, -1, 0, 0,  -0.5f, -0.5f,  0.5f, -1, 0, 0,
+        -0.5f,  0.5f,  0.5f, -1, 0, 0,  -0.5f,  0.5f, -0.5f, -1, 0, 0,
     };
 
-    m_cubeIndices = {
-        // Front face
-        0, 1, 2, 2, 3, 0,
-        // Back face
-        4, 5, 6, 6, 7, 4,
-        // Top face
-        8, 9, 10, 10, 11, 8,
-        // Bottom face
-        12, 13, 14, 14, 15, 12,
-        // Right face
-        16, 17, 18, 18, 19, 16,
-        // Left face
-        20, 21, 22, 22, 23, 20
-    };
+    std::vector<unsigned int> idx;
+    idx.reserve(36);
+    for (unsigned int f = 0; f < 6; ++f) {
+        unsigned int b = f * 4;
+        idx.insert(idx.end(), { b, b + 1, b + 2, b + 2, b + 3, b });
+    }
+    m_cubeIndexCount = static_cast<GLsizei>(idx.size());
 
-    // Generate and setup VAO, VBO, EBO for cube
     glGenVertexArrays(1, &m_cubeVAO);
     glGenBuffers(1, &m_cubeVBO);
     glGenBuffers(1, &m_cubeEBO);
 
     glBindVertexArray(m_cubeVAO);
-
     glBindBuffer(GL_ARRAY_BUFFER, m_cubeVBO);
-    glBufferData(GL_ARRAY_BUFFER, m_cubeVertices.size() * sizeof(float), m_cubeVertices.data(), GL_STATIC_DRAW);
-
+    glBufferData(GL_ARRAY_BUFFER, sizeof(v), v, GL_STATIC_DRAW);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_cubeEBO);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, m_cubeIndices.size() * sizeof(unsigned int), m_cubeIndices.data(), GL_STATIC_DRAW);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, idx.size() * sizeof(unsigned int), idx.data(), GL_STATIC_DRAW);
 
-    // Position attribute
     glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)0);
-
-    // Normal attribute
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 6 * sizeof(float), (void*)0);
     glEnableVertexAttribArray(1);
-    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)(3 * sizeof(float)));
-
-    // Texture coordinate attribute (even though we might not use it)
-    glEnableVertexAttribArray(2);
-    glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)(6 * sizeof(float)));
-
+    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 6 * sizeof(float), (void*)(3 * sizeof(float)));
     glBindVertexArray(0);
 }
 
 void CursorPreview3D::generateSphereGeometry() {
-    m_sphereVertices.clear();
-    m_sphereIndices.clear();
+    std::vector<float> verts;
+    std::vector<unsigned int> idx;
 
     const unsigned int rings = 32;
     const unsigned int sectors = 32;
-    const float radius = 1.0f;
 
     for (unsigned int i = 0; i <= rings; ++i) {
-        float phi = M_PI * static_cast<float>(i) / static_cast<float>(rings);
+        float phi = static_cast<float>(M_PI) * static_cast<float>(i) / static_cast<float>(rings);
         float y = std::cos(phi);
         float ringRadius = std::sin(phi);
-
         for (unsigned int j = 0; j <= sectors; ++j) {
-            float theta = 2.0f * M_PI * static_cast<float>(j) / static_cast<float>(sectors);
+            float theta = 2.0f * static_cast<float>(M_PI) * static_cast<float>(j) / static_cast<float>(sectors);
             float x = ringRadius * std::cos(theta);
             float z = ringRadius * std::sin(theta);
-
-            // Position
-            m_sphereVertices.push_back(x * radius);
-            m_sphereVertices.push_back(y * radius);
-            m_sphereVertices.push_back(z * radius);
-
-            // Normal (same as position for unit sphere)
-            m_sphereVertices.push_back(x);
-            m_sphereVertices.push_back(y);
-            m_sphereVertices.push_back(z);
+            verts.insert(verts.end(), { x, y, z, x, y, z }); // pos == normal (unit sphere)
         }
     }
-
-    // Generate indices
     for (unsigned int i = 0; i < rings; ++i) {
         for (unsigned int j = 0; j < sectors; ++j) {
-            unsigned int current = i * (sectors + 1) + j;
-            unsigned int next = current + sectors + 1;
-
-            m_sphereIndices.push_back(current);
-            m_sphereIndices.push_back(next);
-            m_sphereIndices.push_back(current + 1);
-
-            m_sphereIndices.push_back(current + 1);
-            m_sphereIndices.push_back(next);
-            m_sphereIndices.push_back(next + 1);
+            unsigned int cur = i * (sectors + 1) + j;
+            unsigned int nxt = cur + sectors + 1;
+            idx.insert(idx.end(), { cur, nxt, cur + 1, cur + 1, nxt, nxt + 1 });
         }
     }
+    m_sphereIndexCount = static_cast<GLsizei>(idx.size());
 
-    // Generate and setup VAO, VBO, EBO for sphere
     glGenVertexArrays(1, &m_sphereVAO);
     glGenBuffers(1, &m_sphereVBO);
     glGenBuffers(1, &m_sphereEBO);
 
     glBindVertexArray(m_sphereVAO);
-
     glBindBuffer(GL_ARRAY_BUFFER, m_sphereVBO);
-    glBufferData(GL_ARRAY_BUFFER, m_sphereVertices.size() * sizeof(float), m_sphereVertices.data(), GL_STATIC_DRAW);
-
+    glBufferData(GL_ARRAY_BUFFER, verts.size() * sizeof(float), verts.data(), GL_STATIC_DRAW);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_sphereEBO);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, m_sphereIndices.size() * sizeof(unsigned int), m_sphereIndices.data(), GL_STATIC_DRAW);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, idx.size() * sizeof(unsigned int), idx.data(), GL_STATIC_DRAW);
 
-    // Position attribute
     glEnableVertexAttribArray(0);
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 6 * sizeof(float), (void*)0);
-
-    // Normal attribute
     glEnableVertexAttribArray(1);
     glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 6 * sizeof(float), (void*)(3 * sizeof(float)));
-
     glBindVertexArray(0);
 }
 
-void CursorPreview3D::generatePlaneGeometry() {
-    // Create a simple quad for the plane cursor
-    m_planeVertices = {
-        // Quad vertices (position only)
-        -0.5f, 0.0f, -0.5f,  // Bottom-left
-         0.5f, 0.0f, -0.5f,  // Bottom-right
-         0.5f, 0.0f,  0.5f,  // Top-right
-        -0.5f, 0.0f,  0.5f   // Top-left
+void CursorPreview3D::generateQuadGeometry() {
+    // Unit quad in the XY plane spanning [-1, 1]; reused for the background
+    // gradient and the camera-facing billboards.
+    const float q[] = {
+        -1.0f, -1.0f,   1.0f, -1.0f,   1.0f,  1.0f,
+        -1.0f, -1.0f,   1.0f,  1.0f,  -1.0f,  1.0f,
     };
-
-    m_planeIndices = {
-        0, 1, 2,  // First triangle
-        2, 3, 0   // Second triangle
-    };
-
-    // Generate and setup VAO, VBO, EBO for plane
-    glGenVertexArrays(1, &m_planeVAO);
-    glGenBuffers(1, &m_planeVBO);
-    glGenBuffers(1, &m_planeEBO);
-
-    glBindVertexArray(m_planeVAO);
-
-    glBindBuffer(GL_ARRAY_BUFFER, m_planeVBO);
-    glBufferData(GL_ARRAY_BUFFER, m_planeVertices.size() * sizeof(float), m_planeVertices.data(), GL_STATIC_DRAW);
-
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_planeEBO);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, m_planeIndices.size() * sizeof(unsigned int), m_planeIndices.data(), GL_STATIC_DRAW);
-
-    // Position attribute (only position, no normal for simple plane shader)
+    glGenVertexArrays(1, &m_quadVAO);
+    glGenBuffers(1, &m_quadVBO);
+    glBindVertexArray(m_quadVAO);
+    glBindBuffer(GL_ARRAY_BUFFER, m_quadVBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(q), q, GL_STATIC_DRAW);
     glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
-
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 2 * sizeof(float), (void*)0);
     glBindVertexArray(0);
 }
 
 void CursorPreview3D::setupFramebuffer() {
-    // Generate framebuffer
-    glGenFramebuffers(1, &m_framebuffer);
-    glBindFramebuffer(GL_FRAMEBUFFER, m_framebuffer);
+    // Clamp the sample count to what the driver actually supports.
+    GLint maxSamples = 1;
+    glGetIntegerv(GL_MAX_SAMPLES, &maxSamples);
+    m_samples = std::max(1, std::min(m_samples, maxSamples));
 
-    // Generate color texture
+    // Multisampled render target.
+    glGenFramebuffers(1, &m_msaaFBO);
+    glBindFramebuffer(GL_FRAMEBUFFER, m_msaaFBO);
+
+    glGenRenderbuffers(1, &m_msaaColorRBO);
+    glBindRenderbuffer(GL_RENDERBUFFER, m_msaaColorRBO);
+    glRenderbufferStorageMultisample(GL_RENDERBUFFER, m_samples, GL_RGBA8, m_width, m_height);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_msaaColorRBO);
+
+    glGenRenderbuffers(1, &m_msaaDepthRBO);
+    glBindRenderbuffer(GL_RENDERBUFFER, m_msaaDepthRBO);
+    glRenderbufferStorageMultisample(GL_RENDERBUFFER, m_samples, GL_DEPTH_COMPONENT24, m_width, m_height);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_msaaDepthRBO);
+
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+        std::cerr << "[CursorPreview3D] multisample framebuffer incomplete." << std::endl;
+
+    // Single-sample resolve target sampled by ImGui.
+    glGenFramebuffers(1, &m_resolveFBO);
+    glBindFramebuffer(GL_FRAMEBUFFER, m_resolveFBO);
+
     glGenTextures(1, &m_colorTexture);
     glBindTexture(GL_TEXTURE_2D, m_colorTexture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, m_width, m_height, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, m_width, m_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_colorTexture, 0);
 
-    // Generate depth texture
-    glGenTextures(1, &m_depthTexture);
-    glBindTexture(GL_TEXTURE_2D, m_depthTexture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, m_width, m_height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, NULL);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, m_depthTexture, 0);
-
-    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-        std::cerr << "Framebuffer not complete!" << std::endl;
-    }
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+        std::cerr << "[CursorPreview3D] resolve framebuffer incomplete." << std::endl;
 
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
 
 void CursorPreview3D::setupCamera() {
-    m_projectionMatrix = glm::perspective(glm::radians(45.0f), (float)m_width / (float)m_height, 0.1f, 100.0f);
-    m_viewMatrix = glm::lookAt(m_cameraPosition, glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, 1.0f, 0.0f));
+    m_projectionMatrix = glm::perspective(glm::radians(38.0f),
+                                          (float)m_width / (float)m_height, 0.1f, 100.0f);
+    m_viewMatrix = glm::lookAt(m_cameraPosition, glm::vec3(0.0f),
+                               glm::vec3(0.0f, 1.0f, 0.0f));
 }
 
 void CursorPreview3D::updateRotation(float deltaX, float deltaY) {
     m_rotationY += deltaX * 0.5f;
     m_rotationX += deltaY * 0.5f;
-
-    // Clamp X rotation to avoid flipping
     m_rotationX = glm::clamp(m_rotationX, -89.0f, 89.0f);
 }
 
-void CursorPreview3D::renderCube() {
-    if (m_cubeVAO == 0) return;
-
-    // Try the sphere shader first as fallback since we know it works
-    Engine::Shader* activeShader = m_sphereShader ? m_sphereShader : m_cubeShader;
-    if (!activeShader) return;
-
-    activeShader->use();
-
-    // Create model matrix with rotation and scaling to make cube more visible
-    glm::mat4 model = glm::mat4(1.0f);
-    model = glm::rotate(model, glm::radians(m_rotationX), glm::vec3(1.0f, 0.0f, 0.0f));
-    model = glm::rotate(model, glm::radians(m_rotationY), glm::vec3(0.0f, 1.0f, 0.0f));
-    model = glm::scale(model, glm::vec3(0.8f)); // Slightly smaller cube to fit better in view
-
-    activeShader->setMat4("model", model);
-    activeShader->setMat4("view", m_viewMatrix);
-    activeShader->setMat4("projection", m_projectionMatrix);
-
-    // If using sphere shader, set sphere-specific uniforms
-    if (activeShader == m_sphereShader) {
-        activeShader->setVec3("viewPos", m_cameraPosition);
-        activeShader->setVec4("sphereColor", glm::vec4(1.0f, 1.0f, 1.0f, 0.3f)); // Semi-transparent white
-        activeShader->setFloat("transparency", 0.3f);
-        activeShader->setFloat("edgeSoftness", 0.0f); // Sharp edges for cube
-        activeShader->setFloat("centerTransparency", 0.3f);
-        activeShader->setFloat("innerSphereFactor", 1.0f);
-        activeShader->setBool("isInnerSphere", false);
-    } else {
-        // Try cube shader uniforms with extensive fallbacks
-        try {
-            activeShader->setVec3("lightPos", glm::vec3(2.0f, 2.0f, 2.0f));
-            activeShader->setVec3("viewPos", m_cameraPosition);
-            activeShader->setVec3("objectColor", glm::vec3(1.0f, 1.0f, 1.0f));
-            activeShader->setVec3("lightColor", glm::vec3(1.0f, 1.0f, 1.0f));
-        } catch (...) {
-            try {
-                activeShader->setVec3("color", glm::vec3(1.0f, 1.0f, 1.0f));
-            } catch (...) {
-                try {
-                    activeShader->setVec4("sphereColor", glm::vec4(1.0f, 1.0f, 1.0f, 1.0f));
-                } catch (...) {}
-            }
-        }
-    }
-
-    glEnable(GL_DEPTH_TEST);
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-
-    glBindVertexArray(m_cubeVAO);
-
-    // Render simple solid white cube
-    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
-
-    // Set white color for the cube
-    if (activeShader == m_sphereShader) {
-        activeShader->setVec4("sphereColor", glm::vec4(1.0f, 1.0f, 1.0f, 0.8f)); // White with slight transparency
-        activeShader->setFloat("transparency", 0.8f);
-    } else {
-        try {
-            activeShader->setVec3("objectColor", glm::vec3(1.0f, 1.0f, 1.0f));
-        } catch (...) {}
-    }
-
-    glDrawElements(GL_TRIANGLES, m_cubeIndices.size(), GL_UNSIGNED_INT, 0);
-    glBindVertexArray(0);
-}
-
-void CursorPreview3D::renderFallbackReference() {
-    // If cube rendering fails, render some simple reference lines using sphere shader
-    if (!m_sphereShader) return;
-
-    m_sphereShader->use();
-
-    // Render some reference spheres at the corners of where the cube should be
-    glm::vec3 corners[] = {
-        glm::vec3(-0.4f, -0.4f, -0.4f), glm::vec3(0.4f, -0.4f, -0.4f),
-        glm::vec3(-0.4f, 0.4f, -0.4f), glm::vec3(0.4f, 0.4f, -0.4f),
-        glm::vec3(-0.4f, -0.4f, 0.4f), glm::vec3(0.4f, -0.4f, 0.4f),
-        glm::vec3(-0.4f, 0.4f, 0.4f), glm::vec3(0.4f, 0.4f, 0.4f)
-    };
-
-    if (m_sphereVAO != 0) {
-        for (int i = 0; i < 8; i++) {
-            glm::mat4 cubeRotation = glm::mat4(1.0f);
-            cubeRotation = glm::rotate(cubeRotation, glm::radians(m_rotationX), glm::vec3(1.0f, 0.0f, 0.0f));
-            cubeRotation = glm::rotate(cubeRotation, glm::radians(m_rotationY), glm::vec3(0.0f, 1.0f, 0.0f));
-
-            glm::vec3 rotatedCorner = glm::vec3(cubeRotation * glm::vec4(corners[i], 1.0f));
-
-            glm::mat4 model = glm::mat4(1.0f);
-            model = glm::translate(model, rotatedCorner);
-            model = glm::scale(model, glm::vec3(0.05f)); // Small reference spheres
-
-            m_sphereShader->setMat4("model", model);
-            m_sphereShader->setMat4("view", m_viewMatrix);
-            m_sphereShader->setMat4("projection", m_projectionMatrix);
-            m_sphereShader->setVec3("viewPos", m_cameraPosition);
-            m_sphereShader->setVec4("sphereColor", glm::vec4(1.0f, 1.0f, 0.0f, 1.0f)); // Bright yellow
-            m_sphereShader->setFloat("transparency", 1.0f);
-            m_sphereShader->setFloat("edgeSoftness", 0.0f);
-            m_sphereShader->setFloat("centerTransparency", 1.0f);
-            m_sphereShader->setFloat("innerSphereFactor", 1.0f);
-            m_sphereShader->setBool("isInnerSphere", false);
-
-            glBindVertexArray(m_sphereVAO);
-            glDrawElements(GL_TRIANGLES, m_sphereIndices.size(), GL_UNSIGNED_INT, 0);
-        }
-        glBindVertexArray(0);
-    }
-}
+// ───────────────────────────── rendering ────────────────────────────────────
 
 void CursorPreview3D::render(Cursor::BaseCursor* cursor) {
     if (!m_initialized || !cursor) return;
 
-    // Save current viewport and framebuffer
-    GLint viewport[4];
-    glGetIntegerv(GL_VIEWPORT, viewport);
-    GLint currentFramebuffer;
-    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &currentFramebuffer);
+    // Save the caller's framebuffer / viewport so we leave the scene untouched.
+    GLint prevViewport[4];
+    glGetIntegerv(GL_VIEWPORT, prevViewport);
+    GLint prevFBO = 0;
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prevFBO);
 
-    // Bind our framebuffer
-    glBindFramebuffer(GL_FRAMEBUFFER, m_framebuffer);
+    glBindFramebuffer(GL_FRAMEBUFFER, m_msaaFBO);
     glViewport(0, 0, m_width, m_height);
-
-    // Clear the framebuffer with darker background to show wireframes better
-    glClearColor(0.1f, 0.1f, 0.1f, 1.0f); // Darker background
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-    glEnable(GL_DEPTH_TEST);
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glm::mat4 modelRotation(1.0f);
+    modelRotation = glm::rotate(modelRotation, glm::radians(m_rotationX), glm::vec3(1, 0, 0));
+    modelRotation = glm::rotate(modelRotation, glm::radians(m_rotationY), glm::vec3(0, 1, 0));
 
-    // Render the cube first
-    renderCube();
-
-    // Render the cursor based on its type - completely independent preview
-    // Position cursor at one of the cube edges (front-top-right corner like the yellow dots)
-    glm::vec3 cursorPosition(0.4f, 0.4f, 0.4f); // At cube corner where yellow dots are
+    drawBackground();
+    drawReferenceCube(modelRotation);
 
     if (cursor->isVisible()) {
-        // Calculate scale in preview context using preview camera
-        cursor->setPosition(cursorPosition);  // Temporarily set position for scaling calculation
-        float previewScale = cursor->calculateScale(m_cameraPosition);
-
-        if (auto* sphereCursor = dynamic_cast<Cursor::SphereCursor*>(cursor)) {
-            // Use the unified scaling system with preview context
-            float basePreviewRadius = 0.2f;
-            float scaledRadius = basePreviewRadius * previewScale;
-            renderPreviewSphere(
-                sphereCursor->getColor(),
-                scaledRadius,
-                sphereCursor->getShowInnerSphere(),
-                sphereCursor->getInnerSphereColor(),
-                sphereCursor->getInnerSphereFactor(),
-                cursorPosition,
-                sphereCursor->getTransparency(),
-                sphereCursor->getEdgeSoftness(),
-                sphereCursor->getCenterTransparency()
-            );
-        }
-        else if (auto* fragmentCursor = dynamic_cast<Cursor::FragmentCursor*>(cursor)) {
-            // Use the unified scaling system for fragment cursor
-            float basePreviewRadius = 0.2f;
-            float scaledRadius = basePreviewRadius * previewScale;
-            renderPreviewFragmentCursor(
-                scaledRadius,
-                fragmentCursor->getOuterColor(),
-                cursorPosition
-            );
-        }
-        else if (auto* planeCursor = dynamic_cast<Cursor::PlaneCursor*>(cursor)) {
-            // Use the unified scaling system for plane cursor
-            float basePreviewDiameter = 0.3f;
-            float scaledDiameter = basePreviewDiameter * previewScale;
-            renderPreviewPlaneCursor(
-                scaledDiameter,
-                planeCursor->getColor(),
-                cursorPosition
-            );
+        if (auto* s = dynamic_cast<Cursor::SphereCursor*>(cursor)) {
+            drawSphereCursor(s, modelRotation);
+        } else if (auto* fcur = dynamic_cast<Cursor::FragmentCursor*>(cursor)) {
+            drawFragmentCursor(fcur);
+        } else if (auto* p = dynamic_cast<Cursor::PlaneCursor*>(cursor)) {
+            drawPlaneCursor(p);
         }
     }
 
-    // Restore previous framebuffer and viewport
-    glBindFramebuffer(GL_FRAMEBUFFER, currentFramebuffer);
-    glViewport(viewport[0], viewport[1], viewport[2], viewport[3]);
+    // Resolve MSAA into the texture ImGui samples.
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, m_msaaFBO);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_resolveFBO);
+    glBlitFramebuffer(0, 0, m_width, m_height, 0, 0, m_width, m_height,
+                      GL_COLOR_BUFFER_BIT, GL_LINEAR);
+
+    // Restore caller state and a neutral default render state.
+    glBindFramebuffer(GL_FRAMEBUFFER, prevFBO);
+    glViewport(prevViewport[0], prevViewport[1], prevViewport[2], prevViewport[3]);
+    glDisable(GL_BLEND);
+    glDisable(GL_CULL_FACE);
+    glDepthMask(GL_TRUE);
+    glEnable(GL_DEPTH_TEST);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glUseProgram(0);
+    glBindVertexArray(0);
 }
 
-void CursorPreview3D::renderPreviewSphere(const glm::vec4& color, float radius, bool showInner, const glm::vec4& innerColor, float innerFactor, const glm::vec3& position, float transparency, float edgeSoftness, float centerTransparency) {
+void CursorPreview3D::drawBackground() {
+    if (!m_gradientShader) return;
+    glDisable(GL_DEPTH_TEST);
+    glDepthMask(GL_FALSE);
+    glDisable(GL_BLEND);
+    m_gradientShader->use();
+    m_gradientShader->setVec3("uTop", glm::vec3(0.085f, 0.095f, 0.115f));
+    m_gradientShader->setVec3("uBottom", glm::vec3(0.16f, 0.17f, 0.20f));
+    glBindVertexArray(m_quadVAO);
+    glDrawArrays(GL_TRIANGLES, 0, 6);
+    glBindVertexArray(0);
+    glDepthMask(GL_TRUE);
+    glEnable(GL_DEPTH_TEST);
+}
+
+void CursorPreview3D::drawReferenceCube(const glm::mat4& modelRotation) {
+    if (!m_litShader || m_cubeVAO == 0) return;
+
+    glEnable(GL_DEPTH_TEST);
+    glDepthMask(GL_TRUE);
+    glEnable(GL_CULL_FACE);
+    glCullFace(GL_BACK);
+    glDisable(GL_BLEND);
+
+    glm::mat4 model = modelRotation * glm::scale(glm::mat4(1.0f), glm::vec3(kCubeScale));
+    glm::mat3 normalMatrix = glm::mat3(glm::transpose(glm::inverse(model)));
+
+    m_litShader->use();
+    m_litShader->setMat4("model", model);
+    m_litShader->setMat4("view", m_viewMatrix);
+    m_litShader->setMat4("projection", m_projectionMatrix);
+    m_litShader->setMat3("normalMatrix", normalMatrix);
+    m_litShader->setVec3("uViewPos", m_cameraPosition);
+    m_litShader->setVec3("uBaseColor", glm::vec3(0.50f, 0.53f, 0.60f));
+
+    glBindVertexArray(m_cubeVAO);
+    glDrawElements(GL_TRIANGLES, m_cubeIndexCount, GL_UNSIGNED_INT, 0);
+    glBindVertexArray(0);
+}
+
+void CursorPreview3D::drawSphereCursor(Cursor::SphereCursor* cursor, const glm::mat4& modelRotation) {
     if (!m_sphereShader || m_sphereVAO == 0) return;
 
-    // Save current OpenGL state
-    GLboolean blendEnabled = glIsEnabled(GL_BLEND);
-    GLint blendSrc, blendDst;
-    glGetIntegerv(GL_BLEND_SRC_ALPHA, &blendSrc);
-    glGetIntegerv(GL_BLEND_DST_ALPHA, &blendDst);
-    GLboolean depthMaskState;
-    glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMaskState);
-    GLint cullFaceMode;
-    glGetIntegerv(GL_CULL_FACE_MODE, &cullFaceMode);
+    // Map the cursor's base size to a representative preview radius that always
+    // stays nicely framed while still reacting to the size setting.
+    float baseSize = std::max(cursor->getBaseSize(), 1e-4f);
+    float radius = glm::clamp(0.28f * (0.5f + 0.5f * (baseSize / 0.05f)), 0.15f, 0.40f);
 
-    // Set required state for sphere rendering
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glEnable(GL_DEPTH_TEST);
+    // Anchor the sphere on the +Z face of the cube so it half-embeds in the
+    // surface, exactly as it would sit on geometry in the scene.
+    glm::vec3 anchorModel(kCubeHalf * 0.4f, kCubeHalf * 0.3f, kCubeHalf);
+    glm::vec3 anchorWorld = glm::vec3(modelRotation * glm::vec4(anchorModel, 1.0f));
 
-    m_sphereShader->use();
-
-    // Create model matrix with cube rotation, then position and scale the sphere
-    glm::mat4 cubeRotation = glm::mat4(1.0f);
-    cubeRotation = glm::rotate(cubeRotation, glm::radians(m_rotationX), glm::vec3(1.0f, 0.0f, 0.0f));
-    cubeRotation = glm::rotate(cubeRotation, glm::radians(m_rotationY), glm::vec3(0.0f, 1.0f, 0.0f));
-
-    // Transform position by cube rotation, then translate and scale
-    glm::vec3 rotatedPosition = glm::vec3(cubeRotation * glm::vec4(position, 1.0f));
-
-    glm::mat4 model = glm::mat4(1.0f);
-    model = glm::translate(model, rotatedPosition);
+    glm::mat4 model = glm::translate(glm::mat4(1.0f), anchorWorld);
     model = glm::scale(model, glm::vec3(radius));
 
+    glEnable(GL_BLEND);
+    // Blend RGB normally but keep the framebuffer alpha at 1 so the resolved
+    // preview texture stays fully opaque for ImGui.
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_CULL_FACE);
+
+    m_sphereShader->use();
     m_sphereShader->setMat4("view", m_viewMatrix);
     m_sphereShader->setMat4("projection", m_projectionMatrix);
     m_sphereShader->setVec3("viewPos", m_cameraPosition);
+
+    bool showInner = cursor->getShowInnerSphere();
+    float innerFactor = cursor->getInnerSphereFactor();
+    glm::vec4 color = cursor->getColor();
+    glm::vec4 innerColor = cursor->getInnerSphereColor();
+    float transparency = cursor->getTransparency();
+    float edgeSoftness = cursor->getEdgeSoftness();
+    float centerTransparency = cursor->getCenterTransparency();
+
     m_sphereShader->setFloat("innerSphereFactor", innerFactor);
+    glm::mat4 innerModel = glm::scale(model, glm::vec3(innerFactor));
 
     glBindVertexArray(m_sphereVAO);
 
-    // First pass: Render back faces (exactly like real sphere cursor)
-    glDepthMask(GL_TRUE);
-    glCullFace(GL_FRONT);
+    // Two passes (back faces with depth write, then front faces) – matches the
+    // in-scene SphereCursor so transparency layering looks identical.
+    for (int pass = 0; pass < 2; ++pass) {
+        if (pass == 0) { glDepthMask(GL_TRUE);  glCullFace(GL_FRONT); }
+        else           { glDepthMask(GL_FALSE); glCullFace(GL_BACK);  }
 
-    if (showInner) {
-        m_sphereShader->setBool("isInnerSphere", true);
-        m_sphereShader->setVec4("sphereColor", innerColor);
-        m_sphereShader->setFloat("transparency", 1.0f);
-        glm::mat4 innerModel = glm::scale(model, glm::vec3(innerFactor));
-        m_sphereShader->setMat4("model", innerModel);
-        glDrawElements(GL_TRIANGLES, m_sphereIndices.size(), GL_UNSIGNED_INT, 0);
+        if (showInner) {
+            m_sphereShader->setBool("isInnerSphere", true);
+            m_sphereShader->setVec4("sphereColor", innerColor);
+            m_sphereShader->setFloat("transparency", 1.0f);
+            m_sphereShader->setMat4("model", innerModel);
+            glDrawElements(GL_TRIANGLES, m_sphereIndexCount, GL_UNSIGNED_INT, 0);
+        }
+
+        m_sphereShader->setBool("isInnerSphere", false);
+        m_sphereShader->setVec4("sphereColor", color);
+        m_sphereShader->setFloat("transparency", transparency);
+        m_sphereShader->setFloat("edgeSoftness", edgeSoftness);
+        m_sphereShader->setFloat("centerTransparencyFactor", centerTransparency);
+        m_sphereShader->setMat4("model", model);
+        glDrawElements(GL_TRIANGLES, m_sphereIndexCount, GL_UNSIGNED_INT, 0);
     }
 
-    m_sphereShader->setBool("isInnerSphere", false);
-    m_sphereShader->setVec4("sphereColor", color);
-    m_sphereShader->setFloat("transparency", transparency);
-    m_sphereShader->setFloat("edgeSoftness", edgeSoftness);
-    m_sphereShader->setFloat("centerTransparencyFactor", centerTransparency);
-    m_sphereShader->setMat4("model", model);
-    glDrawElements(GL_TRIANGLES, m_sphereIndices.size(), GL_UNSIGNED_INT, 0);
-
-    // Second pass: Render front faces (exactly like real sphere cursor)
-    glDepthMask(GL_FALSE);
-    glCullFace(GL_BACK);
-
-    if (showInner) {
-        m_sphereShader->setBool("isInnerSphere", true);
-        m_sphereShader->setVec4("sphereColor", innerColor);
-        m_sphereShader->setFloat("transparency", 1.0f);
-        glm::mat4 innerModel = glm::scale(model, glm::vec3(innerFactor));
-        m_sphereShader->setMat4("model", innerModel);
-        glDrawElements(GL_TRIANGLES, m_sphereIndices.size(), GL_UNSIGNED_INT, 0);
-    }
-
-    m_sphereShader->setBool("isInnerSphere", false);
-    m_sphereShader->setVec4("sphereColor", color);
-    m_sphereShader->setFloat("transparency", transparency);
-    m_sphereShader->setFloat("edgeSoftness", edgeSoftness);
-    m_sphereShader->setFloat("centerTransparencyFactor", centerTransparency);
-    m_sphereShader->setMat4("model", model);
-    glDrawElements(GL_TRIANGLES, m_sphereIndices.size(), GL_UNSIGNED_INT, 0);
-
-    // Restore previous OpenGL state
-    if (blendEnabled) {
-        glEnable(GL_BLEND);
-        glBlendFunc(blendSrc, blendDst);
-    } else {
-        glDisable(GL_BLEND);
-    }
-    glDepthMask(depthMaskState);
-    glCullFace(cullFaceMode);
     glBindVertexArray(0);
+    glDepthMask(GL_TRUE);
+    glCullFace(GL_BACK);
 }
 
-void CursorPreview3D::renderPreviewFragmentCursor(float radius, const glm::vec4& color, const glm::vec3& position) {
-    // Fragment cursor is a 2D circle effect - use the sphere shader with modified settings to approximate this
-    if (!m_sphereShader || m_sphereVAO == 0) return;
+void CursorPreview3D::drawPlaneCursor(Cursor::PlaneCursor* cursor) {
+    if (!m_discShader || m_quadVAO == 0) return;
 
-    // Save current OpenGL state
-    GLboolean blendEnabled = glIsEnabled(GL_BLEND);
-    GLint blendSrc, blendDst;
-    glGetIntegerv(GL_BLEND_SRC_ALPHA, &blendSrc);
-    glGetIntegerv(GL_BLEND_DST_ALPHA, &blendDst);
-    GLboolean depthMaskState;
-    glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMaskState);
-    GLint cullFaceMode;
-    glGetIntegerv(GL_CULL_FACE_MODE, &cullFaceMode);
+    // The plane cursor billboards to face the camera and lies over the surface,
+    // so draw it centered, facing the camera, on top of the cube.
+    float diameter = cursor->getDiameter();
+    float radius = glm::clamp(0.12f + diameter * 0.09f, 0.12f, 0.55f);
 
-    // Set required state for fragment cursor rendering
+    glm::mat4 model = glm::scale(glm::mat4(1.0f), glm::vec3(radius));
+
+    glDisable(GL_DEPTH_TEST);
+    glDepthMask(GL_FALSE);
     glEnable(GL_BLEND);
+    // Premultiplied output; keep destination alpha at 1 for an opaque preview.
+    glBlendFuncSeparate(GL_ONE, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+
+    m_discShader->use();
+    m_discShader->setMat4("model", model);
+    m_discShader->setMat4("view", m_viewMatrix);
+    m_discShader->setMat4("projection", m_projectionMatrix);
+    m_discShader->setVec4("uColor", cursor->getColor());
+
+    glBindVertexArray(m_quadVAO);
+    glDrawArrays(GL_TRIANGLES, 0, 6);
+    glBindVertexArray(0);
+
+    glDisable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glDepthMask(GL_TRUE);
     glEnable(GL_DEPTH_TEST);
-
-    m_sphereShader->use();
-
-    // Create model matrix with cube rotation, then position and scale
-    glm::mat4 cubeRotation = glm::mat4(1.0f);
-    cubeRotation = glm::rotate(cubeRotation, glm::radians(m_rotationX), glm::vec3(1.0f, 0.0f, 0.0f));
-    cubeRotation = glm::rotate(cubeRotation, glm::radians(m_rotationY), glm::vec3(0.0f, 1.0f, 0.0f));
-
-    // Transform position by cube rotation, then translate and scale
-    glm::vec3 rotatedPosition = glm::vec3(cubeRotation * glm::vec4(position, 1.0f));
-
-    glm::mat4 model = glm::mat4(1.0f);
-    model = glm::translate(model, rotatedPosition);
-    model = glm::scale(model, glm::vec3(radius));
-
-    m_sphereShader->setMat4("model", model);
-    m_sphereShader->setMat4("view", m_viewMatrix);
-    m_sphereShader->setMat4("projection", m_projectionMatrix);
-    m_sphereShader->setVec3("viewPos", m_cameraPosition);
-
-    // Set sphere properties to mimic the 2D circle effect
-    // Make it more opaque and with sharp edges to simulate the fragment cursor
-    m_sphereShader->setVec4("sphereColor", color);
-    m_sphereShader->setFloat("transparency", 1.0f); // Fully opaque
-    m_sphereShader->setFloat("edgeSoftness", 0.0f); // Sharp edges like the fragment cursor
-    m_sphereShader->setFloat("centerTransparency", 1.0f); // No center transparency
-    m_sphereShader->setFloat("innerSphereFactor", 0.5f); // Small inner area
-    m_sphereShader->setBool("isInnerSphere", false);
-
-    glBindVertexArray(m_sphereVAO);
-
-    // Render only front faces for a more 2D-like appearance
-    glDepthMask(GL_TRUE);
-    glCullFace(GL_BACK);
-    glDrawElements(GL_TRIANGLES, m_sphereIndices.size(), GL_UNSIGNED_INT, 0);
-
-    // Restore previous OpenGL state
-    if (blendEnabled) {
-        glEnable(GL_BLEND);
-        glBlendFunc(blendSrc, blendDst);
-    } else {
-        glDisable(GL_BLEND);
-    }
-    glDepthMask(depthMaskState);
-    glCullFace(cullFaceMode);
-    glBindVertexArray(0);
 }
 
-void CursorPreview3D::renderPreviewPlaneCursor(float diameter, const glm::vec4& color, const glm::vec3& position) {
-    // Use the proper plane cursor shader and geometry
-    if (!m_planeShader || m_planeVAO == 0) return;
+void CursorPreview3D::drawFragmentCursor(Cursor::FragmentCursor* cursor) {
+    if (!m_ringShader || m_quadVAO == 0) return;
 
-    // Save current OpenGL state
-    GLboolean blendEnabled = glIsEnabled(GL_BLEND);
-    GLint blendSrc, blendDst;
-    glGetIntegerv(GL_BLEND_SRC_ALPHA, &blendSrc);
-    glGetIntegerv(GL_BLEND_DST_ALPHA, &blendDst);
-    GLboolean depthMaskState;
-    glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMaskState);
+    const GUI::FragmentShaderCursorSettings& s = cursor->getSettings();
 
-    // Set required state for plane cursor rendering
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    // The fragment cursor is a screen-space ring pair. Normalise its radii by the
+    // slider's maximum outer radius (0.3) so the largest setting fills the
+    // billboard, preserving the relative proportions the user configures.
+    constexpr float kRefMax = 0.30f;
+    constexpr float kBillboardRadius = 0.55f;
 
-    m_planeShader->use();
+    glm::mat4 model = glm::scale(glm::mat4(1.0f), glm::vec3(kBillboardRadius));
 
-    // Create model matrix with cube rotation, then position and scale the plane
-    glm::mat4 cubeRotation = glm::mat4(1.0f);
-    cubeRotation = glm::rotate(cubeRotation, glm::radians(m_rotationX), glm::vec3(1.0f, 0.0f, 0.0f));
-    cubeRotation = glm::rotate(cubeRotation, glm::radians(m_rotationY), glm::vec3(0.0f, 1.0f, 0.0f));
-
-    // Transform position by cube rotation
-    glm::vec3 rotatedPosition = glm::vec3(cubeRotation * glm::vec4(position, 1.0f));
-
-    glm::mat4 model = glm::mat4(1.0f);
-    model = glm::translate(model, rotatedPosition);
-    model = glm::scale(model, glm::vec3(diameter, 1.0f, diameter)); // Scale x and z for diameter, keep y thin
-
-    m_planeShader->setMat4("model", model);
-    m_planeShader->setMat4("view", m_viewMatrix);
-    m_planeShader->setMat4("projection", m_projectionMatrix);
-
-    // Set plane color
-    m_planeShader->setVec4("color", color);
-
-    // Disable depth writing for transparent plane
+    glDisable(GL_DEPTH_TEST);
     glDepthMask(GL_FALSE);
+    glEnable(GL_BLEND);
+    // Premultiplied output; keep destination alpha at 1 for an opaque preview.
+    glBlendFuncSeparate(GL_ONE, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 
-    glBindVertexArray(m_planeVAO);
-    glDrawElements(GL_TRIANGLES, m_planeIndices.size(), GL_UNSIGNED_INT, 0);
+    m_ringShader->use();
+    m_ringShader->setMat4("model", model);
+    m_ringShader->setMat4("view", m_viewMatrix);
+    m_ringShader->setMat4("projection", m_projectionMatrix);
+    m_ringShader->setFloat("uOuterR", glm::clamp(s.baseOuterRadius / kRefMax, 0.0f, 1.0f));
+    m_ringShader->setFloat("uOuterT", glm::clamp(s.baseOuterBorderThickness / kRefMax, 0.0f, 1.0f));
+    m_ringShader->setFloat("uInnerR", glm::clamp(s.baseInnerRadius / kRefMax, 0.0f, 1.0f));
+    m_ringShader->setFloat("uInnerT", glm::clamp(s.baseInnerBorderThickness / kRefMax, 0.0f, 1.0f));
+    m_ringShader->setVec4("uOuterColor", s.outerColor);
+    m_ringShader->setVec4("uInnerColor", s.innerColor);
+
+    glBindVertexArray(m_quadVAO);
+    glDrawArrays(GL_TRIANGLES, 0, 6);
     glBindVertexArray(0);
 
-    // Restore previous OpenGL state
-    if (blendEnabled) {
-        glEnable(GL_BLEND);
-        glBlendFunc(blendSrc, blendDst);
-    } else {
-        glDisable(GL_BLEND);
-    }
-    glDepthMask(depthMaskState);
+    glDisable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glDepthMask(GL_TRUE);
+    glEnable(GL_DEPTH_TEST);
 }
+
+// ───────────────────────────── teardown ─────────────────────────────────────
 
 void CursorPreview3D::cleanup() {
-    if (m_framebuffer) {
-        glDeleteFramebuffers(1, &m_framebuffer);
-        m_framebuffer = 0;
-    }
-    if (m_colorTexture) {
-        glDeleteTextures(1, &m_colorTexture);
-        m_colorTexture = 0;
-    }
-    if (m_depthTexture) {
-        glDeleteTextures(1, &m_depthTexture);
-        m_depthTexture = 0;
-    }
-    if (m_cubeVAO) {
-        glDeleteVertexArrays(1, &m_cubeVAO);
-        m_cubeVAO = 0;
-    }
-    if (m_cubeVBO) {
-        glDeleteBuffers(1, &m_cubeVBO);
-        m_cubeVBO = 0;
-    }
-    if (m_cubeEBO) {
-        glDeleteBuffers(1, &m_cubeEBO);
-        m_cubeEBO = 0;
-    }
-    if (m_sphereVAO) {
-        glDeleteVertexArrays(1, &m_sphereVAO);
-        m_sphereVAO = 0;
-    }
-    if (m_sphereVBO) {
-        glDeleteBuffers(1, &m_sphereVBO);
-        m_sphereVBO = 0;
-    }
-    if (m_sphereEBO) {
-        glDeleteBuffers(1, &m_sphereEBO);
-        m_sphereEBO = 0;
-    }
-    if (m_planeVAO) {
-        glDeleteVertexArrays(1, &m_planeVAO);
-        m_planeVAO = 0;
-    }
-    if (m_planeVBO) {
-        glDeleteBuffers(1, &m_planeVBO);
-        m_planeVBO = 0;
-    }
-    if (m_planeEBO) {
-        glDeleteBuffers(1, &m_planeEBO);
-        m_planeEBO = 0;
-    }
-    if (m_cubeShader) {
-        delete m_cubeShader;
-        m_cubeShader = nullptr;
-    }
-    if (m_sphereShader) {
-        delete m_sphereShader;
-        m_sphereShader = nullptr;
-    }
-    if (m_planeShader) {
-        delete m_planeShader;
-        m_planeShader = nullptr;
-    }
+    if (m_msaaColorRBO) { glDeleteRenderbuffers(1, &m_msaaColorRBO); m_msaaColorRBO = 0; }
+    if (m_msaaDepthRBO) { glDeleteRenderbuffers(1, &m_msaaDepthRBO); m_msaaDepthRBO = 0; }
+    if (m_msaaFBO)      { glDeleteFramebuffers(1, &m_msaaFBO); m_msaaFBO = 0; }
+    if (m_resolveFBO)   { glDeleteFramebuffers(1, &m_resolveFBO); m_resolveFBO = 0; }
+    if (m_colorTexture) { glDeleteTextures(1, &m_colorTexture); m_colorTexture = 0; }
+
+    if (m_cubeVAO)   { glDeleteVertexArrays(1, &m_cubeVAO); m_cubeVAO = 0; }
+    if (m_cubeVBO)   { glDeleteBuffers(1, &m_cubeVBO); m_cubeVBO = 0; }
+    if (m_cubeEBO)   { glDeleteBuffers(1, &m_cubeEBO); m_cubeEBO = 0; }
+    if (m_sphereVAO) { glDeleteVertexArrays(1, &m_sphereVAO); m_sphereVAO = 0; }
+    if (m_sphereVBO) { glDeleteBuffers(1, &m_sphereVBO); m_sphereVBO = 0; }
+    if (m_sphereEBO) { glDeleteBuffers(1, &m_sphereEBO); m_sphereEBO = 0; }
+    if (m_quadVAO)   { glDeleteVertexArrays(1, &m_quadVAO); m_quadVAO = 0; }
+    if (m_quadVBO)   { glDeleteBuffers(1, &m_quadVBO); m_quadVBO = 0; }
+
+    delete m_litShader;      m_litShader = nullptr;
+    delete m_sphereShader;   m_sphereShader = nullptr;
+    delete m_discShader;     m_discShader = nullptr;
+    delete m_ringShader;     m_ringShader = nullptr;
+    delete m_gradientShader; m_gradientShader = nullptr;
 
     m_initialized = false;
 }

--- a/StereoVista/src/Gui/CursorPreview3D.cpp
+++ b/StereoVista/src/Gui/CursorPreview3D.cpp
@@ -486,7 +486,7 @@ void CursorPreview3D::render(Cursor::BaseCursor* cursor) {
     glBindFramebuffer(GL_READ_FRAMEBUFFER, m_msaaFBO);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_resolveFBO);
     glBlitFramebuffer(0, 0, m_width, m_height, 0, 0, m_width, m_height,
-                      GL_COLOR_BUFFER_BIT, GL_LINEAR);
+                      GL_COLOR_BUFFER_BIT, GL_NEAREST);
 
     // Restore caller state and a neutral default render state.
     glBindFramebuffer(GL_FRAMEBUFFER, prevFBO);


### PR DESCRIPTION
The cursor settings preview previously only worked for the sphere cursor
and rendered the reference object with the wrong (sphere) shader. The
fragment cursor was drawn as a solid sphere and the plane cursor as a flat
square, neither reflecting their real appearance or most of their settings.

Rewrite CursorPreview3D as a self-contained, higher-quality preview:

- Embedded, purpose-built shaders (no dependency on the heavy scene shader):
  a lit reference cube, the exact sphere-cursor shader, a camera-facing
  disc for the plane cursor, and a concentric-ring shader for the fragment
  cursor.
- Each cursor type now renders faithfully and reflects every appearance
  setting: sphere (color, opacity, edge softness, center fade, inner core
  show/color/size, base size); fragment 2D circle (outer/inner radius and
  border thickness, outer/inner ring colors with alpha); plane (color,
  diameter).
- 4x MSAA framebuffer resolved to the displayed texture for smooth edges,
  with separate-alpha blending so the preview stays opaque under ImGui.
- Gradient background and two-light Phong cube for a cleaner look; the
  cursor sits on the cube surface and the whole scene stays drag-rotatable.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RM6LxGb7EKeSrJwufxYHuP