### PR TITLE
Add Area (polygon) measurement type to the Measurement tool

### DIFF
--- a/StereoVista/headers/Engine/Data.h
+++ b/StereoVista/headers/Engine/Data.h
@@ -328,7 +328,8 @@ namespace Engine {
         enum class Type {
             Distance = 0, // polyline: per-segment + total length
             Angle    = 1, // exactly 3 points: angle at the middle point
-            Point    = 2  // single point: world-coordinate annotation
+            Point    = 2, // single point: world-coordinate annotation
+            Area     = 3  // closed polygon (>= 3 points): planar surface area
         };
 
         Type type = Type::Distance;
@@ -353,6 +354,44 @@ namespace Engine {
             if (la < 1e-6f || lb < 1e-6f) return 0.0f;
             const float c = glm::clamp(glm::dot(a, b) / (la * lb), -1.0f, 1.0f);
             return glm::degrees(glm::acos(c));
+        }
+
+        // Planar surface area of an Area polygon, treating the points as a
+        // closed loop (the last vertex connects back to the first). Uses
+        // Newell's method, so it returns the true area for any planar polygon
+        // regardless of orientation and degrades gracefully (projected area)
+        // for slightly non-planar input. Returns 0 for fewer than 3 points.
+        float area() const {
+            const size_t count = points.size();
+            if (count < 3) return 0.0f;
+            glm::vec3 n(0.0f);
+            for (size_t i = 0; i < count; i++) {
+                const glm::vec3& cur = points[i];
+                const glm::vec3& nxt = points[(i + 1) % count];
+                n.x += (cur.y - nxt.y) * (cur.z + nxt.z);
+                n.y += (cur.z - nxt.z) * (cur.x + nxt.x);
+                n.z += (cur.x - nxt.x) * (cur.y + nxt.y);
+            }
+            return glm::length(n) * 0.5f;
+        }
+
+        // Perimeter of the closed Area polygon (total length plus the closing
+        // segment back to the first vertex). Returns 0 for fewer than 3 points.
+        float perimeter() const {
+            const size_t count = points.size();
+            if (count < 3) return 0.0f;
+            float len = totalLength();
+            len += glm::length(points.front() - points.back());
+            return len;
+        }
+
+        // Average of the vertices, used to place the area label at the polygon
+        // centre. Returns the origin for an empty point set.
+        glm::vec3 centroid() const {
+            if (points.empty()) return glm::vec3(0.0f);
+            glm::vec3 c(0.0f);
+            for (const auto& p : points) c += p;
+            return c / static_cast<float>(points.size());
         }
     };
 

--- a/StereoVista/headers/Tools/MeasurementTool.h
+++ b/StereoVista/headers/Tools/MeasurementTool.h
@@ -76,6 +76,10 @@ namespace Tools {
         // Format a world-space length with the configured unit scale/suffix.
         std::string formatLength(float worldLength) const;
 
+        // Format a world-space area with the configured unit scale/suffix
+        // (length scale is squared, suffix gets a superscript ²).
+        std::string formatArea(float worldArea) const;
+
         // Export all committed measurements to a CSV file (tidy/long format:
         // one row per point, with the measurement's summary value repeated).
         // Lengths are written in the configured display units. Returns false if
@@ -88,9 +92,14 @@ namespace Tools {
                         const glm::vec3& b, const glm::vec3& color) const;
         void appendPoint(std::vector<float>& out, const glm::vec3& p,
                          const glm::vec3& color) const;
+        // Triangulate a polygon (centroid fan) into the triangle vertex buffer
+        // so Area measurements show a translucent fill.
+        void appendFan(std::vector<float>& out, const std::vector<glm::vec3>& pts,
+                       const glm::vec3& color) const;
         void drawBuffers(const glm::mat4& projection, const glm::mat4& view,
                          const std::vector<float>& lineVerts,
-                         const std::vector<float>& pointVerts);
+                         const std::vector<float>& pointVerts,
+                         const std::vector<float>& triVerts);
 
         bool m_enabled = false;
         Engine::Measurement::Type m_mode = Engine::Measurement::Type::Distance;
