### PR TITLE
Overhaul scene save/load: robustness, environment persistence, Scene Manager UI

### DIFF
--- a/StereoVista/headers/Core/SceneManager.h
+++ b/StereoVista/headers/Core/SceneManager.h
@@ -9,6 +9,82 @@
 
 namespace Engine {
 
+    // Current on-disk scene format version. Bumped whenever the schema changes
+    // so loadScene can apply backward-compatible defaults for older files.
+    //   v1: original (untagged) format - models / point clouds / lights /
+    //       measurements / clip planes / camera.
+    //   v2: adds a "formatVersion" tag, a "metadata" header, an optional
+    //       "environment" block (skybox + lighting mode), and a serialized sun.
+    constexpr int kSceneFormatVersion = 2;
+
+    // Human-readable / bookkeeping metadata stored in the scene header. All
+    // fields are optional; timestamps are ISO-8601-ish strings produced at save
+    // time and round-trip through load so "created" is preserved.
+    struct SceneMetadata {
+        std::string description;
+        std::string author;
+        std::string createdAt;   // first time the scene was saved
+        std::string modifiedAt;  // most recent save
+        std::string appVersion;  // app build that wrote the file
+    };
+
+    // Per-scene environment / lighting settings persisted alongside geometry so
+    // a scene reopens looking the way it was authored. `present` records whether
+    // the loaded file actually contained this block (older v1 files do not).
+    struct SceneEnvironment {
+        bool present = false;
+        int  lightingMode = 0;          // GUI::LightingMode
+        int  skyboxType = 1;            // GUI::SkyboxType (HDR default)
+        glm::vec3 skyboxSolidColor     = glm::vec3(0.2f, 0.3f, 0.4f);
+        glm::vec3 skyboxGradientTop    = glm::vec3(0.1f, 0.1f, 0.3f);
+        glm::vec3 skyboxGradientBottom = glm::vec3(0.7f, 0.7f, 1.0f);
+        int       selectedCubemap      = 0;
+        std::string skyboxHdrPath;
+        float     skyboxExposure       = 0.2f;
+    };
+
+    // Controls which optional blocks saveScene writes. Geometry (models, point
+    // clouds) is always written; everything else is opt-out.
+    struct SceneSaveOptions {
+        bool includeCamera       = true;  // viewpoint
+        bool includeLighting     = true;  // sun + point/spot lights
+        bool includeEnvironment  = true;  // skybox + lighting mode
+        bool includeMeasurements = true;
+        bool includeClipPlanes   = true;
+        bool compact             = false; // minified JSON (no indentation)
+    };
+
+    // Lightweight scene header, read by loadSceneInfo without loading geometry.
+    // Used to populate the recent-scenes list and the Scene Manager preview.
+    struct SceneInfo {
+        bool valid = false;
+        std::string path;
+        int formatVersion = 0;
+        SceneMetadata metadata;
+        int modelCount = 0;
+        int pointCloudCount = 0;
+        int pointLightCount = 0;
+        int spotLightCount = 0;
+        int measurementCount = 0;
+        int clipPlaneCount = 0;
+    };
+
+    // Per-load diagnostics. Populated when a non-null report is passed to
+    // loadScene so the UI can surface partial loads (e.g. missing assets)
+    // instead of silently dropping objects.
+    struct SceneLoadReport {
+        std::vector<std::string> warnings;
+        int modelsLoaded = 0,  modelsFailed = 0;
+        int pointCloudsLoaded = 0, pointCloudsFailed = 0;
+        int pointLightsLoaded = 0;
+        int spotLightsLoaded = 0;
+        int measurementsLoaded = 0;
+        int clipPlanesLoaded = 0;
+        int formatVersion = 0;
+
+        bool hasWarnings() const { return !warnings.empty(); }
+    };
+
     struct Scene {
         std::vector<Model> models;
         std::vector<PointCloud> pointClouds;
@@ -17,7 +93,13 @@ namespace Engine {
         std::vector<Measurement> measurements;
         std::vector<ClipPlane> clipPlanes;
         Camera::CameraState cameraState;
-        
+
+        // Persisted scene-level state (since v2).
+        Sun sun;
+        bool hasSun = false; // transient: did the loaded file carry a sun?
+        SceneEnvironment environment;
+        SceneMetadata metadata;
+
         // Default constructor with default camera state
         Scene() {
             // Initialize with default camera values matching Camera.h
@@ -27,12 +109,26 @@ namespace Engine {
             cameraState.yaw = -90.0f;
             cameraState.pitch = 0.0f;
             cameraState.zoom = 45.0f;
+
+            // Neutral default sun (overwritten by the live sun before save).
+            sun.direction = glm::vec3(-0.2f, -1.0f, -0.3f);
+            sun.color = glm::vec3(1.0f);
+            sun.intensity = 1.0f;
+            sun.enabled = true;
         }
     };
 
-    void saveScene(const std::string& filename, const Scene& scene, const Camera& camera);
+    void saveScene(const std::string& filename, const Scene& scene,
+                   const Camera& camera,
+                   const SceneSaveOptions& options = SceneSaveOptions());
     void saveModelData(const Model& model, const std::string& filename);
-    Scene loadScene(const std::string& filename, Camera& camera);
+    Scene loadScene(const std::string& filename, Camera& camera,
+                    SceneLoadReport* report = nullptr);
     void loadModelData(Model& model, const std::string& filename);
 
-} 
+    // Parse just the header of a .scene file (version, metadata, object counts)
+    // without loading geometry. Returns SceneInfo with valid == false if the
+    // file cannot be read or parsed.
+    SceneInfo loadSceneInfo(const std::string& filename);
+
+}

--- a/StereoVista/headers/Core/UndoManager.h
+++ b/StereoVista/headers/Core/UndoManager.h
@@ -76,6 +76,11 @@ namespace Engine {
         // (voxelizer, SpaceMouse bounds, selection state) can resynchronize.
         void setSceneChangedCallback(std::function<void()> callback);
 
+        // Invoked whenever the scene is mutated through the undo system
+        // (record / undo / redo). Used to flag the scene as having unsaved
+        // changes. Not called by clear() (which runs on scene load/shutdown).
+        void setModifiedCallback(std::function<void()> callback);
+
     private:
         UndoManager() = default;
         static constexpr size_t kMaxUndoEntries = 64;
@@ -83,6 +88,7 @@ namespace Engine {
         std::vector<std::unique_ptr<UndoCommand>> undoStack;
         std::vector<std::unique_ptr<UndoCommand>> redoStack;
         std::function<void()> sceneChangedCallback;
+        std::function<void()> modifiedCallback;
     };
 
     // -----------------------------------------------------------------------

--- a/StereoVista/headers/Gui/Gui.h
+++ b/StereoVista/headers/Gui/Gui.h
@@ -48,6 +48,7 @@ void renderBrushToolWindow();
 void renderMeasurementToolWindow();
 void renderClipPlaneToolWindow();
 void renderSnapshotsWindow();
+void renderSceneManagerWindow();
 void renderSunManipulationPanel();
 void renderModelManipulationPanel(Engine::Model &model, Engine::Shader *shader);
 void renderMeshManipulationPanel(Engine::Model &model, int meshIndex,

--- a/StereoVista/headers/Gui/GuiTypes.h
+++ b/StereoVista/headers/Gui/GuiTypes.h
@@ -369,6 +369,27 @@ struct ApplicationPreferences {
   // Scene loading behavior
   SceneLoadingBehavior sceneLoadingBehavior = SCENE_LOAD_ALWAYS_ASK;
 
+  // What optional data is written when saving a scene (mirrors
+  // Engine::SceneSaveOptions; kept here so GuiTypes stays independent of the
+  // SceneManager header). Geometry is always saved; these gate the extras.
+  struct SceneSaveSettings {
+    bool includeCamera = true;       // saved viewpoint
+    bool includeLighting = true;     // sun + point/spot lights
+    bool includeEnvironment = true;  // skybox + lighting mode
+    bool includeMeasurements = true; // measurement annotations
+    bool includeClipPlanes = true;   // section planes
+    bool includeSnapshots = true;    // named snapshots (metadata + thumbnails)
+    bool compact = false;            // minified JSON (smaller, less readable)
+  } sceneSaveSettings;
+
+  // When loading a scene that stored an environment block, apply its skybox /
+  // lighting mode to the live session. Off keeps the current environment.
+  bool applySceneEnvironmentOnLoad = true;
+
+  // Most-recently-used scene files (newest first), surfaced in the File menu
+  // and the Scene Manager panel. Capped to a small number on insert.
+  std::vector<std::string> recentScenes;
+
   // Model Import Settings
   struct ModelImportSettings {
     bool flipUVs = false;        // Toggle UV coordinate flipping

--- a/StereoVista/src/Core/SceneManager.cpp
+++ b/StereoVista/src/Core/SceneManager.cpp
@@ -6,12 +6,83 @@
 #include <filesystem>
 #include <unordered_set>
 #include <utility>
+#include <ctime>
 
 using json = nlohmann::json;
 
 namespace Engine {
 
-    void saveScene(const std::string& filename, const Scene& scene, const Camera& camera) {
+    namespace {
+        // Local "now" as an ISO-8601-ish string (YYYY-MM-DD HH:MM:SS). Used for
+        // the scene's created/modified metadata timestamps.
+        std::string currentTimestamp() {
+            std::time_t t = std::time(nullptr);
+            std::tm tmBuf{};
+#if defined(_WIN32)
+            localtime_s(&tmBuf, &t);
+#else
+            localtime_r(&t, &tmBuf);
+#endif
+            char buf[32];
+            std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &tmBuf);
+            return std::string(buf);
+        }
+
+        // Read a 3-component array from json into a glm::vec3, leaving the
+        // destination untouched if the field is missing or malformed.
+        void readVec3(const json& parent, const char* key, glm::vec3& out) {
+            if (parent.contains(key) && parent[key].is_array() &&
+                parent[key].size() == 3) {
+                out = glm::vec3(parent[key][0].get<float>(),
+                                parent[key][1].get<float>(),
+                                parent[key][2].get<float>());
+            }
+        }
+
+        // Write `content` to `target` atomically: stream to a sibling .tmp file,
+        // flush, then rename over the destination. A crash mid-write therefore
+        // leaves the previous scene file intact instead of a truncated one.
+        void writeFileAtomic(const std::filesystem::path& target,
+                             const std::string& content) {
+            std::filesystem::path tmp = target;
+            tmp += ".tmp";
+            {
+                std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
+                if (!out.is_open()) {
+                    throw std::runtime_error("Failed to create temp file: " +
+                                             tmp.string());
+                }
+                out.write(content.data(),
+                          static_cast<std::streamsize>(content.size()));
+                out.flush();
+                if (!out) {
+                    throw std::runtime_error("Failed while writing: " +
+                                             tmp.string());
+                }
+            }
+            std::error_code ec;
+            std::filesystem::rename(tmp, target, ec);
+            if (ec) {
+                // Some platforms refuse rename over an existing file; fall back
+                // to remove + rename, then to a direct copy.
+                std::filesystem::remove(target, ec);
+                std::filesystem::rename(tmp, target, ec);
+                if (ec) {
+                    std::filesystem::copy_file(
+                        tmp, target,
+                        std::filesystem::copy_options::overwrite_existing, ec);
+                    std::filesystem::remove(tmp, ec);
+                    if (ec) {
+                        throw std::runtime_error(
+                            "Failed to finalize scene file: " + target.string());
+                    }
+                }
+            }
+        }
+    } // namespace
+
+    void saveScene(const std::string& filename, const Scene& scene,
+                   const Camera& camera, const SceneSaveOptions& options) {
         try {
             // Ensure filename has .scene extension
             std::filesystem::path scenePath(filename);
@@ -29,7 +100,29 @@ namespace Engine {
             // Create scene data json
             json sceneJson;
 
+            // Format version + metadata header. Preserve the original creation
+            // timestamp if the scene already had one (round-tripped on load).
+            sceneJson["formatVersion"] = kSceneFormatVersion;
+            json metaJson;
+            metaJson["description"] = scene.metadata.description;
+            metaJson["author"] = scene.metadata.author;
+            metaJson["createdAt"] = scene.metadata.createdAt.empty()
+                                        ? currentTimestamp()
+                                        : scene.metadata.createdAt;
+            metaJson["modifiedAt"] = currentTimestamp();
+            metaJson["appVersion"] = "StereoVista";
+            metaJson["counts"] = {
+                {"models", scene.models.size()},
+                {"pointClouds", scene.pointClouds.size()},
+                {"pointLights", scene.pointLights.size()},
+                {"spotLights", scene.spotLights.size()},
+                {"measurements", scene.measurements.size()},
+                {"clipPlanes", scene.clipPlanes.size()},
+            };
+            sceneJson["metadata"] = metaJson;
+
             // Save current camera state
+            if (options.includeCamera) {
             auto cameraState = camera.GetState();
             sceneJson["camera"]["position"] = {cameraState.position.x, cameraState.position.y, cameraState.position.z};
             sceneJson["camera"]["front"] = {cameraState.front.x, cameraState.front.y, cameraState.front.z};
@@ -38,6 +131,7 @@ namespace Engine {
             sceneJson["camera"]["pitch"] = cameraState.pitch;
             sceneJson["camera"]["zoom"] = cameraState.zoom;
             sceneJson["camera"]["orientation"] = {cameraState.orientation.x, cameraState.orientation.y, cameraState.orientation.z, cameraState.orientation.w};
+            }
 
             // Save models
             json modelsJson = json::array();
@@ -238,6 +332,7 @@ namespace Engine {
             sceneJson["pointClouds"] = pointCloudsJson;
 
             // Save measurements (world-space annotation points)
+            if (options.includeMeasurements) {
             json measurementsJson = json::array();
             for (const auto& measurement : scene.measurements) {
                 json measurementJson;
@@ -253,8 +348,10 @@ namespace Engine {
                 measurementsJson.push_back(measurementJson);
             }
             sceneJson["measurements"] = measurementsJson;
+            }
 
             // Save section / clip planes (world-space)
+            if (options.includeClipPlanes) {
             json clipPlanesJson = json::array();
             for (const auto& plane : scene.clipPlanes) {
                 json planeJson;
@@ -266,6 +363,17 @@ namespace Engine {
                 clipPlanesJson.push_back(planeJson);
             }
             sceneJson["clipPlanes"] = clipPlanesJson;
+            }
+
+            // Save lighting (sun + point/spot lights)
+            if (options.includeLighting) {
+            // Sun (directional key light)
+            json sunJson;
+            sunJson["direction"] = { scene.sun.direction.x, scene.sun.direction.y, scene.sun.direction.z };
+            sunJson["color"] = { scene.sun.color.x, scene.sun.color.y, scene.sun.color.z };
+            sunJson["intensity"] = scene.sun.intensity;
+            sunJson["enabled"] = scene.sun.enabled;
+            sceneJson["sun"] = sunJson;
 
             // Save point lights
             json pointLightsJson = json::array();
@@ -274,6 +382,9 @@ namespace Engine {
                 pointLightJson["position"] = { pointLight.position.x, pointLight.position.y, pointLight.position.z };
                 pointLightJson["color"] = { pointLight.color.x, pointLight.color.y, pointLight.color.z };
                 pointLightJson["intensity"] = pointLight.intensity;
+                pointLightJson["linear"] = pointLight.linear;
+                pointLightJson["quadratic"] = pointLight.quadratic;
+                pointLightJson["castShadows"] = pointLight.castShadows;
                 pointLightsJson.push_back(pointLightJson);
             }
             sceneJson["pointLights"] = pointLightsJson;
@@ -288,9 +399,32 @@ namespace Engine {
                 spotLightJson["intensity"] = spotLight.intensity;
                 spotLightJson["innerCutOff"] = spotLight.innerCutOff;
                 spotLightJson["outerCutOff"] = spotLight.outerCutOff;
+                spotLightJson["castShadows"] = spotLight.castShadows;
                 spotLightsJson.push_back(spotLightJson);
             }
             sceneJson["spotLights"] = spotLightsJson;
+            }
+
+            // Save environment (skybox + lighting mode) so the scene reopens
+            // with the look it was authored in.
+            if (options.includeEnvironment) {
+                json envJson;
+                envJson["lightingMode"] = scene.environment.lightingMode;
+                envJson["skyboxType"] = scene.environment.skyboxType;
+                envJson["skyboxSolidColor"] = { scene.environment.skyboxSolidColor.r,
+                                                scene.environment.skyboxSolidColor.g,
+                                                scene.environment.skyboxSolidColor.b };
+                envJson["skyboxGradientTop"] = { scene.environment.skyboxGradientTop.r,
+                                                 scene.environment.skyboxGradientTop.g,
+                                                 scene.environment.skyboxGradientTop.b };
+                envJson["skyboxGradientBottom"] = { scene.environment.skyboxGradientBottom.r,
+                                                    scene.environment.skyboxGradientBottom.g,
+                                                    scene.environment.skyboxGradientBottom.b };
+                envJson["selectedCubemap"] = scene.environment.selectedCubemap;
+                envJson["skyboxHdrPath"] = scene.environment.skyboxHdrPath;
+                envJson["skyboxExposure"] = scene.environment.skyboxExposure;
+                sceneJson["environment"] = envJson;
+            }
 
             std::cout << "\n=== Scene Save Summary ===" << std::endl;
             std::cout << "Models saved: " << scene.models.size() << std::endl;
@@ -300,8 +434,10 @@ namespace Engine {
             std::cout << "Scene directory: " << sceneDir << std::endl;
             std::cout << "========================\n" << std::endl;
 
-            // Write scene file with chunking support
-            std::string jsonStr = sceneJson.dump(4);
+            // Write scene file with chunking support. The compact option
+            // minifies the JSON (no indentation) to shrink large scene files.
+            std::string jsonStr = options.compact ? sceneJson.dump()
+                                                   : sceneJson.dump(4);
             const size_t maxChunkSize = 100 * 1024 * 1024; // 100MB chunks
 
             if (jsonStr.size() > maxChunkSize) {
@@ -310,29 +446,20 @@ namespace Engine {
 
                 for (size_t i = 0; i < numChunks; i++) {
                     std::string chunkFilename = scenePath.string() + "." + std::to_string(i);
-                    std::ofstream chunkFile(chunkFilename);
-                    if (!chunkFile.is_open()) {
-                        throw std::runtime_error("Failed to create scene chunk file: " + chunkFilename);
-                    }
-
                     size_t start = i * maxChunkSize;
                     size_t length = std::min(maxChunkSize, jsonStr.size() - start);
-                    chunkFile << jsonStr.substr(start, length);
+                    writeFileAtomic(chunkFilename, jsonStr.substr(start, length));
                 }
 
-                // Write metadata file
-                std::ofstream metaFile(scenePath);
-                json metaJson;
-                metaJson["numChunks"] = numChunks;
-                metaFile << std::setw(4) << metaJson << std::endl;
+                // Write metadata file (atomic) pointing at the chunk count.
+                json chunkMeta;
+                chunkMeta["numChunks"] = numChunks;
+                writeFileAtomic(scenePath, chunkMeta.dump(4));
             }
             else {
-                // Write single file
-                std::ofstream sceneFile(scenePath);
-                if (!sceneFile.is_open()) {
-                    throw std::runtime_error("Failed to create scene file: " + scenePath.string());
-                }
-                sceneFile << jsonStr;
+                // Write single file atomically (temp + rename) so a crash
+                // mid-save never corrupts the previously saved scene.
+                writeFileAtomic(scenePath, jsonStr);
             }
         }
         catch (const std::exception& e) {
@@ -340,11 +467,19 @@ namespace Engine {
         }
     }
 
-    Scene loadScene(const std::string& filename, Camera& camera) {
+    Scene loadScene(const std::string& filename, Camera& camera,
+                    SceneLoadReport* report) {
         Scene scene;
         json sceneJson;
         std::filesystem::path scenePath;
         std::filesystem::path sceneDir;
+
+        // Helper to record a warning both to the console and (if requested) to
+        // the caller's report so the UI can surface partial loads.
+        auto warn = [&](const std::string& msg) {
+            std::cerr << msg << std::endl;
+            if (report) report->warnings.push_back(msg);
+        };
 
         try {
             // Check if this is a chunked file
@@ -386,6 +521,44 @@ namespace Engine {
 
             // Check if scene directory exists (it may not exist for scenes with no external assets)
             if (!std::filesystem::exists(sceneDir)) {
+            }
+
+            // Format version (untagged v1 files default to 1).
+            int formatVersion = sceneJson.value("formatVersion", 1);
+            if (report) report->formatVersion = formatVersion;
+
+            // Metadata header (v2+).
+            if (sceneJson.contains("metadata") && sceneJson["metadata"].is_object()) {
+                const auto& m = sceneJson["metadata"];
+                scene.metadata.description = m.value("description", std::string());
+                scene.metadata.author = m.value("author", std::string());
+                scene.metadata.createdAt = m.value("createdAt", std::string());
+                scene.metadata.modifiedAt = m.value("modifiedAt", std::string());
+                scene.metadata.appVersion = m.value("appVersion", std::string());
+            }
+
+            // Environment block (v2+): skybox + lighting mode.
+            if (sceneJson.contains("environment") && sceneJson["environment"].is_object()) {
+                const auto& e = sceneJson["environment"];
+                scene.environment.present = true;
+                scene.environment.lightingMode = e.value("lightingMode", 0);
+                scene.environment.skyboxType = e.value("skyboxType", 1);
+                readVec3(e, "skyboxSolidColor", scene.environment.skyboxSolidColor);
+                readVec3(e, "skyboxGradientTop", scene.environment.skyboxGradientTop);
+                readVec3(e, "skyboxGradientBottom", scene.environment.skyboxGradientBottom);
+                scene.environment.selectedCubemap = e.value("selectedCubemap", 0);
+                scene.environment.skyboxHdrPath = e.value("skyboxHdrPath", std::string());
+                scene.environment.skyboxExposure = e.value("skyboxExposure", 0.2f);
+            }
+
+            // Sun (v2+).
+            if (sceneJson.contains("sun") && sceneJson["sun"].is_object()) {
+                const auto& s = sceneJson["sun"];
+                readVec3(s, "direction", scene.sun.direction);
+                readVec3(s, "color", scene.sun.color);
+                scene.sun.intensity = s.value("intensity", scene.sun.intensity);
+                scene.sun.enabled = s.value("enabled", scene.sun.enabled);
+                scene.hasSun = true;
             }
 
             // Load camera state if it exists in the scene
@@ -463,7 +636,8 @@ namespace Engine {
 
                             // Verify model file exists
                             if (!std::filesystem::exists(modelPath)) {
-                                std::cerr << "Error: Model file not found: " << modelPath << std::endl;
+                                warn("Model file not found: " + modelPath.string());
+                                if (report) report->modelsFailed++;
                                 continue;
                             }
 
@@ -481,7 +655,8 @@ namespace Engine {
                             std::cout << "Loading model from: " << modelPath << std::endl;
                             Model* loadedModel = Engine::loadModel(modelPath.string());
                             if (!loadedModel) {
-                                std::cerr << "Error: Failed to load model: " << modelPath << std::endl;
+                                warn("Failed to load model: " + modelPath.string());
+                                if (report) report->modelsFailed++;
                                 continue;
                             }
 
@@ -635,7 +810,8 @@ namespace Engine {
                         scene.models.push_back(model);
                     }
                     catch (const std::exception& e) {
-                        std::cerr << "Failed to load model: " << e.what() << std::endl;
+                        warn(std::string("Failed to load model: ") + e.what());
+                        if (report) report->modelsFailed++;
                     }
                 }
             }
@@ -679,15 +855,16 @@ namespace Engine {
                         pointCloud.sourceScenePath = filename;
 
                         if (!pointCloud.isLoaded()) {
-                            std::cerr << "Warning: point cloud '" << pointCloud.name
-                                      << "' loaded with no points (data file: " << pcPath << ")"
-                                      << std::endl;
+                            warn("Point cloud '" + pointCloud.name +
+                                 "' loaded with no points (data file: " +
+                                 pcPath.string() + ")");
                         }
 
                         scene.pointClouds.push_back(std::move(pointCloud));
                     }
                     catch (const std::exception& e) {
-                        std::cerr << "Failed to load point cloud: " << e.what() << std::endl;
+                        warn(std::string("Failed to load point cloud: ") + e.what());
+                        if (report) report->pointCloudsFailed++;
                     }
                 }
             }
@@ -786,6 +963,9 @@ namespace Engine {
                             pointLightJson["color"][2].get<float>()
                         );
                         pointLight.intensity = pointLightJson.value("intensity", 1.0f);
+                        pointLight.linear = pointLightJson.value("linear", pointLight.linear);
+                        pointLight.quadratic = pointLightJson.value("quadratic", pointLight.quadratic);
+                        pointLight.castShadows = pointLightJson.value("castShadows", true);
 
                         // Set source scene path for grouping in GUI
                         pointLight.sourceScenePath = filename;
@@ -821,6 +1001,7 @@ namespace Engine {
                         spotLight.intensity = spotLightJson.value("intensity", 1.0f);
                         spotLight.innerCutOff = spotLightJson.value("innerCutOff", 0.9f);
                         spotLight.outerCutOff = spotLightJson.value("outerCutOff", 0.82f);
+                        spotLight.castShadows = spotLightJson.value("castShadows", true);
 
                         // Set source scene path for grouping in GUI
                         spotLight.sourceScenePath = filename;
@@ -832,6 +1013,15 @@ namespace Engine {
                     }
                 }
             }
+            if (report) {
+                report->modelsLoaded = static_cast<int>(scene.models.size());
+                report->pointCloudsLoaded = static_cast<int>(scene.pointClouds.size());
+                report->pointLightsLoaded = static_cast<int>(scene.pointLights.size());
+                report->spotLightsLoaded = static_cast<int>(scene.spotLights.size());
+                report->measurementsLoaded = static_cast<int>(scene.measurements.size());
+                report->clipPlanesLoaded = static_cast<int>(scene.clipPlanes.size());
+            }
+
             std::cout << "\n=== Scene Load Summary ===" << std::endl;
             std::cout << "Models loaded: " << scene.models.size() << std::endl;
             std::cout << "Point clouds loaded: " << scene.pointClouds.size() << std::endl;
@@ -895,6 +1085,59 @@ namespace Engine {
         catch (const std::exception& e) {
             throw std::runtime_error("Failed to save model data: " + std::string(e.what()));
         }
+    }
+
+    SceneInfo loadSceneInfo(const std::string& filename) {
+        SceneInfo info;
+        info.path = filename;
+        try {
+            std::ifstream file(filename);
+            if (!file.is_open()) {
+                return info; // valid stays false
+            }
+
+            json sceneJson;
+            file >> sceneJson;
+
+            // Chunked scenes only store {"numChunks": N} in the header file; we
+            // intentionally do not stitch the (potentially huge) chunks back
+            // together just to preview counts.
+            if (sceneJson.contains("numChunks")) {
+                info.valid = true;
+                info.formatVersion = sceneJson.value("formatVersion", 1);
+                return info;
+            }
+
+            info.valid = true;
+            info.formatVersion = sceneJson.value("formatVersion", 1);
+
+            if (sceneJson.contains("metadata") && sceneJson["metadata"].is_object()) {
+                const auto& m = sceneJson["metadata"];
+                info.metadata.description = m.value("description", std::string());
+                info.metadata.author = m.value("author", std::string());
+                info.metadata.createdAt = m.value("createdAt", std::string());
+                info.metadata.modifiedAt = m.value("modifiedAt", std::string());
+                info.metadata.appVersion = m.value("appVersion", std::string());
+            }
+
+            auto arraySize = [&](const char* key) -> int {
+                return (sceneJson.contains(key) && sceneJson[key].is_array())
+                           ? static_cast<int>(sceneJson[key].size())
+                           : 0;
+            };
+            info.modelCount = arraySize("models");
+            info.pointCloudCount = arraySize("pointClouds");
+            info.pointLightCount = arraySize("pointLights");
+            info.spotLightCount = arraySize("spotLights");
+            info.measurementCount = arraySize("measurements");
+            info.clipPlaneCount = arraySize("clipPlanes");
+        }
+        catch (const std::exception& e) {
+            std::cerr << "Failed to read scene info for '" << filename
+                      << "': " << e.what() << std::endl;
+            info.valid = false;
+        }
+        return info;
     }
 
 }  // namespace Engine

--- a/StereoVista/src/Core/UndoManager.cpp
+++ b/StereoVista/src/Core/UndoManager.cpp
@@ -30,6 +30,7 @@ namespace Engine {
         }
         // A new action invalidates everything that was undone before it.
         redoStack.clear();
+        if (modifiedCallback) modifiedCallback();
     }
 
     bool UndoManager::undo() {
@@ -40,6 +41,7 @@ namespace Engine {
         std::cout << "Undo: " << command->description() << std::endl;
         redoStack.push_back(std::move(command));
         if (sceneChangedCallback) sceneChangedCallback();
+        if (modifiedCallback) modifiedCallback();
         return true;
     }
 
@@ -51,6 +53,7 @@ namespace Engine {
         std::cout << "Redo: " << command->description() << std::endl;
         undoStack.push_back(std::move(command));
         if (sceneChangedCallback) sceneChangedCallback();
+        if (modifiedCallback) modifiedCallback();
         return true;
     }
 
@@ -69,6 +72,10 @@ namespace Engine {
 
     void UndoManager::setSceneChangedCallback(std::function<void()> callback) {
         sceneChangedCallback = std::move(callback);
+    }
+
+    void UndoManager::setModifiedCallback(std::function<void()> callback) {
+        modifiedCallback = std::move(callback);
     }
 
     // ======================================================================

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -1275,9 +1275,12 @@ static void SceneReportToast(const std::string &sceneFile,
   GUI::ShowToast(std::string("Scene ") + verb + ": " + name,
                  GUI::ToastType::Success);
   int failed = report.modelsFailed + report.pointCloudsFailed;
-  if (failed > 0 || report.hasWarnings()) {
+  if (failed > 0) {
     GUI::ShowToast(std::to_string(failed) +
                        " object(s) could not be loaded - see log for details",
+                   GUI::ToastType::Warning);
+  } else if (report.hasWarnings()) {
+    GUI::ShowToast("Scene loaded with warnings - see log for details",
                    GUI::ToastType::Warning);
   }
 }
@@ -1291,14 +1294,29 @@ static bool SceneSaveTo(const std::string &destination) {
     captureSceneEnvironment(currentScene);
     Engine::saveScene(destination, currentScene, camera,
                       SceneOptionsFromPrefs());
-    if (preferences.sceneSaveSettings.includeSnapshots)
-      Core::SnapshotManager::instance().saveToScene(destination);
 
     std::filesystem::path p(destination);
     if (p.extension() != ".scene")
       p.replace_extension(".scene");
+
+    if (preferences.sceneSaveSettings.includeSnapshots) {
+      Core::SnapshotManager::instance().saveToScene(p.string());
+    } else {
+      // Snapshot saving is off: drop any snapshot index left in this scene's
+      // folder so a later load doesn't restore stale snapshots.
+      std::error_code ec;
+      std::filesystem::remove(p.parent_path() / p.stem() / "snapshots.json", ec);
+    }
+
     g_currentScenePath = p.string();
     g_sceneDirty = false;
+    // Reflect the timestamps the file was actually written with so the Scene
+    // Manager panel shows them without needing a reload. Guard on a non-empty
+    // modifiedAt so a chunked scene (whose header carries no metadata) doesn't
+    // wipe the description/author the user just entered.
+    Engine::SceneInfo info = Engine::loadSceneInfo(g_currentScenePath);
+    if (info.valid && !info.metadata.modifiedAt.empty())
+      currentScene.metadata = info.metadata;
     SceneAddRecent(g_currentScenePath);
     GUI::UpdateWindowTitleForScene(g_currentScenePath);
     GUI::ShowToast("Scene saved: " + p.filename().string(),
@@ -7101,6 +7119,7 @@ void renderSceneManagerWindow() {
     row("Spot Lights", spotLights.size());
     row("Measurements", currentScene.measurements.size());
     row("Section Planes", currentScene.clipPlanes.size());
+    row("Snapshots", Core::SnapshotManager::instance().snapshots().size());
     ImGui::EndTable();
   }
 
@@ -7141,6 +7160,9 @@ void renderSceneManagerWindow() {
   changed |= ImGui::Checkbox("Measurements", &opt.includeMeasurements);
   changed |= ImGui::Checkbox("Section planes", &opt.includeClipPlanes);
   changed |= ImGui::Checkbox("Snapshots", &opt.includeSnapshots);
+  ImGui::SameLine();
+  DrawHelpMarker("Save named snapshots (metadata + thumbnails) into the "
+                 "scene folder so they reload with the scene.");
   changed |= ImGui::Checkbox("Compact (minified) JSON", &opt.compact);
   ImGui::SameLine();
   DrawHelpMarker("Write the scene's .scene file without indentation. Smaller "
@@ -7167,7 +7189,11 @@ void renderSceneManagerWindow() {
   if (preferences.recentScenes.empty()) {
     ImGui::TextDisabled("No recent scenes.");
   } else {
+    // Defer all mutating actions until after the loop: loading a scene calls
+    // SceneAddRecent(), which rewrites preferences.recentScenes and would
+    // invalidate the iterator / dangling `recent` reference mid-iteration.
     std::string toRemove;
+    std::string toLoad;
     bool clearAll = false;
     for (const auto &recent : preferences.recentScenes) {
       ImGui::PushID(recent.c_str());
@@ -7177,7 +7203,7 @@ void renderSceneManagerWindow() {
       if (!exists)
         ImGui::BeginDisabled();
       if (ImGui::Button("Load"))
-        SceneRequestLoad(recent);
+        toLoad = recent;
       if (!exists)
         ImGui::EndDisabled();
 
@@ -7205,6 +7231,8 @@ void renderSceneManagerWindow() {
       auto &r = preferences.recentScenes;
       r.erase(std::remove(r.begin(), r.end(), toRemove), r.end());
       savePreferences();
+    } else if (!toLoad.empty()) {
+      SceneRequestLoad(toLoad);
     }
   }
 

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -1220,6 +1220,269 @@ static void importLASFiles(const std::vector<std::string> &lasFiles) {
   updateSpaceMouseBounds();
 }
 
+// ===========================================================================
+// Scene file operations
+//
+// Shared by the File menu, the keyboard shortcuts and the Scene Manager window
+// so save / load / merge / new behave identically wherever they are invoked.
+// They operate on the live application globals (currentScene, lights, camera).
+// ===========================================================================
+
+// Live "current scene" bookkeeping owned by main.cpp.
+extern std::string g_currentScenePath;
+extern bool g_sceneDirty;
+extern bool showSceneManagerWindow;
+// Apply / capture the per-scene environment (skybox + lighting mode + sun).
+void applyLoadedSceneEnvironment(const Engine::Scene &scene);
+void captureSceneEnvironment(Engine::Scene &scene);
+
+// Insert `path` at the head of the recent-scenes list (newest first), removing
+// any earlier occurrence and capping the list. Persists preferences.
+static void SceneAddRecent(const std::string &path) {
+  if (path.empty())
+    return;
+  std::string normalized =
+      std::filesystem::path(path).lexically_normal().string();
+  auto &recents = preferences.recentScenes;
+  recents.erase(std::remove(recents.begin(), recents.end(), normalized),
+                recents.end());
+  recents.insert(recents.begin(), normalized);
+  constexpr size_t kMaxRecent = 12;
+  if (recents.size() > kMaxRecent)
+    recents.resize(kMaxRecent);
+  savePreferences();
+}
+
+// Build the engine save options from the user's preferences.
+static Engine::SceneSaveOptions SceneOptionsFromPrefs() {
+  Engine::SceneSaveOptions opt;
+  const auto &s = preferences.sceneSaveSettings;
+  opt.includeCamera = s.includeCamera;
+  opt.includeLighting = s.includeLighting;
+  opt.includeEnvironment = s.includeEnvironment;
+  opt.includeMeasurements = s.includeMeasurements;
+  opt.includeClipPlanes = s.includeClipPlanes;
+  opt.compact = s.compact;
+  return opt;
+}
+
+// Surface a load report as a toast: success with a count, plus a warning toast
+// when assets were missing / objects were dropped.
+static void SceneReportToast(const std::string &sceneFile,
+                             const Engine::SceneLoadReport &report,
+                             const char *verb) {
+  std::string name = std::filesystem::path(sceneFile).filename().string();
+  GUI::ShowToast(std::string("Scene ") + verb + ": " + name,
+                 GUI::ToastType::Success);
+  int failed = report.modelsFailed + report.pointCloudsFailed;
+  if (failed > 0 || report.hasWarnings()) {
+    GUI::ShowToast(std::to_string(failed) +
+                       " object(s) could not be loaded - see log for details",
+                   GUI::ToastType::Warning);
+  }
+}
+
+// Save the live scene to `destination`. Returns true on success. Updates the
+// current-scene path, clears the dirty flag and refreshes the recent list.
+static bool SceneSaveTo(const std::string &destination) {
+  try {
+    currentScene.pointLights = pointLights;
+    currentScene.spotLights = spotLights;
+    captureSceneEnvironment(currentScene);
+    Engine::saveScene(destination, currentScene, camera,
+                      SceneOptionsFromPrefs());
+    if (preferences.sceneSaveSettings.includeSnapshots)
+      Core::SnapshotManager::instance().saveToScene(destination);
+
+    std::filesystem::path p(destination);
+    if (p.extension() != ".scene")
+      p.replace_extension(".scene");
+    g_currentScenePath = p.string();
+    g_sceneDirty = false;
+    SceneAddRecent(g_currentScenePath);
+    GUI::UpdateWindowTitleForScene(g_currentScenePath);
+    GUI::ShowToast("Scene saved: " + p.filename().string(),
+                   GUI::ToastType::Success);
+    return true;
+  } catch (const std::exception &e) {
+    std::cerr << "Failed to save scene: " << e.what() << std::endl;
+    GUI::ShowToast(std::string("Failed to save scene: ") + e.what(),
+                   GUI::ToastType::Error);
+    return false;
+  }
+}
+
+// Prompt for a destination and save (Save As...). Returns true if saved.
+static bool SceneSaveAsDialog() {
+  std::string suggested =
+      g_currentScenePath.empty()
+          ? std::string("scene.scene")
+          : std::filesystem::path(g_currentScenePath).filename().string();
+  auto destination = pfd::save_file("Save scene as", suggested,
+                                    {"Scene Files", "*.scene", "All Files", "*"})
+                         .result();
+  if (destination.empty())
+    return false;
+  return SceneSaveTo(destination);
+}
+
+// Quick save (Ctrl+S): re-save to the current path, or fall back to Save As
+// when the scene has never been saved.
+static bool SceneQuickSave() {
+  if (g_currentScenePath.empty())
+    return SceneSaveAsDialog();
+  return SceneSaveTo(g_currentScenePath);
+}
+
+// Replace the live scene with the contents of `sceneFile`.
+static void SceneReplaceFrom(const std::string &sceneFile) {
+  try {
+    // Recorded undo entries reference objects by index, which no longer match
+    // once a scene file replaces the containers.
+    Engine::UndoManager::instance().clear();
+
+    currentScene.models.clear();
+    currentScene.pointClouds.clear();
+    pointLights.clear();
+    spotLights.clear();
+    currentSelectedType = SelectedType::None;
+    currentSelectedIndex = -1;
+    currentSelectedMeshIndex = -1;
+
+    Engine::SceneLoadReport report;
+    currentScene = Engine::loadScene(sceneFile, camera, &report);
+    pointLights = currentScene.pointLights;
+    for (auto &pl : pointLights)
+      pl.castShadows = true;
+    spotLights = currentScene.spotLights;
+
+    Core::SnapshotManager::instance().loadFromScene(sceneFile);
+    applyLoadedSceneEnvironment(currentScene);
+
+    for (auto &model : currentScene.models) {
+      glm::vec3 targetScale = model.scale;
+      if (preferences.enableSpawnAnimation)
+        model.startSpawnAnimation(targetScale, 1.1f);
+    }
+    currentSelectedIndex = currentScene.models.empty() ? -1 : 0;
+    updateSpaceMouseBounds();
+    if (voxelizer)
+      voxelizer->markDirty();
+
+    g_currentScenePath = sceneFile;
+    g_sceneDirty = false;
+    SceneAddRecent(sceneFile);
+    GUI::UpdateWindowTitleForScene(sceneFile);
+    SceneReportToast(sceneFile, report, "loaded");
+  } catch (const std::exception &e) {
+    std::cerr << "Failed to load scene: " << e.what() << std::endl;
+    GUI::ShowToast(std::string("Failed to load scene: ") + e.what(),
+                   GUI::ToastType::Error);
+  }
+}
+
+// Merge the contents of `sceneFile` into the live scene (keep existing).
+static void SceneMergeFrom(const std::string &sceneFile) {
+  try {
+    // Bulk merges are not tracked, so drop the index-based undo history.
+    Engine::UndoManager::instance().clear();
+
+    Engine::SceneLoadReport report;
+    Engine::Scene newScene = Engine::loadScene(sceneFile, camera, &report);
+
+    for (auto &model : newScene.models) {
+      glm::vec3 targetScale = model.scale;
+      if (preferences.enableSpawnAnimation)
+        model.startSpawnAnimation(targetScale, 1.1f);
+      currentScene.models.push_back(model);
+    }
+    for (auto &pc : newScene.pointClouds)
+      currentScene.pointClouds.push_back(std::move(pc));
+    for (auto &pl : newScene.pointLights) {
+      pl.castShadows = true;
+      pointLights.push_back(pl);
+    }
+    for (auto &sl : newScene.spotLights)
+      spotLights.push_back(sl);
+
+    updateSpaceMouseBounds();
+    if (voxelizer)
+      voxelizer->markDirty();
+
+    g_sceneDirty = true; // merged content is unsaved
+    SceneAddRecent(sceneFile);
+    SceneReportToast(sceneFile, report, "merged");
+  } catch (const std::exception &e) {
+    std::cerr << "Failed to merge scene: " << e.what() << std::endl;
+    GUI::ShowToast(std::string("Failed to merge scene: ") + e.what(),
+                   GUI::ToastType::Error);
+  }
+}
+
+// Clear the live scene back to an empty, untitled state.
+static void SceneNew() {
+  Engine::UndoManager::instance().clear();
+  currentScene.models.clear();
+  currentScene.pointClouds.clear();
+  currentScene.measurements.clear();
+  currentScene.clipPlanes.clear();
+  pointLights.clear();
+  spotLights.clear();
+  currentScene.metadata = Engine::SceneMetadata{};
+  currentScene.environment = Engine::SceneEnvironment{};
+  currentSelectedType = SelectedType::None;
+  currentSelectedIndex = -1;
+  currentSelectedMeshIndex = -1;
+  Core::SnapshotManager::instance().clear();
+  updateSpaceMouseBounds();
+  if (voxelizer)
+    voxelizer->markDirty();
+  g_currentScenePath.clear();
+  g_sceneDirty = false;
+  GUI::UpdateWindowTitleForScene("");
+  GUI::ShowToast("New (empty) scene", GUI::ToastType::Info);
+}
+
+// Shared modal state. The modals themselves are drawn by renderGUI each frame;
+// these flags can be raised from anywhere (menu, shortcuts, Scene Manager).
+static std::string g_pendingSceneToLoad;
+static bool g_showLoadSceneDialog = false;
+static bool g_showNewSceneGuard = false;
+
+// Route a scene file through the user's replace / merge / ask preference.
+static void SceneRequestLoad(const std::string &sceneFile) {
+  bool hasExistingObjects = !currentScene.models.empty() ||
+                            !currentScene.pointClouds.empty() ||
+                            !pointLights.empty() || !spotLights.empty();
+  if (!hasExistingObjects ||
+      preferences.sceneLoadingBehavior == GUI::SCENE_LOAD_ALWAYS_REPLACE) {
+    SceneReplaceFrom(sceneFile);
+  } else if (preferences.sceneLoadingBehavior == GUI::SCENE_LOAD_ALWAYS_MERGE) {
+    SceneMergeFrom(sceneFile);
+  } else {
+    g_pendingSceneToLoad = sceneFile;
+    g_showLoadSceneDialog = true;
+  }
+}
+
+// New Scene, guarded against silently discarding unsaved changes.
+static void SceneRequestNew() {
+  if (g_sceneDirty)
+    g_showNewSceneGuard = true;
+  else
+    SceneNew();
+}
+
+// Open a file dialog and load the chosen scene through the preference router.
+static void SceneOpenDialog() {
+  auto selection =
+      pfd::open_file("Select a scene file to load", ".",
+                     {"Scene Files", "*.scene", "All Files", "*"})
+          .result();
+  if (!selection.empty())
+    SceneRequestLoad(selection[0]);
+}
+
 // Case-insensitive substring test used by the Scene Hierarchy search filter.
 // An empty needle matches everything (so the unfiltered list shows in full).
 static bool searchMatches(const std::string &haystack, const char *needle) {
@@ -1271,145 +1534,33 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
   // MAIN MENU BAR
   // ========================
 
-  // Static variables for scene loading dialog (must be outside menu scope)
-  static std::string pendingSceneToLoad = "";
-  static bool showLoadSceneDialog = false;
 
-  // Helper lambda to load and replace scene
+  // Thin wrappers kept for the existing call sites below; they delegate to the
+  // shared scene-file operations so every entry point behaves identically.
   auto loadAndReplaceScene = [&](const std::string &sceneFile) {
-    try {
-      // Recorded undo entries reference objects by index, which no longer
-      // match once a scene file replaces the containers
-      Engine::UndoManager::instance().clear();
-
-      // Clear all existing objects
-      currentScene.models.clear();
-      currentScene.pointClouds.clear();
-      pointLights.clear();
-      spotLights.clear();
-      currentSelectedType = SelectedType::None;
-      currentSelectedIndex = -1;
-      currentSelectedMeshIndex = -1;
-
-      // Load new scene
-      currentScene = Engine::loadScene(sceneFile, camera);
-      pointLights = currentScene.pointLights;
-      for (auto &pl : pointLights) {
-        pl.castShadows = true;
-      }
-      spotLights = currentScene.spotLights;
-
-      // Replace the snapshot list with the ones saved for this scene.
-      Core::SnapshotManager::instance().loadFromScene(sceneFile);
-
-      for (auto &model : currentScene.models) {
-        glm::vec3 targetScale = model.scale;
-        if (preferences.enableSpawnAnimation) {
-          model.startSpawnAnimation(targetScale, 1.1f);
-        }
-      }
-      currentSelectedIndex = currentScene.models.empty() ? -1 : 0;
-      updateSpaceMouseBounds();
-
-      // Mark voxelizer dirty for re-voxelization with new scene
-      if (voxelizer) {
-        voxelizer->markDirty();
-      }
-
-      GUI::UpdateWindowTitleForScene(sceneFile);
-      GUI::ShowToast("Scene loaded: " +
-                         std::filesystem::path(sceneFile).filename().string(),
-                     GUI::ToastType::Success);
-    } catch (const std::exception &e) {
-      std::cerr << "Failed to load scene: " << e.what() << std::endl;
-      GUI::ShowToast(std::string("Failed to load scene: ") + e.what(),
-                     GUI::ToastType::Error);
-    }
+    SceneReplaceFrom(sceneFile);
   };
-
-  // Helper lambda to load and merge scene
   auto loadAndMergeScene = [&](const std::string &sceneFile) {
-    try {
-      // Bulk merges are not tracked, so drop the index-based undo history
-      Engine::UndoManager::instance().clear();
-
-      // Load new scene and merge with existing
-      Engine::Scene newScene = Engine::loadScene(sceneFile, camera);
-
-      // Merge models
-      for (auto &model : newScene.models) {
-        glm::vec3 targetScale = model.scale;
-        if (preferences.enableSpawnAnimation) {
-          model.startSpawnAnimation(targetScale, 1.1f);
-        }
-        currentScene.models.push_back(model);
-      }
-
-      // Merge point clouds
-      for (auto &pc : newScene.pointClouds) {
-        currentScene.pointClouds.push_back(std::move(pc));
-      }
-
-      // Merge point lights
-      for (auto &pl : newScene.pointLights) {
-        pl.castShadows = true;
-        pointLights.push_back(pl);
-      }
-
-      // Merge spot lights
-      for (auto &sl : newScene.spotLights) {
-        spotLights.push_back(sl);
-      }
-
-      updateSpaceMouseBounds();
-
-      // Mark voxelizer dirty for re-voxelization with merged geometry
-      if (voxelizer) {
-        voxelizer->markDirty();
-      }
-
-      GUI::ShowToast("Scene merged: " +
-                         std::filesystem::path(sceneFile).filename().string(),
-                     GUI::ToastType::Success);
-    } catch (const std::exception &e) {
-      std::cerr << "Failed to load scene: " << e.what() << std::endl;
-      GUI::ShowToast(std::string("Failed to merge scene: ") + e.what(),
-                     GUI::ToastType::Error);
-    }
+    SceneMergeFrom(sceneFile);
   };
 
-  // Helper lambda to load scene (first load or based on preference)
-  auto loadSceneWithPreference = [&](const std::string &sceneFile) {
-    Engine::UndoManager::instance().clear();
-    currentScene = Engine::loadScene(sceneFile, camera);
-    pointLights = currentScene.pointLights;
-    for (auto &pl : pointLights) {
-      pl.castShadows = true;
-    }
-    spotLights = currentScene.spotLights;
-
-    // Replace the snapshot list with the ones saved for this scene.
-    Core::SnapshotManager::instance().loadFromScene(sceneFile);
-
-    for (auto &model : currentScene.models) {
-      glm::vec3 targetScale = model.scale;
-      if (preferences.enableSpawnAnimation) {
-        model.startSpawnAnimation(targetScale, 1.1f);
+  // Global keyboard shortcuts for scene file operations. Ignored while a text
+  // field has keyboard focus so they don't fire while the user is typing.
+  {
+    ImGuiIO &io = ImGui::GetIO();
+    if (io.KeyCtrl && !io.WantTextInput) {
+      if (ImGui::IsKeyPressed(ImGuiKey_S, false)) {
+        if (io.KeyShift)
+          SceneSaveAsDialog();
+        else
+          SceneQuickSave();
+      } else if (ImGui::IsKeyPressed(ImGuiKey_N, false)) {
+        SceneRequestNew();
+      } else if (ImGui::IsKeyPressed(ImGuiKey_O, false)) {
+        SceneOpenDialog();
       }
     }
-    currentSelectedIndex = currentScene.models.empty() ? -1 : 0;
-    updateSpaceMouseBounds();
-
-    // Mark voxelizer dirty for re-voxelization with new scene
-    if (voxelizer) {
-      voxelizer->markDirty();
-    }
-
-    GUI::UpdateWindowTitleForScene(sceneFile);
-    GUI::ShowToast("Scene loaded: " +
-                       std::filesystem::path(sceneFile).filename().string(),
-                   GUI::ToastType::Success);
-  };
+  }
 
   // Import any files dropped onto the window (queued by the GLFW drop
   // callback). Scene files follow the same replace/merge/ask flow as
@@ -1426,27 +1577,7 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
       std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
 
       if (ext == ".scene") {
-        bool hasExistingObjects = !currentScene.models.empty() ||
-                                  !currentScene.pointClouds.empty() ||
-                                  !pointLights.empty() || !spotLights.empty();
-        if (!hasExistingObjects) {
-          try {
-            loadSceneWithPreference(filePath);
-          } catch (const std::exception &e) {
-            std::cerr << "Failed to load scene: " << e.what() << std::endl;
-            GUI::ShowToast(std::string("Failed to load scene: ") + e.what(),
-                           GUI::ToastType::Error);
-          }
-        } else if (preferences.sceneLoadingBehavior ==
-                   GUI::SCENE_LOAD_ALWAYS_REPLACE) {
-          loadAndReplaceScene(filePath);
-        } else if (preferences.sceneLoadingBehavior ==
-                   GUI::SCENE_LOAD_ALWAYS_MERGE) {
-          loadAndMergeScene(filePath);
-        } else {
-          pendingSceneToLoad = filePath;
-          showLoadSceneDialog = true;
-        }
+        SceneRequestLoad(filePath);
       } else if (ext == ".obj" || ext == ".fbx" || ext == ".3ds" ||
                  ext == ".gltf" || ext == ".glb") {
         importModelFile(filePath);
@@ -1555,7 +1686,12 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
 
       ImGui::Separator();
 
-      // Add icon to Load Scene
+      // New Scene (guarded against discarding unsaved changes).
+      if (ImGui::MenuItem("New Scene", "Ctrl+N")) {
+        SceneRequestNew();
+      }
+
+      // Load Scene
       std::string sceneMenuText = "Load Scene...";
       if (g_Fonts.icons) {
         ImGui::PushFont(g_Fonts.icons);
@@ -1563,69 +1699,48 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
         ImGui::PopFont();
         ImGui::SameLine();
       }
-
-      if (ImGui::MenuItem(sceneMenuText.c_str())) {
-        auto selection =
-            pfd::open_file("Select a scene file to load", ".",
-                           {"Scene Files", "*.scene", "All Files", "*"})
-                .result();
-        if (!selection.empty()) {
-          // Check if there are existing objects in the scene
-          bool hasExistingObjects = !currentScene.models.empty() ||
-                                    !currentScene.pointClouds.empty() ||
-                                    !pointLights.empty() || !spotLights.empty();
-
-          if (hasExistingObjects) {
-            // Check user preference for scene loading behavior
-            if (preferences.sceneLoadingBehavior ==
-                GUI::SCENE_LOAD_ALWAYS_REPLACE) {
-              // Auto-replace: clear existing and load new
-              loadAndReplaceScene(selection[0]);
-            } else if (preferences.sceneLoadingBehavior ==
-                       GUI::SCENE_LOAD_ALWAYS_MERGE) {
-              // Auto-merge: keep existing and add new
-              loadAndMergeScene(selection[0]);
-            } else {
-              // Always ask: show dialog
-              pendingSceneToLoad = selection[0];
-              showLoadSceneDialog = true;
-            }
-          } else {
-            // No existing objects, just load directly
-            try {
-              loadSceneWithPreference(selection[0]);
-            } catch (const std::exception &e) {
-              std::cerr << "Failed to load scene: " << e.what() << std::endl;
-              GUI::ShowToast(std::string("Failed to load scene: ") + e.what(),
-                             GUI::ToastType::Error);
-            }
-          }
-        }
+      if (ImGui::MenuItem(sceneMenuText.c_str(), "Ctrl+O")) {
+        SceneOpenDialog();
       }
 
-      if (ImGui::MenuItem("Save Scene...")) {
-        auto destination =
-            pfd::save_file("Select a file to save scene", ".",
-                           {"Scene Files", "*.scene", "All Files", "*"})
-                .result();
-        if (!destination.empty()) {
-          try {
-            currentScene.pointLights = pointLights;
-            currentScene.spotLights = spotLights;
-            Engine::saveScene(destination, currentScene, camera);
-            // Persist this scene's snapshots (metadata + thumbnails) alongside it.
-            Core::SnapshotManager::instance().saveToScene(destination);
-            GUI::UpdateWindowTitleForScene(destination);
-            GUI::ShowToast(
-                "Scene saved: " +
-                    std::filesystem::path(destination).filename().string(),
-                GUI::ToastType::Success);
-          } catch (const std::exception &e) {
-            std::cerr << "Failed to save scene: " << e.what() << std::endl;
-            GUI::ShowToast(std::string("Failed to save scene: ") + e.what(),
-                           GUI::ToastType::Error);
+      // Recent Scenes submenu (most-recently-used first).
+      if (ImGui::BeginMenu("Recent Scenes",
+                           !preferences.recentScenes.empty())) {
+        // Copy so we can mutate the list (remove missing entries) while
+        // iterating safely.
+        std::vector<std::string> recents = preferences.recentScenes;
+        for (const auto &recent : recents) {
+          bool exists = std::filesystem::exists(recent);
+          std::string label = std::filesystem::path(recent).filename().string();
+          if (!exists)
+            label += "  (missing)";
+          if (!exists)
+            ImGui::BeginDisabled();
+          if (ImGui::MenuItem(label.c_str())) {
+            SceneRequestLoad(recent);
           }
+          if (!exists)
+            ImGui::EndDisabled();
+          if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("%s", recent.c_str());
         }
+        ImGui::Separator();
+        if (ImGui::MenuItem("Clear Recent")) {
+          preferences.recentScenes.clear();
+          savePreferences();
+        }
+        ImGui::EndMenu();
+      }
+
+      ImGui::Separator();
+
+      // Save / Save As. Save re-writes the current file (or prompts when the
+      // scene has never been saved); Save As always prompts.
+      if (ImGui::MenuItem("Save Scene", "Ctrl+S")) {
+        SceneQuickSave();
+      }
+      if (ImGui::MenuItem("Save Scene As...", "Ctrl+Shift+S")) {
+        SceneSaveAsDialog();
       }
 
       ImGui::Separator();
@@ -1701,9 +1816,9 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
 
     // Load Scene Dialog Modal (must be outside menu scope for popup to work
     // correctly)
-    if (showLoadSceneDialog) {
+    if (g_showLoadSceneDialog) {
       ImGui::OpenPopup("Load Scene");
-      showLoadSceneDialog = false;
+      g_showLoadSceneDialog = false;
     }
 
     // Center the popup in the viewport (both horizontally and vertically)
@@ -1722,7 +1837,7 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
 
       // Replace button - clear existing scene
       if (ImGui::Button("Replace (Clear Existing)", ImVec2(200, 0))) {
-        loadAndReplaceScene(pendingSceneToLoad);
+        loadAndReplaceScene(g_pendingSceneToLoad);
         ImGui::CloseCurrentPopup();
       }
       ImGui::SameLine();
@@ -1732,7 +1847,7 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
 
       // Merge button - keep existing scene
       if (ImGui::Button("Merge (Keep Existing)", ImVec2(200, 0))) {
-        loadAndMergeScene(pendingSceneToLoad);
+        loadAndMergeScene(g_pendingSceneToLoad);
         ImGui::CloseCurrentPopup();
       }
       ImGui::SameLine();
@@ -1757,6 +1872,41 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
                          "Display > Scene Loading");
       ImGui::PopStyleColor();
 
+      ImGui::EndPopup();
+    }
+
+    // New Scene unsaved-changes guard.
+    if (g_showNewSceneGuard) {
+      ImGui::OpenPopup("Unsaved Changes");
+      g_showNewSceneGuard = false;
+    }
+    ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+    if (ImGui::BeginPopupModal("Unsaved Changes", nullptr,
+                               ImGuiWindowFlags_AlwaysAutoResize |
+                                   ImGuiWindowFlags_NoMove)) {
+      ImGui::Text("The current scene has unsaved changes.");
+      ImGui::Spacing();
+      ImGui::Text("Save before creating a new scene?");
+      ImGui::Spacing();
+      ImGui::Separator();
+      ImGui::Spacing();
+
+      if (ImGui::Button("Save", ImVec2(120, 0))) {
+        if (SceneQuickSave()) {
+          SceneNew();
+          ImGui::CloseCurrentPopup();
+        }
+        // If the save was cancelled / failed, keep the dialog open.
+      }
+      ImGui::SameLine();
+      if (ImGui::Button("Don't Save", ImVec2(120, 0))) {
+        SceneNew();
+        ImGui::CloseCurrentPopup();
+      }
+      ImGui::SameLine();
+      if (ImGui::Button("Cancel", ImVec2(120, 0))) {
+        ImGui::CloseCurrentPopup();
+      }
       ImGui::EndPopup();
     }
 
@@ -2127,6 +2277,10 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
 
       ImGui::MenuItem("Snapshots", nullptr, &showSnapshotsWindow);
       menuButtonTooltip("Save and restore camera / scene / tool snapshots");
+
+      ImGui::MenuItem("Scene Manager", nullptr, &showSceneManagerWindow);
+      menuButtonTooltip("Save / load scenes, recent files, scene info and "
+                        "save options");
 
       // Plugin-contributed tool entries (each toggles its own window).
       ImGui::Separator();
@@ -2844,6 +2998,10 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
 
   if (showSnapshotsWindow) {
     renderSnapshotsWindow();
+  }
+
+  if (showSceneManagerWindow) {
+    renderSceneManagerWindow();
   }
 
   // Screen-space measurement labels (distances/angles/coordinates) projected
@@ -6871,6 +7029,186 @@ static bool DrawTagChip(const char *label, bool active) {
   ImGui::PopStyleVar();
   ImGui::PopStyleColor(3);
   return clicked;
+}
+
+// Scene Manager panel: a single home for scene file operations (new / open /
+// save / save-as), recent files, the live scene's stats and editable metadata,
+// and the per-scene save options. Complements the File menu so all of this is
+// reachable from one dockable window.
+void renderSceneManagerWindow() {
+  float scale = g_GuiScale.currentScale;
+  ImGui::SetNextWindowSize(ImVec2(460 * scale, 640 * scale),
+                           ImGuiCond_FirstUseEver);
+  ImGui::SetNextWindowSizeConstraints(ImVec2(340 * scale, 320 * scale),
+                                      ImVec2(100000.0f, 100000.0f));
+  ImGui::Begin("Scene Manager", &showSceneManagerWindow);
+
+  // ── Current scene ────────────────────────────────────────────────────────
+  DrawSectionHeader("Current Scene");
+
+  const bool untitled = g_currentScenePath.empty();
+  std::string sceneName =
+      untitled ? std::string("Untitled")
+               : std::filesystem::path(g_currentScenePath).stem().string();
+
+  ImGui::Text("%s", sceneName.c_str());
+  ImGui::SameLine();
+  if (g_sceneDirty) {
+    ImGui::TextColored(ImVec4(1.0f, 0.7f, 0.2f, 1.0f), "  (unsaved changes)");
+  } else {
+    ImGui::TextColored(ImVec4(0.5f, 0.8f, 0.5f, 1.0f), "  (saved)");
+  }
+  if (!untitled) {
+    ImGui::TextDisabled("%s", g_currentScenePath.c_str());
+    if (ImGui::IsItemHovered())
+      ImGui::SetTooltip("%s", g_currentScenePath.c_str());
+  }
+  if (!currentScene.metadata.modifiedAt.empty()) {
+    ImGui::TextDisabled("Last saved: %s",
+                        currentScene.metadata.modifiedAt.c_str());
+  }
+
+  ImGui::Spacing();
+
+  // ── Action buttons ───────────────────────────────────────────────────────
+  float fullW = ImGui::GetContentRegionAvail().x;
+  float halfW = (fullW - ImGui::GetStyle().ItemSpacing.x) * 0.5f;
+  if (ImGui::Button("New", ImVec2(halfW, 0)))
+    SceneRequestNew();
+  ImGui::SameLine();
+  if (ImGui::Button("Open...", ImVec2(halfW, 0)))
+    SceneOpenDialog();
+  if (ImGui::Button("Save", ImVec2(halfW, 0)))
+    SceneQuickSave();
+  ImGui::SameLine();
+  if (ImGui::Button("Save As...", ImVec2(halfW, 0)))
+    SceneSaveAsDialog();
+
+  // ── Statistics ───────────────────────────────────────────────────────────
+  DrawSectionHeader("Contents");
+  if (ImGui::BeginTable("scene_stats", 2,
+                        ImGuiTableFlags_SizingStretchProp)) {
+    auto row = [](const char *label, size_t count) {
+      ImGui::TableNextRow();
+      ImGui::TableSetColumnIndex(0);
+      ImGui::TextUnformatted(label);
+      ImGui::TableSetColumnIndex(1);
+      ImGui::Text("%zu", count);
+    };
+    row("Models", currentScene.models.size());
+    row("Point Clouds", currentScene.pointClouds.size());
+    row("Point Lights", pointLights.size());
+    row("Spot Lights", spotLights.size());
+    row("Measurements", currentScene.measurements.size());
+    row("Section Planes", currentScene.clipPlanes.size());
+    ImGui::EndTable();
+  }
+
+  // ── Metadata ─────────────────────────────────────────────────────────────
+  DrawSectionHeader("Metadata");
+  static char descBuf[1024];
+  static char authorBuf[256];
+  // Keep the buffers in sync with the live scene's metadata while the fields
+  // aren't being edited (so New / Load refreshes them, and edits aren't lost).
+  if (!ImGui::IsAnyItemActive()) {
+    strncpy_s(descBuf, currentScene.metadata.description.c_str(),
+              sizeof(descBuf) - 1);
+    strncpy_s(authorBuf, currentScene.metadata.author.c_str(),
+              sizeof(authorBuf) - 1);
+  }
+  if (ImGui::InputText("Author", authorBuf, sizeof(authorBuf))) {
+    currentScene.metadata.author = authorBuf;
+    g_sceneDirty = true;
+  }
+  if (ImGui::InputTextMultiline("Description", descBuf, sizeof(descBuf),
+                                ImVec2(ImGui::GetContentRegionAvail().x,
+                                       60 * scale))) {
+    currentScene.metadata.description = descBuf;
+    g_sceneDirty = true;
+  }
+  if (!currentScene.metadata.createdAt.empty()) {
+    ImGui::TextDisabled("Created: %s", currentScene.metadata.createdAt.c_str());
+  }
+
+  // ── Save options ─────────────────────────────────────────────────────────
+  DrawSectionHeader("Save Options");
+  auto &opt = preferences.sceneSaveSettings;
+  bool changed = false;
+  changed |= ImGui::Checkbox("Camera viewpoint", &opt.includeCamera);
+  changed |= ImGui::Checkbox("Lighting (sun + lights)", &opt.includeLighting);
+  changed |= ImGui::Checkbox("Environment (skybox + mode)",
+                             &opt.includeEnvironment);
+  changed |= ImGui::Checkbox("Measurements", &opt.includeMeasurements);
+  changed |= ImGui::Checkbox("Section planes", &opt.includeClipPlanes);
+  changed |= ImGui::Checkbox("Snapshots", &opt.includeSnapshots);
+  changed |= ImGui::Checkbox("Compact (minified) JSON", &opt.compact);
+  ImGui::SameLine();
+  DrawHelpMarker("Write the scene's .scene file without indentation. Smaller "
+                 "files, slightly harder to read by hand.");
+  changed |= ImGui::Checkbox("Apply saved environment on load",
+                             &preferences.applySceneEnvironmentOnLoad);
+  ImGui::SameLine();
+  DrawHelpMarker("When loading a scene that stored a skybox / lighting mode, "
+                 "switch the live session to match it.");
+
+  const char *behaviors[] = {"Always Ask", "Always Replace",
+                             "Always Merge"};
+  int behavior = static_cast<int>(preferences.sceneLoadingBehavior);
+  if (ImGui::Combo("On load (with existing scene)", &behavior, behaviors, 3)) {
+    preferences.sceneLoadingBehavior =
+        static_cast<GUI::SceneLoadingBehavior>(behavior);
+    changed = true;
+  }
+  if (changed)
+    savePreferences();
+
+  // ── Recent scenes ────────────────────────────────────────────────────────
+  DrawSectionHeader("Recent Scenes");
+  if (preferences.recentScenes.empty()) {
+    ImGui::TextDisabled("No recent scenes.");
+  } else {
+    std::string toRemove;
+    bool clearAll = false;
+    for (const auto &recent : preferences.recentScenes) {
+      ImGui::PushID(recent.c_str());
+      bool exists = std::filesystem::exists(recent);
+      std::string fname = std::filesystem::path(recent).filename().string();
+
+      if (!exists)
+        ImGui::BeginDisabled();
+      if (ImGui::Button("Load"))
+        SceneRequestLoad(recent);
+      if (!exists)
+        ImGui::EndDisabled();
+
+      ImGui::SameLine();
+      if (ImGui::SmallButton("x"))
+        toRemove = recent;
+      ImGui::SameLine();
+      ImGui::TextUnformatted(fname.c_str());
+      if (!exists) {
+        ImGui::SameLine();
+        ImGui::TextColored(ImVec4(1.0f, 0.5f, 0.5f, 1.0f), "(missing)");
+      }
+      if (ImGui::IsItemHovered())
+        ImGui::SetTooltip("%s", recent.c_str());
+      ImGui::PopID();
+    }
+    ImGui::Spacing();
+    if (ImGui::Button("Clear Recent List"))
+      clearAll = true;
+
+    if (clearAll) {
+      preferences.recentScenes.clear();
+      savePreferences();
+    } else if (!toRemove.empty()) {
+      auto &r = preferences.recentScenes;
+      r.erase(std::remove(r.begin(), r.end(), toRemove), r.end());
+      savePreferences();
+    }
+  }
+
+  ImGui::End();
 }
 
 // Snapshots panel: capture the current camera / scene / tool state into named,

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -161,6 +161,13 @@ static void finishGizmoDrag();
 // ---- Scene Management ----
 Engine::Scene currentScene;
 int currentModelIndex = -1;
+// Path of the .scene file backing the live scene ("" = untitled / never saved).
+// Used by quick-save (Ctrl+S) so it can re-save without prompting, and by the
+// Scene Manager panel / window title. g_sceneDirty tracks whether the live
+// scene has unsaved edits since the last save/load (set via the UndoManager
+// modified callback and the load/import paths, cleared on save/load).
+std::string g_currentScenePath;
+bool g_sceneDirty = false;
 std::string modelPath = "D:/OBJ/motorbike.obj";
 static char modelPathBuffer[256] = ""; // Buffer for ImGui model path input
 
@@ -259,6 +266,7 @@ bool showBrushToolWindow = false;
 bool showMeasurementToolWindow = false;
 bool showClipPlaneToolWindow = false;
 bool showSnapshotsWindow = false;
+bool showSceneManagerWindow = false;
 enum class SelectedType {
   None,
   Model,
@@ -1652,6 +1660,58 @@ void updateSkybox() {
   }
 }
 
+// Apply a freshly-loaded scene's persisted environment (skybox + lighting mode)
+// and sun to the live session. No-op for older scenes that did not store an
+// environment block, or when the user has disabled the behavior in settings.
+// Always restores the sun when the scene carries one, since old scenes simply
+// keep the previous sun. Safe to call only with a current GL context (it
+// rebuilds the skybox).
+void applyLoadedSceneEnvironment(const Engine::Scene &scene) {
+  // Restore the sun only when the scene actually carried one, so loading an
+  // older scene leaves the current sun untouched.
+  if (scene.hasSun) {
+    sun = scene.sun;
+  }
+
+  if (!scene.environment.present || !preferences.applySceneEnvironmentOnLoad) {
+    return;
+  }
+
+  const Engine::SceneEnvironment &env = scene.environment;
+
+  currentLightingMode = static_cast<GUI::LightingMode>(env.lightingMode);
+  preferences.lightingMode = currentLightingMode;
+
+  skyboxConfig.type = static_cast<GUI::SkyboxType>(env.skyboxType);
+  skyboxConfig.solidColor = env.skyboxSolidColor;
+  skyboxConfig.gradientTopColor = env.skyboxGradientTop;
+  skyboxConfig.gradientBottomColor = env.skyboxGradientBottom;
+  skyboxConfig.selectedCubemap = env.selectedCubemap;
+  if (!env.skyboxHdrPath.empty()) {
+    skyboxConfig.hdrPath = env.skyboxHdrPath;
+  }
+  preferences.skyboxType = skyboxConfig.type;
+  preferences.skyboxExposure = env.skyboxExposure;
+
+  updateSkybox();
+}
+
+// Capture the live environment (skybox + lighting mode + sun) into a scene so
+// it is written when the scene is saved.
+void captureSceneEnvironment(Engine::Scene &scene) {
+  scene.sun = sun;
+  Engine::SceneEnvironment &env = scene.environment;
+  env.present = true;
+  env.lightingMode = static_cast<int>(currentLightingMode);
+  env.skyboxType = static_cast<int>(skyboxConfig.type);
+  env.skyboxSolidColor = skyboxConfig.solidColor;
+  env.skyboxGradientTop = skyboxConfig.gradientTopColor;
+  env.skyboxGradientBottom = skyboxConfig.gradientBottomColor;
+  env.selectedCubemap = skyboxConfig.selectedCubemap;
+  env.skyboxHdrPath = skyboxConfig.hdrPath;
+  env.skyboxExposure = preferences.skyboxExposure;
+}
+
 void setupShadowMapping() {
   // Create shadow map framebuffer and texture
   glGenFramebuffers(1, &depthMapFBO);
@@ -2347,6 +2407,24 @@ void savePreferences() {
   j["startup"]["sceneLoadingBehavior"] =
       static_cast<int>(preferences.sceneLoadingBehavior);
 
+  // Scene save options + recent scenes + environment-on-load behavior.
+  j["scene"]["save"]["includeCamera"] =
+      preferences.sceneSaveSettings.includeCamera;
+  j["scene"]["save"]["includeLighting"] =
+      preferences.sceneSaveSettings.includeLighting;
+  j["scene"]["save"]["includeEnvironment"] =
+      preferences.sceneSaveSettings.includeEnvironment;
+  j["scene"]["save"]["includeMeasurements"] =
+      preferences.sceneSaveSettings.includeMeasurements;
+  j["scene"]["save"]["includeClipPlanes"] =
+      preferences.sceneSaveSettings.includeClipPlanes;
+  j["scene"]["save"]["includeSnapshots"] =
+      preferences.sceneSaveSettings.includeSnapshots;
+  j["scene"]["save"]["compact"] = preferences.sceneSaveSettings.compact;
+  j["scene"]["applyEnvironmentOnLoad"] =
+      preferences.applySceneEnvironmentOnLoad;
+  j["scene"]["recent"] = preferences.recentScenes;
+
   // Save lighting settings
   j["lighting"]["mode"] = static_cast<int>(preferences.lightingMode);
   j["lighting"]["enableShadows"] = preferences.enableShadows;
@@ -2902,6 +2980,28 @@ void loadPreferences() {
                              static_cast<int>(GUI::SCENE_LOAD_ALWAYS_ASK)));
     }
 
+    // Scene save options + recent scenes + environment-on-load behavior.
+    if (j.contains("scene")) {
+      const auto &sj = j["scene"];
+      if (sj.contains("save")) {
+        const auto &sv = sj["save"];
+        auto &opt = preferences.sceneSaveSettings;
+        opt.includeCamera = sv.value("includeCamera", true);
+        opt.includeLighting = sv.value("includeLighting", true);
+        opt.includeEnvironment = sv.value("includeEnvironment", true);
+        opt.includeMeasurements = sv.value("includeMeasurements", true);
+        opt.includeClipPlanes = sv.value("includeClipPlanes", true);
+        opt.includeSnapshots = sv.value("includeSnapshots", true);
+        opt.compact = sv.value("compact", false);
+      }
+      preferences.applySceneEnvironmentOnLoad =
+          sj.value("applyEnvironmentOnLoad", true);
+      if (sj.contains("recent") && sj["recent"].is_array()) {
+        preferences.recentScenes =
+            sj["recent"].get<std::vector<std::string>>();
+      }
+    }
+
     // Cursor settings
     if (j.contains("cursor")) {
       preferences.currentPresetName =
@@ -3446,6 +3546,10 @@ int main() {
     }
   });
 
+  // Any edit routed through the undo system marks the scene as having unsaved
+  // changes (used by the Scene Manager panel and the unsaved-changes guards).
+  UndoManager::instance().setModifiedCallback([]() { g_sceneDirty = true; });
+
   // ---- Initialize Shadow Mapping Shader ----
   try {
     shadowMappingShader =
@@ -3725,6 +3829,9 @@ int main() {
       }
       currentModelIndex = currentScene.models.empty() ? -1 : 0;
       updateSpaceMouseBounds();
+      applyLoadedSceneEnvironment(currentScene);
+      g_currentScenePath = preferences.startupScenePath;
+      g_sceneDirty = false;
       GUI::UpdateWindowTitleForScene(preferences.startupScenePath);
       GUI::ShowToast(
           "Scene loaded: " +

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -1690,7 +1690,16 @@ void applyLoadedSceneEnvironment(const Engine::Scene &scene) {
   if (!env.skyboxHdrPath.empty()) {
     skyboxConfig.hdrPath = env.skyboxHdrPath;
   }
+
+  // Mirror the live skybox config into preferences so they stay fully in sync
+  // (the skybox settings panel keeps both aligned, and only a complete mirror
+  // avoids a half-updated persisted state on the next launch).
   preferences.skyboxType = skyboxConfig.type;
+  preferences.skyboxSolidColor = skyboxConfig.solidColor;
+  preferences.skyboxGradientTop = skyboxConfig.gradientTopColor;
+  preferences.skyboxGradientBottom = skyboxConfig.gradientBottomColor;
+  preferences.selectedCubemap = skyboxConfig.selectedCubemap;
+  preferences.skyboxHdrPath = skyboxConfig.hdrPath;
   preferences.skyboxExposure = env.skyboxExposure;
 
   updateSkybox();


### PR DESCRIPTION
Backend (SceneManager):
- Versioned scene format (formatVersion + metadata header with
  description/author/created/modified timestamps and object counts).
- Atomic writes (temp file + rename) so a crash mid-save never corrupts
  an existing scene file.
- Persist the sun, a per-scene environment block (skybox + lighting mode)
  and extra light fields (attenuation, castShadows); applied on load
  (gated by a preference) so scenes reopen with their authored look.
- SceneSaveOptions to choose what is written (camera / lighting /
  environment / measurements / clip planes / compact JSON).
- SceneLoadReport surfaces partial loads (missing assets) to the UI;
  loadSceneInfo() peeks at a scene's header without loading geometry.
- Backward compatible: untagged v1 scenes still load; new keys are
  ignored by older builds.

App / UX:
- Track the current scene path and an unsaved-changes flag (driven by a
  new UndoManager modified-callback), shown in the new panel.
- New Scene / Save / Save As / Open with Ctrl+N / Ctrl+S / Ctrl+Shift+S /
  Ctrl+O shortcuts; quick-save re-writes the current file.
- Recent-scenes list (File > Recent Scenes and the panel), persisted in
  preferences.
- Unsaved-changes guard before New Scene.
- New dockable "Scene Manager" window: current-scene info + stats,
  editable metadata, save options, scene-loading behaviour and recent
  files, all routed through one shared set of scene operations also used
  by the File menu and drag-and-drop.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013H9Vo1dPYwUHg4Mkjwd8Ad