### PR TITLE
Add standard camera views (Top/Front/Iso etc.) with numpad shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,17 @@ All user preferences are automatically saved to `preferences.json` and restored 
 | **W / A / S / D** | Move camera forward / left / backward / right |
 | **Space / Left Shift** | Move camera up / down |
 | **C** | Center camera on cursor position or scene midpoint |
+| **Home** | Reset camera to scene default position |
+
+### Standard Views
+Frame the entire scene from a fixed angle (CAD-style numpad layout). Also available as buttons under *Settings → Camera → Standard Views*.
+
+| Input | Action |
+|-------|--------|
+| **Numpad 1** / **Ctrl + Numpad 1** | Front / Back view |
+| **Numpad 3** / **Ctrl + Numpad 3** | Right / Left view |
+| **Numpad 7** / **Ctrl + Numpad 7** | Top / Bottom view |
+| **Numpad 5** | Isometric view |
 
 ### Model & Object Interaction
 | Input | Action |

--- a/StereoVista/headers/Engine/ShortcutManager.h
+++ b/StereoVista/headers/Engine/ShortcutManager.h
@@ -26,6 +26,15 @@ enum class ShortcutAction {
   ToggleSpaceMouseMode,    // Toggle SpaceMouse navigation mode (CAD/Drone)
   ResetCamera,             // Home - Reset camera to scene default position
 
+  // Standard Views (frame the scene from an axis-aligned / isometric angle)
+  ViewFront,    // Numpad 1 - Look along -Z
+  ViewBack,     // Ctrl+Numpad 1 - Look along +Z
+  ViewRight,    // Numpad 3 - Look along -X
+  ViewLeft,     // Ctrl+Numpad 3 - Look along +X
+  ViewTop,      // Numpad 7 - Look straight down (-Y)
+  ViewBottom,   // Ctrl+Numpad 7 - Look straight up (+Y)
+  ViewIso,      // Numpad 5 - Isometric three-quarter view
+
   // Lighting
   CycleLighting,  // L - Cycle lighting modes
   ToggleShadows,  // K - Toggle shadows

--- a/StereoVista/src/Engine/ShortcutManager.cpp
+++ b/StereoVista/src/Engine/ShortcutManager.cpp
@@ -434,6 +434,19 @@ ShortcutProfile ShortcutManager::createDefaultProfile() {
                      KeyBinding(GLFW_KEY_I, true, false, true),
                      0); // Ctrl+Shift+I
   profile.setBinding(ShortcutAction::ResetCamera, KeyBinding(GLFW_KEY_HOME), 0);
+
+  // Standard views (CAD-style numpad layout: 1=front, 3=right, 7=top, 5=iso,
+  // Ctrl+ for the opposite side).
+  profile.setBinding(ShortcutAction::ViewFront, KeyBinding(GLFW_KEY_KP_1), 0);
+  profile.setBinding(ShortcutAction::ViewBack,
+                     KeyBinding(GLFW_KEY_KP_1, true), 0);
+  profile.setBinding(ShortcutAction::ViewRight, KeyBinding(GLFW_KEY_KP_3), 0);
+  profile.setBinding(ShortcutAction::ViewLeft,
+                     KeyBinding(GLFW_KEY_KP_3, true), 0);
+  profile.setBinding(ShortcutAction::ViewTop, KeyBinding(GLFW_KEY_KP_7), 0);
+  profile.setBinding(ShortcutAction::ViewBottom,
+                     KeyBinding(GLFW_KEY_KP_7, true), 0);
+  profile.setBinding(ShortcutAction::ViewIso, KeyBinding(GLFW_KEY_KP_5), 0);
   profile.setBinding(ShortcutAction::OpenMeasurementTool, KeyBinding(GLFW_KEY_M),
                      0);
   profile.setBinding(ShortcutAction::OpenClipPlaneTool, KeyBinding(GLFW_KEY_P),
@@ -518,6 +531,15 @@ const ShortcutProfile *ShortcutManager::getActiveProfile() const {
 }
 
 int ShortcutManager::normalizeKeyToLayout(int key, int scancode) {
+  // The keypad (numpad) has the same physical layout on QWERTY/QWERTZ/AZERTY/...
+  // and is a distinct set of keys from the main number row, so it must never be
+  // folded onto it. glfwGetKeyName *does* report names for the KP_0..KP_EQUAL
+  // range (e.g. "1" for KP_1), which would otherwise remap GLFW_KEY_KP_1 to
+  // GLFW_KEY_1 and make numpad bindings collide with the top-row digits. Leave
+  // every keypad key untouched.
+  if (key >= GLFW_KEY_KP_0 && key <= GLFW_KEY_KP_EQUAL)
+    return key;
+
   // glfwGetKeyName returns the character the physical key produces in the
   // current layout (e.g. on QWERTZ the GLFW_KEY_Y position is labeled "z").
   // When 'key' is a known token GLFW ignores 'scancode' and looks the name up
@@ -595,6 +617,22 @@ std::string ShortcutManager::getActionName(ShortcutAction action) {
     return "ToggleOrbitAroundCursor";
   case ShortcutAction::ResetCamera:
     return "ResetCamera";
+
+  // Standard Views
+  case ShortcutAction::ViewFront:
+    return "ViewFront";
+  case ShortcutAction::ViewBack:
+    return "ViewBack";
+  case ShortcutAction::ViewRight:
+    return "ViewRight";
+  case ShortcutAction::ViewLeft:
+    return "ViewLeft";
+  case ShortcutAction::ViewTop:
+    return "ViewTop";
+  case ShortcutAction::ViewBottom:
+    return "ViewBottom";
+  case ShortcutAction::ViewIso:
+    return "ViewIso";
 
   // Lighting
   case ShortcutAction::CycleLighting:
@@ -722,6 +760,22 @@ std::string ShortcutManager::getActionDescription(ShortcutAction action) {
     return "Toggle SpaceMouse Mode (CAD/Drone)";
   case ShortcutAction::ResetCamera:
     return "Reset Camera to Scene Default";
+
+  // Standard Views
+  case ShortcutAction::ViewFront:
+    return "Standard View: Front";
+  case ShortcutAction::ViewBack:
+    return "Standard View: Back";
+  case ShortcutAction::ViewRight:
+    return "Standard View: Right";
+  case ShortcutAction::ViewLeft:
+    return "Standard View: Left";
+  case ShortcutAction::ViewTop:
+    return "Standard View: Top";
+  case ShortcutAction::ViewBottom:
+    return "Standard View: Bottom";
+  case ShortcutAction::ViewIso:
+    return "Standard View: Isometric";
 
   // Lighting
   case ShortcutAction::CycleLighting:

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -35,6 +35,7 @@ using namespace GUI;
 
 // Forward declarations
 void updateSpaceMouseBounds();
+void applyStandardView(int viewId); // defined in main.cpp
 void updateSpaceMouseCursorAnchor();
 void renderPointLightManipulationPanel();
 void renderSpotLightManipulationPanel();
@@ -4037,6 +4038,36 @@ void renderSettingsWindow() {
       DrawHelpMarker("Maximum visible distance from camera. Higher values may "
                      "impact performance");
 
+      DrawSectionHeader("Standard Views");
+      ImGui::TextDisabled("Frame the scene from a fixed angle (numpad keys).");
+      {
+        const float spacing = ImGui::GetStyle().ItemSpacing.x;
+        const float btnW =
+            (ImGui::GetContentRegionAvail().x - spacing * 2.0f) / 3.0f;
+        const ImVec2 sz(btnW, 0.0f);
+
+        if (ImGui::Button("Top", sz))
+          applyStandardView(4);
+        ImGui::SameLine();
+        if (ImGui::Button("Bottom", sz))
+          applyStandardView(5);
+        ImGui::SameLine();
+        if (ImGui::Button("Isometric", sz))
+          applyStandardView(6);
+
+        if (ImGui::Button("Front", sz))
+          applyStandardView(0);
+        ImGui::SameLine();
+        if (ImGui::Button("Back", sz))
+          applyStandardView(1);
+        ImGui::SameLine();
+        if (ImGui::Button("Right", sz))
+          applyStandardView(2);
+
+        if (ImGui::Button("Left", sz))
+          applyStandardView(3);
+      }
+
       DrawSectionHeader("Stereoscopic 3D");
 
       if (ImGui::SliderFloat("Eye Separation", &preferences.separation, 0.01f,
@@ -5661,6 +5692,13 @@ void renderSettingsWindow() {
           renderAction(StereoVista::ShortcutAction::ResetCamera);
           renderAction(StereoVista::ShortcutAction::ToggleZoomToCursor);
           renderAction(StereoVista::ShortcutAction::ToggleOrbitAroundCursor);
+          renderAction(StereoVista::ShortcutAction::ViewFront);
+          renderAction(StereoVista::ShortcutAction::ViewBack);
+          renderAction(StereoVista::ShortcutAction::ViewRight);
+          renderAction(StereoVista::ShortcutAction::ViewLeft);
+          renderAction(StereoVista::ShortcutAction::ViewTop);
+          renderAction(StereoVista::ShortcutAction::ViewBottom);
+          renderAction(StereoVista::ShortcutAction::ViewIso);
         }
 
         // GROUP: Lighting

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -7605,15 +7605,13 @@ void renderLightVisualizations(Engine::Shader *shader) {
   }
 }
 
-void updateSpaceMouseBounds() {
-  // Calculate combined bounding box for models and point clouds
-  // This function is called when:
-  // - Models or point clouds are loaded/deleted
-  // - Model/point cloud transforms (position, scale, rotation) change
-  // - Scenes are loaded
-  // This ensures SpaceMouse navigation bounds stay accurate without per-frame
-  // updates
-  glm::vec3 modelMin(FLT_MAX), modelMax(-FLT_MAX);
+// Compute the combined world-space axis-aligned bounding box of every model and
+// point cloud in the current scene. Returns false (leaving outMin/outMax
+// untouched) when the scene has no measurable content. Translation and scale are
+// applied; rotation is intentionally ignored to keep this cheap (matching the
+// SpaceMouse-bounds convention this used to inline).
+bool getSceneWorldBounds(glm::vec3 &outMin, glm::vec3 &outMax) {
+  glm::vec3 mn(FLT_MAX), mx(-FLT_MAX);
 
   // Include models in bounding box calculation
   for (const auto &model : currentScene.models) {
@@ -7621,8 +7619,8 @@ void updateSpaceMouseBounds() {
       for (const auto &vertex : mesh.vertices) {
         glm::vec3 worldPos =
             model.position + (glm::vec3(vertex.position) * model.scale);
-        modelMin = glm::min(modelMin, worldPos);
-        modelMax = glm::max(modelMax, worldPos);
+        mn = glm::min(mn, worldPos);
+        mx = glm::max(mx, worldPos);
       }
     }
   }
@@ -7635,35 +7633,122 @@ void updateSpaceMouseBounds() {
           pointCloud.position + (pointCloud.boundsMin * pointCloud.scale);
       const glm::vec3 pcMax =
           pointCloud.position + (pointCloud.boundsMax * pointCloud.scale);
-      modelMin = glm::min(modelMin, pcMin);
-      modelMax = glm::max(modelMax, pcMax);
+      mn = glm::min(mn, pcMin);
+      mx = glm::max(mx, pcMax);
     } else if (pointCloud.octreeRoot) {
       // Legacy: octree was built (e.g. by an older code path)
       const glm::vec3 pcMin =
           pointCloud.position + (pointCloud.octreeBoundsMin * pointCloud.scale);
       const glm::vec3 pcMax =
           pointCloud.position + (pointCloud.octreeBoundsMax * pointCloud.scale);
-      modelMin = glm::min(modelMin, pcMin);
-      modelMax = glm::max(modelMax, pcMax);
+      mn = glm::min(mn, pcMin);
+      mx = glm::max(mx, pcMax);
     } else if (!pointCloud.points.empty()) {
       // Last resort: iterate CPU-side points (only used by very old load paths)
       for (const auto &point : pointCloud.points) {
         const glm::vec3 worldPos =
             pointCloud.position + (point.position * pointCloud.scale);
-        modelMin = glm::min(modelMin, worldPos);
-        modelMax = glm::max(modelMax, worldPos);
+        mn = glm::min(mn, worldPos);
+        mx = glm::max(mx, worldPos);
       }
     }
   }
 
-  // Fallback if no content found
-  if (modelMin.x == FLT_MAX) {
+  if (mn.x == FLT_MAX)
+    return false; // no content
+
+  outMin = mn;
+  outMax = mx;
+  return true;
+}
+
+void updateSpaceMouseBounds() {
+  // Recalculate the combined bounding box for SpaceMouse navigation. Called when
+  // models/point clouds are loaded, deleted, transformed, or a scene is loaded,
+  // so the bounds stay accurate without per-frame updates.
+  glm::vec3 modelMin, modelMax;
+  if (!getSceneWorldBounds(modelMin, modelMax)) {
+    // Fallback if no content found
     modelMin = glm::vec3(-5.0f);
     modelMax = glm::vec3(5.0f);
   }
 
   // Update SpaceMouse with new bounds
   spaceMouseInput.SetModelExtents(modelMin, modelMax);
+}
+
+// Smoothly frame the whole scene from a standard axis-aligned or isometric
+// angle, the way a CAD/inspection viewer's numpad views work. viewId:
+//   0 Front (-Z)  1 Back (+Z)  2 Right (-X)  3 Left (+X)
+//   4 Top  (-Y)   5 Bottom (+Y)            6 Isometric
+// The camera distance is chosen so the scene's bounding sphere fits the current
+// vertical field of view with a small margin. The orbit pivot is re-anchored to
+// the scene centre so subsequent orbiting turns around what was just framed.
+void applyStandardView(int viewId) {
+  glm::vec3 mn, mx, center;
+  float radius;
+  if (getSceneWorldBounds(mn, mx)) {
+    center = (mn + mx) * 0.5f;
+    radius = glm::length(mx - mn) * 0.5f; // bounding-sphere radius
+  } else {
+    center = glm::vec3(0.0f);
+    radius = 5.0f;
+  }
+  if (radius < 0.001f)
+    radius = 1.0f;
+
+  // Front = direction from the camera toward the scene centre. Pick an up vector
+  // that is never parallel to Front so the look-at basis stays well defined.
+  glm::vec3 front;
+  glm::vec3 up(0.0f, 1.0f, 0.0f);
+  switch (viewId) {
+  case 1:
+    front = glm::vec3(0.0f, 0.0f, 1.0f);
+    break; // Back
+  case 2:
+    front = glm::vec3(-1.0f, 0.0f, 0.0f);
+    break; // Right (camera on +X)
+  case 3:
+    front = glm::vec3(1.0f, 0.0f, 0.0f);
+    break; // Left (camera on -X)
+  case 4:
+    front = glm::vec3(0.0f, -1.0f, 0.0f);
+    up = glm::vec3(0.0f, 0.0f, -1.0f);
+    break; // Top (look down)
+  case 5:
+    front = glm::vec3(0.0f, 1.0f, 0.0f);
+    up = glm::vec3(0.0f, 0.0f, 1.0f);
+    break; // Bottom (look up)
+  case 6:
+    front = glm::normalize(glm::vec3(-1.0f, -1.0f, -1.0f));
+    break; // Isometric
+  case 0:
+  default:
+    front = glm::vec3(0.0f, 0.0f, -1.0f);
+    break; // Front
+  }
+  front = glm::normalize(front);
+
+  // Distance so the bounding sphere fits inside the vertical FOV (+20% margin).
+  const float halfFov = glm::radians(glm::max(camera.Zoom, 1.0f) * 0.5f);
+  const float distance = (radius * 1.2f) / glm::max(glm::sin(halfFov), 0.01f);
+
+  // Look-at basis, matching the engine convention used elsewhere:
+  // columns are (Right, Up, -Front).
+  const glm::vec3 right = glm::normalize(glm::cross(front, up));
+  const glm::vec3 trueUp = glm::normalize(glm::cross(right, front));
+  const glm::mat3 rot(right, trueUp, -front);
+
+  Camera::CameraState target = camera.GetState();
+  target.position = center - front * distance;
+  target.orientation = glm::normalize(glm::quat_cast(rot));
+  target.zoom = camera.Zoom; // standard views do not change the FOV
+
+  camera.StartStateAnimation(target, 0.5f);
+  // Re-anchor the orbit pivot to the scene centre. StartStateAnimation keeps
+  // OrbitDistance and rebuilds OrbitPoint = Position + Front * OrbitDistance on
+  // completion, so setting the distance here lands the pivot on `center`.
+  camera.OrbitDistance = distance;
 }
 
 // ---- Snapshot glue (declared in Core/SnapshotManager.h) ----
@@ -9258,6 +9343,29 @@ void key_callback(GLFWwindow *window, int key, int scancode, int action,
         std::cout << "Centering on world origin" << std::endl;
       }
     } break;
+
+    // Standard Views (frame the whole scene from a fixed angle)
+    case StereoVista::ShortcutAction::ViewFront:
+      applyStandardView(0);
+      break;
+    case StereoVista::ShortcutAction::ViewBack:
+      applyStandardView(1);
+      break;
+    case StereoVista::ShortcutAction::ViewRight:
+      applyStandardView(2);
+      break;
+    case StereoVista::ShortcutAction::ViewLeft:
+      applyStandardView(3);
+      break;
+    case StereoVista::ShortcutAction::ViewTop:
+      applyStandardView(4);
+      break;
+    case StereoVista::ShortcutAction::ViewBottom:
+      applyStandardView(5);
+      break;
+    case StereoVista::ShortcutAction::ViewIso:
+      applyStandardView(6);
+      break;
 
     // View/Display Controls
     case StereoVista::ShortcutAction::ToggleFPS:


### PR DESCRIPTION
Adds CAD/inspection-style standard views that smoothly frame the whole scene from a fixed angle: Front/Back (Numpad 1 / Ctrl+1), Right/Left (Numpad 3 / Ctrl+3), Top/Bottom (Numpad 7 / Ctrl+7) and Isometric (Numpad 5), plus a button grid under Settings -> Camera -> Standard Views.

- New ShortcutActions (ViewFront/Back/Right/Left/Top/Bottom/Iso) with default numpad bindings, action names and descriptions; listed in the shortcut editor's Camera Controls group. Existing shortcut files backfill the new defaults on load.
- applyStandardView() in main.cpp builds a look-at orientation and frames the scene's bounding sphere within the current vertical FOV, then glides there via the existing StartStateAnimation; the orbit pivot is re-anchored to the scene centre.
- Extracted getSceneWorldBounds() from updateSpaceMouseBounds() so the world AABB of models + point clouds is shared (no behaviour change to the SpaceMouse bounds).
- Fixed normalizeKeyToLayout() folding keypad keys onto the main number row (glfwGetKeyName reports "1" for KP_1), which would have made numpad bindings collide with the top-row digit shortcuts. Keypad keys are now left untouched by layout remapping.


Claude-Session: https://claude.ai/code/session_01NsZDb6Kq1VzU8JvmJSY9C1