@@ -107,6 +116,7 @@ namespace Tools {
         bool   m_initialized = false;
         GLuint m_lineVAO = 0, m_lineVBO = 0;
         GLuint m_pointVAO = 0, m_pointVBO = 0;
+        GLuint m_triVAO = 0, m_triVBO = 0;
         GLuint m_lineProgram = 0;
         GLuint m_pointProgram = 0;
     };

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -6498,12 +6498,12 @@ void renderMeasurementToolWindow() {
   }
   ImGui::SameLine();
   DrawHelpMarker("While enabled, LEFT CLICK places a measurement point at the "
-                 "3D cursor. RIGHT CLICK or ENTER finishes a polyline, "
+                 "3D cursor. RIGHT CLICK or ENTER finishes a polyline/polygon, "
                  "BACKSPACE removes the last point, DELETE cancels.");
 
   int mode = static_cast<int>(measurementTool.getMode());
   const char *modeNames[] = {"Distance (polyline)", "Angle (3 points)",
-                             "Point (coordinates)"};
+                             "Point (coordinates)", "Area (polygon)"};
   if (ImGui::Combo("Mode", &mode, modeNames, IM_ARRAYSIZE(modeNames))) {
     measurementTool.setMode(static_cast<Engine::Measurement::Type>(mode));
   }
@@ -6522,6 +6522,13 @@ void renderMeasurementToolWindow() {
         active.points.size() >= 2) {
       ImGui::Text("Length so far: %s",
                   measurementTool.formatLength(active.totalLength()).c_str());
+    }
+    if (active.type == Engine::Measurement::Type::Area &&
+        active.points.size() >= 3) {
+      ImGui::Text("Area so far: %s",
+                  measurementTool.formatArea(active.area()).c_str());
+      ImGui::Text("Perimeter: %s",
+                  measurementTool.formatLength(active.perimeter()).c_str());
     }
     if (ImGui::Button("Finish", ImVec2(100, 0))) {
       measurementTool.finishActive();
@@ -6594,6 +6601,9 @@ void renderMeasurementToolWindow() {
                    m.points[0].y, m.points[0].z);
           value = buf;
         }
+        break;
+      case Engine::Measurement::Type::Area:
+        value = measurementTool.formatArea(m.area());
         break;
       case Engine::Measurement::Type::Distance:
       default:
@@ -7347,6 +7357,12 @@ static void drawMeasurementLabels() {
         drawLabel(m.points[0], buf, color);
       }
       break;
+    case Engine::Measurement::Type::Area:
+      if (m.points.size() >= 3) {
+        drawLabel(m.centroid(),
+                  measurementTool.formatArea(m.area()), color);
+      }
+      break;
     case Engine::Measurement::Type::Distance:
     default: {
       const size_t segments = m.points.size() >= 2 ? m.points.size() - 1 : 0;
@@ -7390,6 +7406,13 @@ static void drawMeasurementLabels() {
         char buf[32];
         snprintf(buf, sizeof(buf), "%.1f\xC2\xB0", tmp.angleDegrees());
         drawLabel(tmp.points[1], buf, liveColor);
+      } else if (active.type == Engine::Measurement::Type::Area &&
+                 active.points.size() >= 2) {
+        // Live area preview with the cursor closing the polygon.
+        Engine::Measurement tmp = active;
+        tmp.points.push_back(preview);
+        drawLabel(tmp.centroid(),
+                  measurementTool.formatArea(tmp.area()), liveColor);
       } else if (active.type == Engine::Measurement::Type::Distance) {
         const float len = glm::length(preview - active.points.back());
         drawLabel((active.points.back() + preview) * 0.5f,

--- a/StereoVista/src/Plugins/MeasurementPlugin.cpp
+++ b/StereoVista/src/Plugins/MeasurementPlugin.cpp
@@ -17,7 +17,7 @@ PluginInfo MeasurementPlugin::info() const {
     PluginInfo meta;
     meta.id          = "stereovista.measurement";
     meta.name        = "Measure";
-    meta.description = "Measure distances, angles and coordinates in the scene.";
+    meta.description = "Measure distances, angles, areas and coordinates in the scene.";
     meta.version     = "1.0.0";
     meta.category    = PluginCategory::Tool;
     meta.shortcut    = "M";

--- a/StereoVista/src/Tools/MeasurementTool.cpp
+++ b/StereoVista/src/Tools/MeasurementTool.cpp
@@ -134,6 +134,7 @@ void main() {
 
         makeBuffers(m_lineVAO, m_lineVBO);
         makeBuffers(m_pointVAO, m_pointVBO);
+        makeBuffers(m_triVAO, m_triVBO);
 
         m_lineProgram = compileProgram(kLineVertexSrc, kLineFragmentSrc, "line");
         m_pointProgram = compileProgram(kPointVertexSrc, kPointFragmentSrc, "point");
@@ -146,6 +147,8 @@ void main() {
         if (m_lineVBO) { glDeleteBuffers(1, &m_lineVBO); m_lineVBO = 0; }
         if (m_pointVAO) { glDeleteVertexArrays(1, &m_pointVAO); m_pointVAO = 0; }
         if (m_pointVBO) { glDeleteBuffers(1, &m_pointVBO); m_pointVBO = 0; }
+        if (m_triVAO) { glDeleteVertexArrays(1, &m_triVAO); m_triVAO = 0; }
+        if (m_triVBO) { glDeleteBuffers(1, &m_triVBO); m_triVBO = 0; }
         if (m_lineProgram) { glDeleteProgram(m_lineProgram); m_lineProgram = 0; }
         if (m_pointProgram) { glDeleteProgram(m_pointProgram); m_pointProgram = 0; }
         m_initialized = false;
@@ -174,7 +177,8 @@ void main() {
             m_nameCounter++;
             const char* prefix =
                 (m_mode == Engine::Measurement::Type::Angle) ? "Angle" :
-                (m_mode == Engine::Measurement::Type::Point) ? "Point" : "Distance";
+                (m_mode == Engine::Measurement::Type::Point) ? "Point" :
+                (m_mode == Engine::Measurement::Type::Area)  ? "Area"  : "Distance";
             m_active.name = std::string(prefix) + " " + std::to_string(m_nameCounter);
             m_hasActive = true;
         }
@@ -194,6 +198,7 @@ void main() {
         if (!m_hasActive) return;
         const size_t required =
             (m_active.type == Engine::Measurement::Type::Angle) ? 3 :
+            (m_active.type == Engine::Measurement::Type::Area)  ? 3 :
             (m_active.type == Engine::Measurement::Type::Point) ? 1 : 2;
         if (m_active.points.size() >= required) {
             commitActive();
@@ -242,6 +247,15 @@ void main() {
         return buf;
     }
 
+    std::string MeasurementTool::formatArea(float worldArea) const {
+        char buf[64];
+        // Area scales with the square of the length unit; "\xC2\xB2" is the
+        // UTF-8 superscript two so the suffix reads e.g. "m²".
+        std::snprintf(buf, sizeof(buf), "%.3f %s\xC2\xB2",
+                      worldArea * unitScale * unitScale, unitSuffix.c_str());
+        return buf;
+    }
+
     bool MeasurementTool::exportToCSV(const std::string& path) const {
         std::ofstream file(path, std::ios::out | std::ios::trunc);
         if (!file.is_open()) {
@@ -268,13 +282,15 @@ void main() {
             for (const auto& m : *m_measurements) {
                 const char* typeName =
                     (m.type == Engine::Measurement::Type::Angle) ? "Angle" :
-                    (m.type == Engine::Measurement::Type::Point) ? "Point" : "Distance";
+                    (m.type == Engine::Measurement::Type::Point) ? "Point" :
+                    (m.type == Engine::Measurement::Type::Area)  ? "Area"  : "Distance";
 
                 // Summary value + unit, depending on measurement type. Lengths
                 // are converted to the configured display units; points have no
                 // scalar summary (their coordinates are the value).
                 char summary[48] = "";
                 const char* unit = "";
+                std::string areaUnit; // backing store for the squared-unit suffix
                 if (m.type == Engine::Measurement::Type::Distance) {
                     std::snprintf(summary, sizeof(summary), "%.6f",
                                   m.totalLength() * unitScale);
@@ -282,6 +298,11 @@ void main() {
                 } else if (m.type == Engine::Measurement::Type::Angle) {
                     std::snprintf(summary, sizeof(summary), "%.4f", m.angleDegrees());
                     unit = "deg";
+                } else if (m.type == Engine::Measurement::Type::Area) {
+                    std::snprintf(summary, sizeof(summary), "%.6f",
+                                  m.area() * unitScale * unitScale);
+                    areaUnit = unitSuffix + "^2"; // plain ASCII for spreadsheets
+                    unit = areaUnit.c_str();
                 }
 
                 if (m.points.empty()) {
@@ -315,12 +336,32 @@ void main() {
         out.insert(out.end(), { p.x, p.y, p.z, color.r, color.g, color.b });
     }
 
+    void MeasurementTool::appendFan(std::vector<float>& out,
+                                    const std::vector<glm::vec3>& pts,
+                                    const glm::vec3& color) const {
+        if (pts.size() < 3) return;
+        glm::vec3 c(0.0f);
+        for (const auto& p : pts) c += p;
+        c /= static_cast<float>(pts.size());
+        // Fan from the centroid so the fill covers convex polygons fully and
+        // star-shaped ones reasonably; the fill is purely illustrative.
+        for (size_t i = 0; i < pts.size(); i++) {
+            const glm::vec3& a = pts[i];
+            const glm::vec3& b = pts[(i + 1) % pts.size()];
+            out.insert(out.end(), {
+                c.x, c.y, c.z, color.r, color.g, color.b,
+                a.x, a.y, a.z, color.r, color.g, color.b,
+                b.x, b.y, b.z, color.r, color.g, color.b });
+        }
+    }
+
     void MeasurementTool::render(const glm::mat4& projection, const glm::mat4& view,
                                  const glm::vec3* previewPoint) {
         if (!m_initialized) initialize();
 
         std::vector<float> lineVerts;
         std::vector<float> pointVerts;
+        std::vector<float> triVerts;
 
         // Committed measurements (scene data)
         if (m_measurements) {
@@ -328,6 +369,11 @@ void main() {
                 if (!m.visible) continue;
                 for (size_t i = 1; i < m.points.size(); i++)
                     appendLine(lineVerts, m.points[i - 1], m.points[i], m.color);
+                // Area polygons close back to the first vertex and get a fill.
+                if (m.type == Engine::Measurement::Type::Area && m.points.size() >= 3) {
+                    appendLine(lineVerts, m.points.back(), m.points.front(), m.color);
+                    appendFan(triVerts, m.points, m.color);
+                }
                 for (const auto& p : m.points)
                     appendPoint(pointVerts, p, m.color);
             }
@@ -347,20 +393,37 @@ void main() {
             m_previewPoint = *previewPoint;
             m_previewValid = true;
             if (m_hasActive && !m_active.points.empty()) {
-                appendLine(lineVerts, m_active.points.back(), m_previewPoint,
-                           glm::mix(activeColor, glm::vec3(1.0f), 0.5f));
+                const glm::vec3 previewColor = glm::mix(activeColor, glm::vec3(1.0f), 0.5f);
+                appendLine(lineVerts, m_active.points.back(), m_previewPoint, previewColor);
+                // For an in-progress area, also rubber-band the closing edge and
+                // preview-fill the polygon the cursor is sketching.
+                if (m_active.type == Engine::Measurement::Type::Area &&
+                    m_active.points.size() >= 2) {
+                    appendLine(lineVerts, m_previewPoint, m_active.points.front(),
+                               previewColor);
+                    std::vector<glm::vec3> ghost = m_active.points;
+                    ghost.push_back(m_previewPoint);
+                    appendFan(triVerts, ghost, activeColor);
+                }
             }
             appendPoint(pointVerts, m_previewPoint, glm::vec3(1.0f));
+        } else if (m_hasActive && m_active.type == Engine::Measurement::Type::Area &&
+                   m_active.points.size() >= 3) {
+            // No live cursor: still close + fill the placed area outline.
+            appendLine(lineVerts, m_active.points.back(), m_active.points.front(),
+                       activeColor);
+            appendFan(triVerts, m_active.points, activeColor);
         }
 
-        if (lineVerts.empty() && pointVerts.empty()) return;
+        if (lineVerts.empty() && pointVerts.empty() && triVerts.empty()) return;
 
-        drawBuffers(projection, view, lineVerts, pointVerts);
+        drawBuffers(projection, view, lineVerts, pointVerts, triVerts);
     }
 
     void MeasurementTool::drawBuffers(const glm::mat4& projection, const glm::mat4& view,
                                       const std::vector<float>& lineVerts,
-                                      const std::vector<float>& pointVerts) {
+                                      const std::vector<float>& pointVerts,
+                                      const std::vector<float>& triVerts) {
         // Save the GL state we touch.
         GLint prevDepthFunc = GL_LESS;
         glGetIntegerv(GL_DEPTH_FUNC, &prevDepthFunc);
@@ -368,16 +431,34 @@ void main() {
         glGetBooleanv(GL_DEPTH_WRITEMASK, &prevDepthMask);
         const GLboolean prevBlend = glIsEnabled(GL_BLEND);
         const GLboolean prevPointSize = glIsEnabled(GL_PROGRAM_POINT_SIZE);
+        const GLboolean prevCull = glIsEnabled(GL_CULL_FACE);
 
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         glEnable(GL_PROGRAM_POINT_SIZE);
+        // Area fills are double-sided; never let back-face culling drop them.
+        glDisable(GL_CULL_FACE);
         // Overlay must never write depth: the cursor system samples scene depth
         // from this buffer.
         glDepthMask(GL_FALSE);
         glLineWidth(lineWidth);
 
         const glm::mat4 viewProj = projection * view;
+
+        // Translucent area fill, drawn under the outlines/markers.
+        auto drawFill = [&](float alpha) {
+            if (triVerts.empty()) return;
+            glUseProgram(m_lineProgram);
+            glUniformMatrix4fv(glGetUniformLocation(m_lineProgram, "uViewProj"),
+                               1, GL_FALSE, &viewProj[0][0]);
+            glUniform1f(glGetUniformLocation(m_lineProgram, "uAlpha"), alpha);
+            glBindVertexArray(m_triVAO);
+            glBindBuffer(GL_ARRAY_BUFFER, m_triVBO);
+            glBufferData(GL_ARRAY_BUFFER,
+                         static_cast<GLsizeiptr>(triVerts.size() * sizeof(float)),
+                         triVerts.data(), GL_DYNAMIC_DRAW);
+            glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(triVerts.size() / 6));
+        };
 
         auto drawPass = [&](float alpha) {
             if (!lineVerts.empty()) {
@@ -410,12 +491,14 @@ void main() {
 
         // Pass 1: normally depth-tested, fully opaque.
         glDepthFunc(GL_LEQUAL);
+        drawFill(0.18f);
         drawPass(1.0f);
 
         // Pass 2: occluded parts re-drawn ghosted so measurements stay legible
         // through geometry.
         if (xRay) {
             glDepthFunc(GL_GREATER);
+            drawFill(0.07f);
             drawPass(0.22f);
         }
 
@@ -424,6 +507,7 @@ void main() {
         glDepthMask(prevDepthMask);
         if (!prevBlend) glDisable(GL_BLEND);
         if (!prevPointSize) glDisable(GL_PROGRAM_POINT_SIZE);
+        if (prevCull) glEnable(GL_CULL_FACE);
         glBindVertexArray(0);
         glBindBuffer(GL_ARRAY_BUFFER, 0);
         glUseProgram(0);


### PR DESCRIPTION
Adds a fourth measurement mode that computes the planar surface area of a
user-drawn polygon on a model or point cloud, complementing the existing
Distance, Angle and Point modes.

- Engine::Measurement gains area() (Newell's method, robust to orientation
  and slightly non-planar input), perimeter() (closed loop), and centroid()
  helpers; the Type enum gets Area = 3.
- MeasurementTool: Area polygons auto-name "Area N", require >= 3 points to
  finish, close back to the first vertex, and render a translucent
  centroid-fan fill (new triangle VAO/VBO, drawn under the outline with
  back-face culling disabled and restored). formatArea() scales by the
  square of the unit and appends a superscript-two suffix.
- CSV export writes Area rows with the squared-unit suffix.
- GUI: new "Area (polygon)" mode, live area/perimeter readout while drawing,
  area value in the measurement list, and a centroid area label (committed
  and live-preview) in the world-space label pass.

Areas persist with the scene automatically (the measurement type already
round-trips as an int through SceneManager).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018brqinQGpz6NeaycrLWtty