### PR TITLE
Add progressive (streaming) LAS/LAZ loading (Schütz compute_loop_las style)

### DIFF
--- a/StereoVista/assets/shaders/core/pointcloud_color_lookup.comp
+++ b/StereoVista/assets/shaders/core/pointcloud_color_lookup.comp
@@ -32,7 +32,7 @@
 
 layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
 
-// Framebuffer entry: (depth:32 | (cloudID:5 | localIndex:27)).  This pass only
+// Framebuffer entry: (depth:24 | cloudID:8 | index:32).  This pass only
 // READS the framebuffer — the payload must survive every per-cloud lookup pass,
 // so the resolved colour is written to a SEPARATE colour buffer instead.
 layout(std430, binding = 1) readonly buffer ssFramebufferBlock {
@@ -65,13 +65,12 @@ void main() {
     // Sentinel → no point here; leave colorbuffer untouched (resolve discards it).
     if (entry == 0xFFFFFFFFFFFFFFFFUL) return;
 
-    // Low 32 bits = (cloudID:5 | localIndex:27).  Only the cloud that owns this
+    // Layout: depth:24 | cloudID:8 | index:32.  Only the cloud that owns this
     // pixel resolves it, against its own ssRGBA buffer — so colours from one
     // cloud can never be looked up in another cloud's colour array.
-    uint payload = uint(entry & 0xFFFFFFFFUL);
-    uint cloudID = payload >> 27;
+    uint index   = uint(entry & 0xFFFFFFFFUL);        // bits  0..31
+    uint cloudID = uint((entry >> 32) & 0xFFUL);       // bits 32..39
     if (cloudID != uLookupCloudID) return;
 
-    uint idx = payload & 0x07FFFFFFu;
-    colorbuffer[pixelID] = ssRGBA[idx];
+    colorbuffer[pixelID] = ssRGBA[index];
 }

--- a/StereoVista/assets/shaders/core/pointcloud_rasterize.comp
+++ b/StereoVista/assets/shaders/core/pointcloud_rasterize.comp
@@ -64,7 +64,7 @@ uniform mat4  uModelView;       // view * model        – precision level (view
 uniform mat4  uProj;            // projection matrix   – precision level
 uniform ivec2 uImageSize;
 uniform int   uPointsPerThread; // ceil(kComputeBatchSize / 128)
-uniform uint  uCloudID;         // 5-bit id of this cloud → packed in framebuffer payload
+uniform uint  uCloudID;         // 8-bit id of this cloud → packed in framebuffer payload
 uniform int   uSplatMaxRadius;  // 0 = single-pixel (off); >0 = max adaptive round-splat radius (px)
 
 // User section/clip planes, expressed in this cloud's LOCAL space so they can be
@@ -379,25 +379,30 @@ void main() {
             splatRadius = clamp(int(splatScale / clip.w), 0, uSplatMaxRadius);
         }
 
-        // ── Depth + (cloudID | index) packed into 64 bits ────────────────────
-        // High 32 bits: NDC depth [0,1] — drives atomicMin sort + gl_FragDepth.
-        // Low  32 bits: payload = (cloudID:5 | localIndex:27).  The cloud id lets
-        //               the colour-lookup pass resolve each pixel against the
-        //               CORRECT cloud's ssRGBA buffer when several point clouds
-        //               share this framebuffer.  Without it, every pixel was
-        //               coloured with whichever cloud was bound last, so colours
-        //               bled across clouds.  27-bit index ⇒ ≤134,217,728 points
-        //               per cloud; 5-bit id ⇒ ≤32 clouds per frame.
+        // ── Depth + cloudID + index packed into 64 bits ──────────────────────
+        // Layout (MSB→LSB):  depth:24 | cloudID:8 | index:32
+        //   bits 40..63 : 24-bit NDC depth [0,1] — drives atomicMin sort (nearest
+        //                 point wins) and gl_FragDepth. 24 bits matches a standard
+        //                 hardware depth buffer, so there is no practical loss.
+        //   bits 32..39 :  8-bit cloud id — lets the colour-lookup pass resolve
+        //                 each pixel against the CORRECT cloud's ssRGBA buffer when
+        //                 several point clouds share this framebuffer (≤256 clouds).
+        //   bits  0..31 : 32-bit point index — full per-cloud range (≤4.29B pts),
+        //                 so large clouds no longer wrap (was 27-bit ⇒ 134M cap).
+        // Depth stays in the most-significant bits so the uint64 atomicMin sorts by
+        // depth first. depth24 is clamped below 0xFFFFFF so a real point can never
+        // collide with the 0xFFFF…FF empty sentinel.
         //
         // NOTE: We tested reading ssRGBA[index] here to eliminate the lookup pass.
         // Even though the access is coalesced (consecutive indices per workgroup),
         // it adds a data dependency before the atomicMin (can't start until color
         // is loaded) that stalls warp scheduling — measured +8ms for 13M points.
         // The lookup pass remains the correct architecture for the scatter step.
-        float    depth01 = ndc.z * 0.5 + 0.5;   // NDC z [-1,1] → OpenGL [0,1]
-        uint     depth   = floatBitsToUint(depth01);
-        uint     payload = (uCloudID << 27) | (index & 0x07FFFFFFu);
-        uint64_t entry   = (uint64_t(depth) << 32UL) | uint64_t(payload);
+        float    depth01 = clamp(ndc.z * 0.5 + 0.5, 0.0, 1.0); // NDC z → [0,1]
+        uint     depth24 = min(uint(depth01 * 16777215.0 + 0.5), 16777214u); // 24-bit
+        uint     hi      = (depth24 << 8) | (uCloudID & 0xFFu); // bits 32..63
+        uint64_t entry   = (uint64_t(hi) << 32UL) | uint64_t(index); // index = low 32
+
 
         // ── Write (single-pixel, or adaptive round-splat when zoomed in) ──────
         writePixel(px, entry, splatRadius);

--- a/StereoVista/assets/shaders/core/pointcloud_resolve.frag
+++ b/StereoVista/assets/shaders/core/pointcloud_resolve.frag
@@ -1,9 +1,10 @@
 // Schütz compute rasterizer – final fragment resolve pass.
 //
-// At this point the framebuffer SSBO has been rewritten by
-// pointcloud_color_lookup.comp to contain (depth:32 | packedRGBA8:32) instead
-// of (depth:32 | point_index:32).  All scatter into ssRGBA happened in the
-// preceding compute pass, where memory parallelism is much higher.
+// The framebuffer entry is (depth:24 | cloudID:8 | index:32); the per-pixel
+// colour was scattered into a SEPARATE colour buffer by
+// pointcloud_color_lookup.comp (binding 45), where memory parallelism is much
+// higher.  This pass reads the depth from the entry and the colour from that
+// buffer.
 //
 // This shader does only the unavoidable per-fragment work:
 //   - read the per-pixel SSBO entry (1 contiguous read, cache-friendly)
@@ -20,11 +21,11 @@
 in  vec2 TexCoords;
 out vec4 FragColor;
 
-// Per-pixel framebuffer holding (depth:32 | (cloudID:5 | localIndex:27)).
+// Per-pixel framebuffer holding (depth:24 | cloudID:8 | index:32).
 // Sentinel 0xFFFFFFFFFFFFFFFF = no point.
 // Declared as uvec2 instead of uint64_t for cross-vendor fragment compatibility:
-//   .y = high 32 bits = depth
-//   .x = low  32 bits = (cloudID | localIndex) payload  (no longer the colour)
+//   .y = high 32 bits = (depth:24 | cloudID:8)
+//   .x = low  32 bits = point index  (no longer the colour)
 layout(std430, binding = 1) readonly buffer ssFramebuffer {
     uvec2 framebuffer[];
 };
@@ -45,8 +46,9 @@ void main() {
     uvec2 entry = framebuffer[pixelID];
     if (entry.x == 0xFFFFFFFFu && entry.y == 0xFFFFFFFFu) discard;
 
-    // Depth (high 32 bits = .y) → gl_FragDepth for hardware depth test
-    gl_FragDepth = uintBitsToFloat(entry.y);
+    // Depth = top 24 bits of .y (bits 40..63 of the entry) → gl_FragDepth.
+    // entry.y = (depth24 << 8) | cloudID, so depth24 = entry.y >> 8.
+    gl_FragDepth = float(entry.y >> 8u) / 16777215.0;
 
     // Colour was resolved per-cloud into the separate colour buffer.
     uint rgba = colorbuffer[pixelID];

--- a/StereoVista/headers/Engine/ComputePointCloudRenderer.h
+++ b/StereoVista/headers/Engine/ComputePointCloudRenderer.h
@@ -94,8 +94,10 @@ private:
     int  m_width  = 0;
     int  m_height = 0;
 
-    // Framebuffer SSBO: uint64_t[width*height] – packed (depth:32 | payload:32),
-    // payload = (cloudID:5 | localIndex:27).  Matches Schütz's ssFramebuffer (binding 1).
+    // Framebuffer SSBO: uint64_t[width*height] – packed (depth:24 | cloudID:8 | index:32).
+    // 24-bit depth (hardware-buffer precision) drives the atomicMin sort; 8-bit
+    // cloud id (≤256 clouds) selects the colour buffer; 32-bit index addresses up
+    // to ~4.29B points per cloud.  Based on Schütz's ssFramebuffer (binding 1).
     GLuint m_framebufferSSBO = 0;
 
     // Per-pixel resolved colour (packed RGBA8, binding 45).  Written by the

--- a/StereoVista/headers/Engine/Data.h
+++ b/StereoVista/headers/Engine/Data.h
@@ -112,6 +112,11 @@ namespace Engine {
         PointCloudChunkCache() : maxMemoryMB(8192), currentMemoryMB(0) {} // Default 8GB limit
     };
 
+    // Background streaming state for a progressively-loaded cloud (defined in
+    // PointCloudLoader.cpp).  Held by shared_ptr so PointCloud stays movable and
+    // the worker thread is joined when the last owner is destroyed.
+    struct PointCloudStream;
+
     struct PointCloud {
         std::string name;
         std::string filePath;
@@ -145,6 +150,14 @@ namespace Engine {
         GLuint computeRGBASSBO   = 0; // binding 44 – pre-packed uint RGBA
         uint32_t numBatches           = 0;
         int      computePointsPerThread = 0; // ceil(kComputeBatchSize / 128)
+
+        // ── Progressive streaming (compute_loop_las style) ───────────────────
+        // While `stream` is non-null the cloud is still loading: SSBOs are
+        // pre-allocated to streamTargetCount points and numBatches/totalPointCount
+        // grow each frame as PointCloudLoader::updateStreaming() uploads chunks.
+        // `stream` resets to null when loading completes.
+        std::shared_ptr<PointCloudStream> stream;
+        uint32_t streamTargetCount = 0; // expected final point count (0 = N/A)
 
         float basePointSize = 2.0f;
 
@@ -200,7 +213,9 @@ namespace Engine {
               computeXyz4bSSBO(other.computeXyz4bSSBO),
               computeRGBASSBO(other.computeRGBASSBO),
               numBatches(other.numBatches),
-              computePointsPerThread(other.computePointsPerThread) {
+              computePointsPerThread(other.computePointsPerThread),
+              stream(std::move(other.stream)),
+              streamTargetCount(other.streamTargetCount) {
 
             // Copy lodDistances array
             for (int i = 0; i < 5; i++) {
@@ -222,6 +237,7 @@ namespace Engine {
             other.computeRGBASSBO    = 0;
             other.numBatches         = 0;
             other.computePointsPerThread = 0;
+            other.streamTargetCount  = 0; // stream already nulled by std::move
         }
 
         // Move assignment operator
@@ -274,6 +290,8 @@ namespace Engine {
                 computeRGBASSBO         = other.computeRGBASSBO;
                 numBatches              = other.numBatches;
                 computePointsPerThread  = other.computePointsPerThread;
+                stream                  = std::move(other.stream);
+                streamTargetCount       = other.streamTargetCount;
 
                 // Reset other object
                 other.vao = 0;
@@ -290,6 +308,7 @@ namespace Engine {
                 other.computeRGBASSBO    = 0;
                 other.numBatches         = 0;
                 other.computePointsPerThread = 0;
+                other.streamTargetCount  = 0; // stream already nulled by std::move
             }
             return *this;
         }
@@ -309,9 +328,15 @@ namespace Engine {
         }
 
         // Returns true if point cloud data is loaded and ready to render.
+        // A streaming cloud counts as loaded as soon as its background load has
+        // started (stream != null), so it is kept in the scene and rendered as
+        // its batches fill in.
         bool isLoaded() const {
-            return numBatches > 0 || !points.empty();
+            return numBatches > 0 || !points.empty() || stream != nullptr;
         }
+
+        // True while the cloud is still streaming in from disk.
+        bool isStreaming() const { return stream != nullptr; }
 
         // Returns true if the bounds fields are valid (set by the loader).
         bool hasBounds() const {

--- a/StereoVista/headers/Gui/GuiTypes.h
+++ b/StereoVista/headers/Gui/GuiTypes.h
@@ -222,6 +222,13 @@ struct ApplicationPreferences {
     int  maxRadius = 4; // upper clamp on splat radius in pixels (1–8)
   } pointSplatSettings;
 
+  // LAS/LAZ progressive loading. When true (default), files load two-phase:
+  // instant file-order display, then a background global per-file Morton sort is
+  // hot-swapped in for full render speed (Schütz's expected data layout produced
+  // at load). When false, the literal Schütz file-order layout is kept as-is
+  // (faster load, bounded RAM, but render speed depends on the file's ordering).
+  bool pointCloudMortonResort = true;
+
   // Shadow quality settings
   struct ShadowSettings {
     int pcfKernelSize = 3; // 3, 5, 7, or 9

--- a/StereoVista/headers/Loaders/PointCloudLoader.h
+++ b/StereoVista/headers/Loaders/PointCloudLoader.h
@@ -55,6 +55,19 @@ namespace Engine {
         // is not (or no longer) streaming.
         static void updateStreaming(PointCloud& pointCloud);
 
+        // Live progress for a streaming cloud (for UI). active == false when the
+        // cloud is fully loaded (no longer streaming).
+        struct StreamProgress {
+            bool     active          = false; // still streaming?
+            bool     resorting       = false; // phase 2 (background Morton sort) running
+            uint32_t pointsLoaded    = 0;     // points uploaded so far
+            uint32_t pointsTotal     = 0;     // expected final point count
+            float    fraction        = 0.0f;  // phase-1 load fraction [0,1]
+            double   elapsedSeconds  = 0.0;
+            double   pointsPerSecond = 0.0;   // average load rate
+        };
+        static StreamProgress getStreamProgress(const PointCloud& pointCloud);
+
         // Provide the GL extension loader (e.g. glfwGetProcAddress) so optional
         // GL_ARB_sparse_buffer support can be probed. Call once from main after
         // GLAD init; if not called (or null), streaming falls back to full

--- a/StereoVista/headers/Loaders/PointCloudLoader.h
+++ b/StereoVista/headers/Loaders/PointCloudLoader.h
@@ -39,16 +39,27 @@ namespace Engine {
         // and fills in progressively as updateStreaming() is pumped each frame on
         // the GL thread.  beginLoadLASMultipleProgressive shares a global centre
         // across tiles and loads all files concurrently.
+        // mortonResort=true (default) = two-phase: instant file-order display,
+        // then a background global Morton sort hot-swapped in for full render
+        // speed.  false = pure file-order (literal Schütz) with bounded RAM.
         static PointCloud beginLoadLASProgressive(const std::string& filePath,
                                                   size_t downsampleFactor = 1,
-                                                  const glm::dvec3* globalCenter = nullptr);
+                                                  const glm::dvec3* globalCenter = nullptr,
+                                                  bool mortonResort = true);
         static std::vector<PointCloud> beginLoadLASMultipleProgressive(
-            const std::vector<std::string>& filePaths, size_t downsampleFactor = 1);
+            const std::vector<std::string>& filePaths, size_t downsampleFactor = 1,
+            bool mortonResort = true);
 
         // Pump pending GPU uploads for a streaming cloud.  Call once per frame
         // per cloud on the thread that owns the GL context.  No-op when the cloud
         // is not (or no longer) streaming.
         static void updateStreaming(PointCloud& pointCloud);
+
+        // Provide the GL extension loader (e.g. glfwGetProcAddress) so optional
+        // GL_ARB_sparse_buffer support can be probed. Call once from main after
+        // GLAD init; if not called (or null), streaming falls back to full
+        // (non-sparse) SSBO reservations.
+        static void initGLExtensions(void* (*procLoader)(const char*));
 
         // Streams every point of the cloud to the callback, one decoded batch
         // at a time (peak CPU RAM = one batch). Sources the legacy CPU vector

--- a/StereoVista/headers/Loaders/PointCloudLoader.h
+++ b/StereoVista/headers/Loaders/PointCloudLoader.h
@@ -32,6 +32,24 @@ namespace Engine {
         static std::vector<PointCloud> loadFromLASMultiple(const std::vector<std::string>& filePaths,
                                                            size_t downsampleFactor = 1);
 
+        // ── Progressive (streaming) LAS/LAZ loading (Schütz compute_loop_las) ──
+        // Returns immediately: the SSBOs are pre-allocated from the LAS header's
+        // exact point count, header bounds are set so the cloud can be framed at
+        // once, and a background thread streams the points in.  The cloud renders
+        // and fills in progressively as updateStreaming() is pumped each frame on
+        // the GL thread.  beginLoadLASMultipleProgressive shares a global centre
+        // across tiles and loads all files concurrently.
+        static PointCloud beginLoadLASProgressive(const std::string& filePath,
+                                                  size_t downsampleFactor = 1,
+                                                  const glm::dvec3* globalCenter = nullptr);
+        static std::vector<PointCloud> beginLoadLASMultipleProgressive(
+            const std::vector<std::string>& filePaths, size_t downsampleFactor = 1);
+
+        // Pump pending GPU uploads for a streaming cloud.  Call once per frame
+        // per cloud on the thread that owns the GL context.  No-op when the cloud
+        // is not (or no longer) streaming.
+        static void updateStreaming(PointCloud& pointCloud);
+
         // Streams every point of the cloud to the callback, one decoded batch
         // at a time (peak CPU RAM = one batch). Sources the legacy CPU vector
         // when populated, otherwise reads the quantised compute SSBOs back

--- a/StereoVista/src/Engine/ComputePointCloudRenderer.cpp
+++ b/StereoVista/src/Engine/ComputePointCloudRenderer.cpp
@@ -396,12 +396,12 @@ void ComputePointCloudRenderer::endFrame() {
         m_accLookup  += double(lk)  * 1e-6;
         m_accPass2   += double(p2)  * 1e-6;
         if (++m_accCount >= 120) {
-            double n = m_accCount;
-            std::cout << "[PC GPU] rasterize=" << (m_accCompute/n)
-                      << " ms  lookup=" << (m_accLookup/n)
-                      << " ms  resolve=" << (m_accPass2/n)
-                      << " ms  total=" << ((m_accCompute + m_accLookup + m_accPass2)/n)
-                      << " ms  (avg/eye)\n";
+            //double n = m_accCount;
+            //std::cout << "[PC GPU] rasterize=" << (m_accCompute/n)
+            //          << " ms  lookup=" << (m_accLookup/n)
+            //          << " ms  resolve=" << (m_accPass2/n)
+            //          << " ms  total=" << ((m_accCompute + m_accLookup + m_accPass2)/n)
+            //          << " ms  (avg/eye)\n";
             m_accCompute = m_accClear = m_accLookup = m_accPass2 = 0.0;
             m_accCount = 0;
         }

--- a/StereoVista/src/Engine/ComputePointCloudRenderer.cpp
+++ b/StereoVista/src/Engine/ComputePointCloudRenderer.cpp
@@ -19,8 +19,8 @@ static const float kQuadVerts[] = {
 };
 
 // Max simultaneous point clouds per frame.  Must match the cloudID bit width in
-// pointcloud_rasterize.comp / pointcloud_color_lookup.comp (5 bits → 32).
-static constexpr uint32_t kMaxComputeClouds = 32;
+// pointcloud_rasterize.comp / pointcloud_color_lookup.comp (8 bits → 256).
+static constexpr uint32_t kMaxComputeClouds = 256;
 
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -223,7 +223,7 @@ void ComputePointCloudRenderer::renderNode(
     // Assign this cloud a stable per-frame id = its slot in the render order.
     // The id is packed into the framebuffer payload so endFrame() can resolve
     // each pixel's colour against the CORRECT cloud's rgba buffer.  Packed into
-    // 5 bits → at most kMaxComputeClouds clouds per frame.
+    // 8 bits → at most kMaxComputeClouds clouds per frame.
     uint32_t cloudID = static_cast<uint32_t>(m_frameRGBASSBOs.size());
     if (cloudID >= kMaxComputeClouds) {
         static bool warned = false;

--- a/StereoVista/src/Engine/ComputePointCloudRenderer.cpp
+++ b/StereoVista/src/Engine/ComputePointCloudRenderer.cpp
@@ -396,12 +396,12 @@ void ComputePointCloudRenderer::endFrame() {
         m_accLookup  += double(lk)  * 1e-6;
         m_accPass2   += double(p2)  * 1e-6;
         if (++m_accCount >= 120) {
-            //double n = m_accCount;
-            //std::cout << "[PC GPU] rasterize=" << (m_accCompute/n)
-            //          << " ms  lookup=" << (m_accLookup/n)
-            //          << " ms  resolve=" << (m_accPass2/n)
-            //          << " ms  total=" << ((m_accCompute + m_accLookup + m_accPass2)/n)
-            //          << " ms  (avg/eye)\n";
+            double n = m_accCount;
+            std::cout << "[PC GPU] rasterize=" << (m_accCompute/n)
+                      << " ms  lookup=" << (m_accLookup/n)
+                      << " ms  resolve=" << (m_accPass2/n)
+                      << " ms  total=" << ((m_accCompute + m_accLookup + m_accPass2)/n)
+                      << " ms  (avg/eye)\n";
             m_accCompute = m_accClear = m_accLookup = m_accPass2 = 0.0;
             m_accCount = 0;
         }

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -881,6 +881,91 @@ void GUI::UpdateWindowTitleForScene(const std::string &scenePath) {
 // Draws the active toasts stacked above the bottom edge, newest at the
 // bottom. Called every frame from renderGUI (in both the visible and the
 // hidden-GUI paths).
+// Compact human-readable point count: "1.23B" / "350.4M" / "12.0K" / "742".
+static std::string formatPointCount(uint64_t n) {
+  char buf[32];
+  if (n >= 1000000000ull)
+    snprintf(buf, sizeof(buf), "%.2fB", static_cast<double>(n) / 1e9);
+  else if (n >= 1000000ull)
+    snprintf(buf, sizeof(buf), "%.1fM", static_cast<double>(n) / 1e6);
+  else if (n >= 1000ull)
+    snprintf(buf, sizeof(buf), "%.1fK", static_cast<double>(n) / 1e3);
+  else
+    snprintf(buf, sizeof(buf), "%llu", static_cast<unsigned long long>(n));
+  return buf;
+}
+
+// Overlay (bottom-left) showing progressive LAS/LAZ load state + stats while any
+// point cloud is still streaming: per-cloud phase, % loaded, points and rate.
+// Disappears automatically once everything has finished loading.
+static void renderPointCloudStreamingOverlay() {
+  struct Item {
+    std::string name;
+    Engine::PointCloudLoader::StreamProgress p;
+  };
+  std::vector<Item> items;
+  for (const auto &pc : currentScene.pointClouds) {
+    if (!pc.isStreaming())
+      continue;
+    auto prog = Engine::PointCloudLoader::getStreamProgress(pc);
+    if (prog.active)
+      items.push_back({pc.name, prog});
+  }
+  if (items.empty())
+    return;
+
+  float scale = g_GuiScale.currentScale;
+  SetNextWindowPosInMainWindow(ImVec2(16.0f * scale, windowHeight - 16.0f * scale),
+                               ImGuiCond_Always, ImVec2(0.0f, 1.0f));
+  ImGui::SetNextWindowBgAlpha(0.90f);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 8.0f * scale);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
+                      ImVec2(14.0f * scale, 10.0f * scale));
+  ImGui::Begin("##pcloading", nullptr,
+               ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs |
+                   ImGuiWindowFlags_AlwaysAutoResize |
+                   ImGuiWindowFlags_NoSavedSettings |
+                   ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav);
+
+  if (g_Fonts.icons) {
+    ImGui::PushFont(g_Fonts.icons);
+    ImGui::TextColored(g_StyleColors.info, "%s", ICON_FA_CLOUD);
+    ImGui::PopFont();
+    ImGui::SameLine();
+  }
+  ImGui::Text("Loading %zu point cloud%s", items.size(),
+              items.size() == 1 ? "" : "s");
+  ImGui::Separator();
+
+  const float barW = 240.0f * scale;
+  for (const auto &it : items) {
+    const auto &p = it.p;
+    ImGui::TextUnformatted(it.name.c_str());
+    if (p.resorting) {
+      // Phase 2: background Morton sort — show an animated sweep (no fraction).
+      float anim =
+          static_cast<float>((static_cast<long long>(ImGui::GetTime() * 1000.0) %
+                              1000)) /
+          1000.0f;
+      ImGui::ProgressBar(anim, ImVec2(barW, 0.0f), "Optimizing (Morton sort)");
+      ImGui::TextDisabled("%s pts - sorting for full render speed...",
+                          formatPointCount(p.pointsTotal).c_str());
+    } else {
+      char ov[32];
+      snprintf(ov, sizeof(ov), "%.0f%%", p.fraction * 100.0f);
+      ImGui::ProgressBar(p.fraction, ImVec2(barW, 0.0f), ov);
+      ImGui::TextDisabled("%s / %s pts - %s pts/s",
+                          formatPointCount(p.pointsLoaded).c_str(),
+                          formatPointCount(p.pointsTotal).c_str(),
+                          formatPointCount(static_cast<uint64_t>(p.pointsPerSecond)).c_str());
+    }
+    ImGui::Spacing();
+  }
+
+  ImGui::End();
+  ImGui::PopStyleVar(2);
+}
+
 static void renderToasts() {
   if (g_toasts.empty())
     return;
@@ -1549,6 +1634,7 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
     if (showFPS) {
       renderPerformanceOverlay();
     }
+    renderPointCloudStreamingOverlay();
     renderToasts();
     ImGui::Render();
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
@@ -3046,6 +3132,9 @@ void renderGUI(bool isLeftEye, ImGuiViewportP *viewport,
   if (showFPS) {
     renderPerformanceOverlay();
   }
+
+  // Progressive point-cloud load progress (bottom-left, only while streaming)
+  renderPointCloudStreamingOverlay();
 
   // Transient status notifications (bottom-center)
   renderToasts();

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -1216,7 +1216,8 @@ static void importLASFiles(const std::vector<std::string> &lasFiles) {
   // points stream in on background threads and are uploaded each frame by
   // PointCloudLoader::updateStreaming() in the main loop, so the cloud appears
   // almost instantly and fills in while remaining tiles keep loading.
-  auto clouds = Engine::PointCloudLoader::beginLoadLASMultipleProgressive(lasFiles);
+  auto clouds = Engine::PointCloudLoader::beginLoadLASMultipleProgressive(
+      lasFiles, 1, preferences.pointCloudMortonResort);
   for (auto &pc : clouds) {
     currentScene.pointClouds.emplace_back(std::move(pc));
     Engine::Undo::recordPointCloudAdded(
@@ -3509,6 +3510,23 @@ void renderSettingsWindow() {
                          "fills larger gaps when extremely close, but costs more "
                          "atomic writes. 3-4 is a good balance.");
         }
+
+        // ---- LAS/LAZ progressive loading ----
+        ImGui::Spacing();
+        DrawSectionHeader("Point Cloud Loading (LAS/LAZ)");
+
+        if (ImGui::Checkbox("Morton Resort (two-phase)",
+                            &preferences.pointCloudMortonResort)) {
+          settingsChanged = true;
+        }
+        ImGui::SameLine();
+        DrawHelpMarker(
+            "On (default): LAS/LAZ files appear instantly in file order, then a "
+            "background per-file Morton sort is swapped in for full render speed "
+            "(tight per-batch culling regardless of the file's ordering). Off: "
+            "keep the file's original order as-is (literal Schütz loader) – "
+            "faster to load with lower RAM, but render speed depends on the file "
+            "already being spatially ordered. Applies to the next file loaded.");
 
         ImGui::Spacing();
         DrawSectionHeader("Shadow Quality");

--- a/StereoVista/src/Gui/GUI.cpp
+++ b/StereoVista/src/Gui/GUI.cpp
@@ -1211,12 +1211,19 @@ static void importPointCloudFile(const std::string &filePath) {
 static void importLASFiles(const std::vector<std::string> &lasFiles) {
   if (lasFiles.empty())
     return;
-  auto clouds = Engine::PointCloudLoader::loadFromLASMultiple(lasFiles);
+  // Progressive load: returns immediately with cloud stubs whose SSBOs are
+  // pre-sized from the LAS header and whose bounds are already valid.  The
+  // points stream in on background threads and are uploaded each frame by
+  // PointCloudLoader::updateStreaming() in the main loop, so the cloud appears
+  // almost instantly and fills in while remaining tiles keep loading.
+  auto clouds = Engine::PointCloudLoader::beginLoadLASMultipleProgressive(lasFiles);
   for (auto &pc : clouds) {
     currentScene.pointClouds.emplace_back(std::move(pc));
     Engine::Undo::recordPointCloudAdded(
         static_cast<int>(currentScene.pointClouds.size()) - 1);
   }
+  // Bounds come from the LAS headers, so SpaceMouse extents are correct
+  // immediately even though points are still streaming.
   updateSpaceMouseBounds();
 }
 

--- a/StereoVista/src/Loaders/PointCloudLoader.cpp
+++ b/StereoVista/src/Loaders/PointCloudLoader.cpp
@@ -224,23 +224,86 @@ namespace Engine {
     // =========================================================================
     // Progressive (streaming) LAS/LAZ loading – Schütz "compute_loop_las" style
     // =========================================================================
-    // Mirrors m-schuetz/compute_rasterizer's LasLoaderSparse:
-    //   • a background worker thread reads the file in chunks and produces
-    //     ready-to-upload GPU staging ("StreamChunk"s);
-    //   • the GL/main thread drains those chunks every frame in updateStreaming()
-    //     via glBufferSubData into SSBOs that were pre-allocated to the exact
-    //     header point count, growing pc.numBatches as data arrives so the
-    //     existing compute rasterizer draws the cloud while it is still loading.
+    // Mirrors m-schuetz/compute_rasterizer's LasLoaderSparse, with a two-phase
+    // ordering strategy:
     //
-    // Unlike Schütz's pure file-order streaming, each chunk is Morton-sorted and
-    // its batches shuffled (the same transform buildComputeCloud applies, but
-    // scoped to the chunk).  This keeps per-batch bounding boxes tight regardless
-    // of the file's on-disk ordering, so frustum culling / adaptive precision /
-    // early-z stay exactly as fast as the one-shot path – at bounded CPU RAM.
+    //   Phase 1 (instant display, Schütz's literal loader): a background worker
+    //     reads the file in chunks and produces ready-to-upload GPU staging
+    //     ("StreamChunk"s) in *file order* (no sort). The GL/main thread drains
+    //     them each frame in updateStreaming() via glBufferSubData into SSBOs
+    //     pre-allocated to the exact header point count, growing pc.numBatches as
+    //     data arrives so the compute rasterizer draws the cloud while it loads.
+    //
+    //   Phase 2 (full speed, optional): once the whole file is in, the worker
+    //     runs a single global per-file Morton sort + batch shuffle (exactly the
+    //     buildComputeCloud transform) over the accumulated points, producing
+    //     re-ordered arrays that the main thread swaps into the SSBOs in place.
+    //     Re-ordering points never changes the rendered image, only batch AABB
+    //     tightness, so the swap is visually transparent. Both phases keep the
+    //     partial last batch in the final slot, so phase-1 and phase-2 batch
+    //     boundaries align (multiples of kComputeBatchSize) and the swap is
+    //     point/descriptor-consistent. Phase 2 is the default; it can be disabled
+    //     (mortonResort=false) for the pure file-order Schütz path.
     //
     // The LAS header is exploited up front: exact point count (precise SSBO
     // pre-allocation + progress, no counting pass) and exact bounds (camera
     // framing and SpaceMouse extents are valid before a single point is read).
+
+    // ── Optional GL_ARB_sparse_buffer support ────────────────────────────────
+    // Schütz allocates the point SSBOs as *sparse* buffers and commits physical
+    // pages on demand as data streams in, so VRAM use tracks the loaded portion
+    // rather than the full reservation. Our vendored GLAD does not expose the
+    // extension, so we load the entry point manually (set up from main once the
+    // GL context exists) and fall back to a normal glBufferData reservation when
+    // it is unavailable.
+#ifndef GL_SPARSE_STORAGE_BIT_ARB
+#define GL_SPARSE_STORAGE_BIT_ARB 0x0400
+#endif
+#ifndef GL_SPARSE_BUFFER_PAGE_SIZE_ARB
+#define GL_SPARSE_BUFFER_PAGE_SIZE_ARB 0x82F8
+#endif
+    typedef void (APIENTRYP PFN_glBufferPageCommitmentARB_t)(GLenum target, GLintptr offset, GLsizeiptr size, GLboolean commit);
+    static PFN_glBufferPageCommitmentARB_t s_glBufferPageCommitmentARB = nullptr;
+    static void* (*s_glProcLoader)(const char*) = nullptr;
+    static GLint s_sparsePageSize  = 0;
+    static bool  s_sparseChecked   = false;
+    static bool  s_sparseAvailable = false;
+
+    // True if sparse buffers can be used (entry point loaded + page size known).
+    static bool sparseBuffersAvailable() {
+        if (s_sparseChecked) return s_sparseAvailable;
+        s_sparseChecked = true;
+        if (s_glProcLoader) {
+            s_glBufferPageCommitmentARB = reinterpret_cast<PFN_glBufferPageCommitmentARB_t>(
+                s_glProcLoader("glBufferPageCommitmentARB"));
+        }
+        if (s_glBufferPageCommitmentARB) {
+            glGetIntegerv(GL_SPARSE_BUFFER_PAGE_SIZE_ARB, &s_sparsePageSize);
+            if (glGetError() == GL_NO_ERROR && s_sparsePageSize > 0)
+                s_sparseAvailable = true;
+        }
+        std::cout << "[LAS-Stream] Sparse buffers "
+                  << (s_sparseAvailable ? "available (page size "
+                      + std::to_string(s_sparsePageSize) + ")" : "unavailable – using full reservation")
+                  << "\n";
+        return s_sparseAvailable;
+    }
+
+    // Commit the sparse pages covering [byteOffset, byteOffset+byteSize) of the
+    // currently-bound SSBO (Schütz's alignment).  No-op unless this cloud's
+    // buffers were actually created sparse (sparse==true). The entry point and
+    // page size are stable once probed, so this stays correct even if a later
+    // cloud falls back to non-sparse.
+    static void commitSparseRange(bool sparse, GLintptr byteOffset, GLsizeiptr byteSize, GLsizeiptr bufferBytes) {
+        if (!sparse || !s_glBufferPageCommitmentARB || s_sparsePageSize <= 0 || byteSize <= 0) return;
+        const GLintptr  page  = static_cast<GLintptr>(s_sparsePageSize);
+        const GLintptr  aOff  = byteOffset - (byteOffset % page);
+        GLsizeiptr      aSize = byteSize + (byteOffset - aOff);
+        aSize = ((aSize + page - 1) / page) * page;             // round up to page
+        if (aOff + aSize > bufferBytes) aSize = bufferBytes - aOff; // clamp to buffer
+        if (aSize > 0)
+            s_glBufferPageCommitmentARB(GL_SHADER_STORAGE_BUFFER, aOff, aSize, GL_TRUE);
+    }
 
     struct StreamChunk {
         uint32_t firstPoint = 0;   // base offset into the per-point SSBOs
@@ -259,13 +322,24 @@ namespace Engine {
         std::thread             worker;
         std::mutex              mtx;
         std::condition_variable cv;          // signals both produce and consume
-        std::queue<StreamChunk> ready;       // produced chunks awaiting upload
+        std::queue<StreamChunk> ready;       // phase-1 chunks awaiting upload
         std::atomic<bool>       stop{false}; // request worker exit (cloud removed)
+        std::atomic<bool>       phase1Done{false};
         std::atomic<bool>       finished{false};
         std::atomic<bool>       failed{false};
         size_t                  maxInFlight = 4; // backpressure → bounds CPU RAM
+        bool                    resort = true;   // do phase 2 (global Morton sort)?
+        bool                    sparse = false;  // were the SSBOs created sparse?
         uint32_t                targetPoints  = 0;
         uint32_t                targetBatches = 0;
+
+        // ── Phase 2 result (built by the worker, swapped in by the GL thread) ──
+        // Re-ordered, fully-quantised arrays for the whole cloud. Boundaries are
+        // aligned to kComputeBatchSize so they overwrite the phase-1 SSBOs in
+        // place. resortReady flips true when these are populated.
+        std::atomic<bool>         resortReady{false};
+        std::vector<uint32_t>     r_xyz4b, r_xyz8b, r_xyz12b, r_rgba;
+        std::vector<ComputeBatch> r_batches;
 
         ~PointCloudStream() {
             stop.store(true);
@@ -274,133 +348,195 @@ namespace Engine {
         }
     };
 
-    // Build one StreamChunk from a run of decoded points using exactly the
-    // Morton-sort + per-batch shuffle + 10/20/30-bit quantisation of
-    // buildComputeCloud, scoped to the chunk.  globalFirstPoint/globalFirstBatch
-    // are this chunk's base offsets in the pre-allocated SSBOs; batch.firstPoint
-    // is written as a *global* index so the rasterizer indexes the SSBOs directly.
-    static void buildStreamChunk(std::vector<PointCloudPoint>& pts,
-                                 uint32_t globalFirstPoint,
-                                 uint32_t globalFirstBatch,
-                                 StreamChunk& out) {
-        const size_t N = pts.size();
+    // Quantise one point relative to its batch bbox [bMin, bMin+sz] into the
+    // three 10-bit tiers + packed RGBA (alpha carries intensity), writing output
+    // index o.  Identical encoding to buildComputeCloud.
+    static inline void quantizePoint(const PointCloudPoint& P,
+                                     const glm::vec3& bMin, const glm::vec3& sz, uint32_t o,
+                                     uint32_t* xyz4b, uint32_t* xyz8b, uint32_t* xyz12b, uint32_t* rgba) {
+        constexpr uint32_t STEPS_30BIT = 1u << 30;
+        constexpr uint32_t MASK_10BIT  = 1023u;
+        auto q = [](float v, float lo, float ss) -> uint32_t {
+            const float nn = glm::clamp((v - lo) / ss, 0.0f, 1.0f);
+            return std::min(static_cast<uint32_t>(nn * static_cast<float>(STEPS_30BIT)), STEPS_30BIT - 1u);
+        };
+        const uint32_t Xb = q(P.position.x, bMin.x, sz.x);
+        const uint32_t Yb = q(P.position.y, bMin.y, sz.y);
+        const uint32_t Zb = q(P.position.z, bMin.z, sz.z);
+        xyz4b [o] = ((Xb>>20)&MASK_10BIT) | (((Yb>>20)&MASK_10BIT)<<10) | (((Zb>>20)&MASK_10BIT)<<20);
+        xyz8b [o] = ((Xb>>10)&MASK_10BIT) | (((Yb>>10)&MASK_10BIT)<<10) | (((Zb>>10)&MASK_10BIT)<<20);
+        xyz12b[o] = (Xb&MASK_10BIT) | ((Yb&MASK_10BIT)<<10) | ((Zb&MASK_10BIT)<<20);
+        const uint32_t r8 = static_cast<uint32_t>(glm::clamp(P.color.r,    0.f, 1.f) * 255.f + 0.5f);
+        const uint32_t g8 = static_cast<uint32_t>(glm::clamp(P.color.g,    0.f, 1.f) * 255.f + 0.5f);
+        const uint32_t b8 = static_cast<uint32_t>(glm::clamp(P.color.b,    0.f, 1.f) * 255.f + 0.5f);
+        const uint32_t a8 = static_cast<uint32_t>(glm::clamp(P.intensity, 0.f, 1.f) * 255.f + 0.5f);
+        rgba[o] = (a8<<24)|(b8<<16)|(g8<<8)|r8;
+    }
+
+    // Phase 1: build a file-order StreamChunk from pts[0..N) (no sort) — Schütz's
+    // literal loader layout. Batches are consecutive runs of kComputeBatchSize,
+    // each with its own bbox; the last batch of a chunk may be partial. The very
+    // last chunk's tail is the only globally-partial batch, so global batch
+    // boundaries are multiples of kComputeBatchSize (matching phase 2).
+    static void buildFileOrderChunk(const PointCloudPoint* pts, size_t N,
+                                    uint32_t globalFirstPoint, uint32_t globalFirstBatch,
+                                    StreamChunk& out) {
         out.firstPoint = globalFirstPoint;
         out.firstBatch = globalFirstBatch;
         out.numPoints  = static_cast<uint32_t>(N);
         if (N == 0) return;
+        const int      B    = PointCloud::kComputeBatchSize;
+        const uint32_t numB = static_cast<uint32_t>((N + B - 1) / B);
+        out.xyz4b.resize(N); out.xyz8b.resize(N); out.xyz12b.resize(N); out.rgba.resize(N);
+        out.batches.resize(numB);
+        for (uint32_t t = 0; t < numB; ++t) {
+            const size_t   first = static_cast<size_t>(t) * B;
+            const uint32_t count = static_cast<uint32_t>(std::min<size_t>(static_cast<size_t>(B), N - first));
+            glm::vec3 bMin( FLT_MAX), bMax(-FLT_MAX);
+            for (uint32_t k = 0; k < count; ++k) { const glm::vec3& p = pts[first+k].position; bMin = glm::min(bMin,p); bMax = glm::max(bMax,p); }
+            const glm::vec3 sz = glm::max(bMax - bMin, glm::vec3(1e-6f));
+            out.batches[t] = { bMin.x,bMin.y,bMin.z, bMax.x,bMax.y,bMax.z,
+                               static_cast<int>(count),
+                               static_cast<int>(globalFirstPoint + static_cast<uint32_t>(first)) };
+            for (uint32_t k = 0; k < count; ++k)
+                quantizePoint(pts[first+k], bMin, sz, static_cast<uint32_t>(first) + k,
+                              out.xyz4b.data(), out.xyz8b.data(), out.xyz12b.data(), out.rgba.data());
+        }
+    }
 
+    // Phase 2: global per-file Morton sort + batch shuffle + quantise the whole
+    // cloud into the given arrays (pure CPU, no GL). Mirrors buildComputeCloud,
+    // except the partial batch (if any) is kept LAST so every output offset is a
+    // multiple of kComputeBatchSize — i.e. phase-2 batch boundaries match phase-1
+    // exactly, letting the GL thread overwrite the SSBOs in place.
+    static void computeCloudArrays(const std::vector<PointCloudPoint>& pts,
+                                   std::vector<uint32_t>& xyz4b, std::vector<uint32_t>& xyz8b,
+                                   std::vector<uint32_t>& xyz12b, std::vector<uint32_t>& rgba,
+                                   std::vector<ComputeBatch>& batches) {
+        const size_t N = pts.size();
+        if (N == 0) return;
         glm::vec3 gMin( FLT_MAX), gMax(-FLT_MAX);
         for (const auto& p : pts) { gMin = glm::min(gMin, p.position); gMax = glm::max(gMax, p.position); }
         const glm::vec3 ext = glm::max(gMax - gMin, glm::vec3(1e-9f));
         constexpr uint32_t MAXQ = (1u << 21) - 1u;
 
         std::vector<std::pair<uint64_t, uint32_t>> order(N);
-        for (size_t i = 0; i < N; ++i) {
-            const glm::vec3 n = glm::clamp((pts[i].position - gMin) / ext, 0.0f, 1.0f);
-            order[i] = { mortonEncode3D(static_cast<uint32_t>(n.x * static_cast<float>(MAXQ)),
-                                        static_cast<uint32_t>(n.y * static_cast<float>(MAXQ)),
-                                        static_cast<uint32_t>(n.z * static_cast<float>(MAXQ))),
-                         static_cast<uint32_t>(i) };
+        #pragma omp parallel for schedule(static)
+        for (long long i = 0; i < static_cast<long long>(N); ++i) {
+            const glm::vec3 n = glm::clamp((pts[static_cast<size_t>(i)].position - gMin) / ext, 0.0f, 1.0f);
+            order[static_cast<size_t>(i)] =
+                { mortonEncode3D(static_cast<uint32_t>(n.x * static_cast<float>(MAXQ)),
+                                 static_cast<uint32_t>(n.y * static_cast<float>(MAXQ)),
+                                 static_cast<uint32_t>(n.z * static_cast<float>(MAXQ))),
+                  static_cast<uint32_t>(i) };
         }
-        std::sort(order.begin(), order.end(),
-                  [](const std::pair<uint64_t, uint32_t>& a,
-                     const std::pair<uint64_t, uint32_t>& b) { return a.first < b.first; });
+        std::sort(std::execution::par, order.begin(), order.end(),
+                  [](const std::pair<uint64_t,uint32_t>& a,
+                     const std::pair<uint64_t,uint32_t>& b) { return a.first < b.first; });
 
-        const int      B    = PointCloud::kComputeBatchSize;
-        const uint32_t numB = static_cast<uint32_t>((N + B - 1) / B);
+        const int      B       = PointCloud::kComputeBatchSize;
+        const uint32_t numB    = static_cast<uint32_t>((N + B - 1) / B);
+        const uint32_t numFull = static_cast<uint32_t>(N / B); // size-B batches
+        // Shuffle the full batches only; the partial batch (sorted index numFull)
+        // stays in the final slot so output offsets remain multiples of B.
         std::vector<uint32_t> perm(numB);
         for (uint32_t i = 0; i < numB; ++i) perm[i] = i;
-        std::mt19937 rng(0x5eed1234u ^ globalFirstBatch);  // per-chunk reproducible
-        std::shuffle(perm.begin(), perm.end(), rng);
+        std::mt19937 rng(0x5eed1234u);
+        if (numFull > 1) std::shuffle(perm.begin(), perm.begin() + numFull, rng);
 
-        std::vector<uint32_t> outFirst(numB);
-        for (uint32_t t = 0, off = 0; t < numB; ++t) {
-            const uint32_t src   = perm[t];
-            const uint32_t count = static_cast<uint32_t>(std::min<size_t>(static_cast<size_t>(B), N - static_cast<size_t>(src) * B));
-            outFirst[t] = off;
-            off += count;
-        }
+        xyz4b.resize(N); xyz8b.resize(N); xyz12b.resize(N); rgba.resize(N);
+        batches.resize(numB);
 
-        out.xyz4b.resize(N); out.xyz8b.resize(N); out.xyz12b.resize(N); out.rgba.resize(N);
-        out.batches.resize(numB);
-        constexpr uint32_t STEPS_30BIT = 1u << 30;
-        constexpr uint32_t MASK_10BIT  = 1023u;
-
-        for (uint32_t t = 0; t < numB; ++t) {
-            const uint32_t src   = perm[t];
+        #pragma omp parallel for schedule(dynamic)
+        for (long long t = 0; t < static_cast<long long>(numB); ++t) {
+            const uint32_t src   = perm[static_cast<size_t>(t)];
             const size_t   s     = static_cast<size_t>(src) * B;
             const uint32_t count = static_cast<uint32_t>(std::min<size_t>(static_cast<size_t>(B), N - s));
-            const uint32_t first = outFirst[t];
-
+            const uint32_t first = static_cast<uint32_t>(t) * B; // aligned (full batches first)
             glm::vec3 bMin( FLT_MAX), bMax(-FLT_MAX);
-            for (uint32_t k = 0; k < count; ++k) {
-                const glm::vec3& p = pts[order[s + k].second].position;
-                bMin = glm::min(bMin, p); bMax = glm::max(bMax, p);
-            }
+            for (uint32_t k = 0; k < count; ++k) { const glm::vec3& p = pts[order[s+k].second].position; bMin=glm::min(bMin,p); bMax=glm::max(bMax,p); }
             const glm::vec3 sz = glm::max(bMax - bMin, glm::vec3(1e-6f));
-            out.batches[t] = { bMin.x, bMin.y, bMin.z, bMax.x, bMax.y, bMax.z,
-                               static_cast<int>(count),
-                               static_cast<int>(globalFirstPoint + first) };
-
-            for (uint32_t k = 0; k < count; ++k) {
-                const PointCloudPoint& P = pts[order[s + k].second];
-                auto q = [&](float v, float lo, float ss) -> uint32_t {
-                    const float nn = glm::clamp((v - lo) / ss, 0.0f, 1.0f);
-                    return std::min(static_cast<uint32_t>(nn * static_cast<float>(STEPS_30BIT)), STEPS_30BIT - 1u);
-                };
-                const uint32_t Xb = q(P.position.x, bMin.x, sz.x);
-                const uint32_t Yb = q(P.position.y, bMin.y, sz.y);
-                const uint32_t Zb = q(P.position.z, bMin.z, sz.z);
-                const uint32_t o  = first + k;
-                out.xyz4b [o] = ((Xb>>20)&MASK_10BIT) | (((Yb>>20)&MASK_10BIT)<<10) | (((Zb>>20)&MASK_10BIT)<<20);
-                out.xyz8b [o] = ((Xb>>10)&MASK_10BIT) | (((Yb>>10)&MASK_10BIT)<<10) | (((Zb>>10)&MASK_10BIT)<<20);
-                out.xyz12b[o] = (Xb&MASK_10BIT) | ((Yb&MASK_10BIT)<<10) | ((Zb&MASK_10BIT)<<20);
-                const uint32_t r8 = static_cast<uint32_t>(glm::clamp(P.color.r,    0.f, 1.f) * 255.f + 0.5f);
-                const uint32_t g8 = static_cast<uint32_t>(glm::clamp(P.color.g,    0.f, 1.f) * 255.f + 0.5f);
-                const uint32_t b8 = static_cast<uint32_t>(glm::clamp(P.color.b,    0.f, 1.f) * 255.f + 0.5f);
-                const uint32_t a8 = static_cast<uint32_t>(glm::clamp(P.intensity, 0.f, 1.f) * 255.f + 0.5f);
-                out.rgba[o] = (a8<<24)|(b8<<16)|(g8<<8)|r8;
-            }
+            batches[static_cast<size_t>(t)] = { bMin.x,bMin.y,bMin.z, bMax.x,bMax.y,bMax.z,
+                                                static_cast<int>(count), static_cast<int>(first) };
+            for (uint32_t k = 0; k < count; ++k)
+                quantizePoint(pts[order[s+k].second], bMin, sz, first + k,
+                              xyz4b.data(), xyz8b.data(), xyz12b.data(), rgba.data());
         }
     }
 
-    // Worker thread body: decode the LAS/LAZ file in chunks, build each chunk,
-    // and hand it to the consumer with backpressure (waits when too many chunks
-    // are already queued).  Pure CPU work – no GL calls happen here.
+    // Worker thread body. Pure CPU work – no GL calls happen here.
+    //   Phase 1: decode the file in chunks and hand file-order StreamChunks to
+    //            the consumer with backpressure (instant display).
+    //   Phase 2: if resorting, run one global Morton sort over the points kept
+    //            during phase 1 and publish the re-ordered arrays for an in-place
+    //            SSBO swap by the GL thread.
     static void streamWorkerLAS(PointCloudStream* S, std::string filePath, size_t downsample,
                                 double sx, double sy, double sz,
                                 double ox, double oy, double oz,
                                 double cx, double cy, double cz,
                                 bool hasColor, float colorScale, int64_t nPoints) {
-        auto bail = [&]() { S->failed.store(true); S->finished.store(true); S->cv.notify_all(); };
+        auto bail = [&]() { S->failed.store(true); S->phase1Done.store(true); S->finished.store(true); S->cv.notify_all(); };
 
         laszip_POINTER reader = nullptr; laszip_BOOL comp = 0;
         if (laszip_create(&reader)) { bail(); return; }
         if (laszip_open_reader(reader, filePath.c_str(), &comp)) { laszip_destroy(reader); bail(); return; }
         laszip_point_struct* lp = nullptr; laszip_get_point_pointer(reader, &lp);
 
-        const int    B     = PointCloud::kComputeBatchSize;
-        const size_t CHUNK = static_cast<size_t>(64) * B;   // ~655k points / chunk
-        std::vector<PointCloudPoint> buf; buf.reserve(CHUNK);
-        uint32_t outPoint = 0, outBatch = 0;
+        const int    B      = PointCloud::kComputeBatchSize;
+        const size_t CHUNK  = static_cast<size_t>(64) * B;   // ~655k points / chunk
+        bool         resort = S->resort;
 
-        auto flush = [&]() {
-            if (buf.empty()) return;
-            StreamChunk ck;
-            buildStreamChunk(buf, outPoint, outBatch, ck);
-            outPoint += ck.numPoints;
-            outBatch += static_cast<uint32_t>(ck.batches.size());
+        // resort: keep every decoded point so the global Morton sort can run after
+        // phase 1 (reserve up front → no reallocation, so chunk pointers stay
+        // valid). non-resort: a small bounded buffer keeps peak RAM tiny.
+        // If the big reserve fails (file larger than RAM), fall back to bounded
+        // file-order streaming so the cloud still loads (just without phase 2).
+        std::vector<PointCloudPoint> allPoints;
+        std::vector<PointCloudPoint> buf;
+        try {
+            if (resort) allPoints.reserve(static_cast<size_t>(std::max<int64_t>(nPoints, 0)));
+            else        buf.reserve(CHUNK);
+        } catch (const std::bad_alloc&) {
+            std::cerr << "[LAS-Stream] not enough RAM to keep points for resort; "
+                         "falling back to file-order streaming for '" << filePath << "'\n";
+            resort = false;
+            buf.reserve(CHUNK);
+        }
+
+        uint32_t outPoint = 0, outBatch = 0;
+        size_t   pendingStart = 0; // resort mode: first allPoints index not yet flushed
+
+        auto pushChunk = [&](StreamChunk& ck) -> bool {
             std::unique_lock<std::mutex> lk(S->mtx);
             S->cv.wait(lk, [&] { return S->stop.load() || S->ready.size() < S->maxInFlight; });
-            if (S->stop.load()) return;
+            if (S->stop.load()) return false;
             S->ready.push(std::move(ck));
             lk.unlock();
             S->cv.notify_all();
+            return true;
+        };
+        auto flushBounded = [&]() -> bool {           // !resort path
+            if (buf.empty()) return true;
+            StreamChunk ck;
+            buildFileOrderChunk(buf.data(), buf.size(), outPoint, outBatch, ck);
+            outPoint += ck.numPoints; outBatch += static_cast<uint32_t>(ck.batches.size());
             buf.clear();
+            return pushChunk(ck);
+        };
+        auto flushAccumulated = [&](bool force) -> bool {  // resort path
+            while ((allPoints.size() - pendingStart) >= CHUNK ||
+                   (force && pendingStart < allPoints.size())) {
+                const size_t n = std::min(CHUNK, allPoints.size() - pendingStart);
+                StreamChunk ck;
+                buildFileOrderChunk(allPoints.data() + pendingStart, n, outPoint, outBatch, ck);
+                outPoint += ck.numPoints; outBatch += static_cast<uint32_t>(ck.batches.size());
+                pendingStart += n;
+                if (!pushChunk(ck)) return false;
+            }
+            return true;
         };
 
-        // Decode loop is wrapped so a std::bad_alloc (or any failure building a
-        // chunk) marks the stream failed instead of std::terminate-ing the app.
+        // ── Phase 1: decode + stream file-order chunks ───────────────────────
         try {
             for (int64_t i = 0; i < nPoints; ++i) {
                 if (S->stop.load()) break;
@@ -419,18 +555,39 @@ namespace Engine {
                 } else {
                     pt.color = glm::vec3(pt.intensity);
                 }
-                buf.push_back(pt);
-                if (buf.size() >= CHUNK) flush();
+
+                if (resort) {
+                    allPoints.push_back(pt);
+                    if ((allPoints.size() - pendingStart) >= CHUNK) { if (!flushAccumulated(false)) break; }
+                } else {
+                    buf.push_back(pt);
+                    if (buf.size() >= CHUNK) { if (!flushBounded()) break; }
+                }
             }
-            if (!S->stop.load()) flush();
+            if (!S->stop.load()) { if (resort) flushAccumulated(true); else flushBounded(); }
         } catch (const std::exception& e) {
-            std::cerr << "[LAS-Stream] worker exception for '" << filePath << "': "
-                      << e.what() << "\n";
+            std::cerr << "[LAS-Stream] phase-1 exception for '" << filePath << "': " << e.what() << "\n";
             S->failed.store(true);
         }
 
         laszip_close_reader(reader);
         laszip_destroy(reader);
+        S->phase1Done.store(true);
+        S->cv.notify_all();
+
+        // ── Phase 2: one global Morton sort, published for an in-place swap ───
+        if (resort && !S->stop.load() && !S->failed.load() && !allPoints.empty()) {
+            try {
+                computeCloudArrays(allPoints, S->r_xyz4b, S->r_xyz8b, S->r_xyz12b, S->r_rgba, S->r_batches);
+                std::vector<PointCloudPoint>().swap(allPoints); // free phase-1 copy
+                S->resortReady.store(true);
+                std::cout << "[LAS-Stream] phase 2 (Morton resort) ready for '" << filePath << "'\n";
+            } catch (const std::exception& e) {
+                std::cerr << "[LAS-Stream] phase-2 exception for '" << filePath << "': " << e.what()
+                          << " – keeping file-order data\n";
+            }
+        }
+
         S->finished.store(true);
         S->cv.notify_all();
     }
@@ -2426,7 +2583,8 @@ namespace Engine {
     // -------------------------------------------------------------------------
     PointCloud PointCloudLoader::beginLoadLASProgressive(const std::string& filePath,
                                                          size_t downsampleFactor,
-                                                         const glm::dvec3* globalCenter) {
+                                                         const glm::dvec3* globalCenter,
+                                                         bool mortonResort) {
         PointCloud pc;
         pc.name     = std::filesystem::path(filePath).stem().string();
         pc.filePath = filePath;
@@ -2489,23 +2647,43 @@ namespace Engine {
         const uint32_t allocBatches =
             (allocPoints + PointCloud::kComputeBatchSize - 1) / PointCloud::kComputeBatchSize;
 
-        // Pre-allocate the 5 SSBOs to full size (NULL data).  VRAM use scales
-        // with the cloud (no artificial cap); allocation fails cleanly if the
-        // cloud exceeds available VRAM (Path B / out-of-core territory).
-        deleteComputeSSBOs(pc);
-        auto alloc = [&](GLuint& id, GLsizeiptr bytes) -> bool {
-            glGenBuffers(1, &id);
-            glBindBuffer(GL_SHADER_STORAGE_BUFFER, id);
-            glBufferData(GL_SHADER_STORAGE_BUFFER, bytes, nullptr, GL_STATIC_DRAW);
-            return glGetError() == GL_NO_ERROR;
+        // Pre-allocate the 5 SSBOs to full size.  When GL_ARB_sparse_buffer is
+        // available we reserve sparsely (glBufferStorage + SPARSE bit) and commit
+        // physical pages on demand as chunks arrive (Schütz), so VRAM tracks the
+        // loaded portion; otherwise we fall back to a plain glBufferData
+        // reservation.  Either way VRAM scales with the cloud (no artificial cap)
+        // and allocation fails cleanly if the cloud exceeds VRAM.
+        bool useSparse = sparseBuffersAvailable();
+        auto allocAll = [&]() -> bool {
+            deleteComputeSSBOs(pc);
+            auto alloc = [&](GLuint& id, GLsizeiptr bytes) -> bool {
+                glGenBuffers(1, &id);
+                glBindBuffer(GL_SHADER_STORAGE_BUFFER, id);
+                if (useSparse)
+                    glBufferStorage(GL_SHADER_STORAGE_BUFFER, bytes, nullptr,
+                                    GL_DYNAMIC_STORAGE_BIT | GL_SPARSE_STORAGE_BIT_ARB);
+                else
+                    glBufferData(GL_SHADER_STORAGE_BUFFER, bytes, nullptr, GL_STATIC_DRAW);
+                return glGetError() == GL_NO_ERROR;
+            };
+            bool ok = true;
+            ok = alloc(pc.computeBatchSSBO,  static_cast<GLsizeiptr>(allocBatches) * sizeof(ComputeBatch)) && ok;
+            ok = alloc(pc.computeXyz4bSSBO,  static_cast<GLsizeiptr>(allocPoints)  * sizeof(uint32_t)) && ok;
+            ok = alloc(pc.computeXyz8bSSBO,  static_cast<GLsizeiptr>(allocPoints)  * sizeof(uint32_t)) && ok;
+            ok = alloc(pc.computeXyz12bSSBO, static_cast<GLsizeiptr>(allocPoints)  * sizeof(uint32_t)) && ok;
+            ok = alloc(pc.computeRGBASSBO,   static_cast<GLsizeiptr>(allocPoints)  * sizeof(uint32_t)) && ok;
+            glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+            return ok;
         };
-        bool ok = true;
-        ok = alloc(pc.computeBatchSSBO,  static_cast<GLsizeiptr>(allocBatches) * sizeof(ComputeBatch)) && ok;
-        ok = alloc(pc.computeXyz4bSSBO,  static_cast<GLsizeiptr>(allocPoints)  * sizeof(uint32_t)) && ok;
-        ok = alloc(pc.computeXyz8bSSBO,  static_cast<GLsizeiptr>(allocPoints)  * sizeof(uint32_t)) && ok;
-        ok = alloc(pc.computeXyz12bSSBO, static_cast<GLsizeiptr>(allocPoints)  * sizeof(uint32_t)) && ok;
-        ok = alloc(pc.computeRGBASSBO,   static_cast<GLsizeiptr>(allocPoints)  * sizeof(uint32_t)) && ok;
-        glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+        bool ok = allocAll();
+        if (!ok && useSparse) {
+            // Sparse storage was reported available but the driver rejected it;
+            // disable sparse globally and retry with a normal reservation.
+            std::cerr << "[LAS-Stream] sparse allocation rejected – retrying non-sparse\n";
+            s_sparseAvailable = false;
+            useSparse = false;
+            ok = allocAll();
+        }
         if (!ok) {
             std::cerr << "[LAS-Stream] GPU allocation failed for " << allocPoints
                       << " points – file likely exceeds available VRAM\n";
@@ -2523,13 +2701,17 @@ namespace Engine {
         pc.stream = std::make_shared<PointCloudStream>();
         pc.stream->targetPoints  = allocPoints;
         pc.stream->targetBatches = allocBatches;
+        pc.stream->resort        = mortonResort;
+        pc.stream->sparse        = useSparse;
         PointCloudStream* S = pc.stream.get();
         S->worker = std::thread(streamWorkerLAS, S, filePath, downsampleFactor,
                                 sx, sy, sz, ox, oy, oz, cx, cy, cz,
                                 hasColor, colorScale, nPoints);
 
         std::cout << "[LAS-Stream] " << (comp ? "LAZ" : "LAS") << " " << filePath
-                  << " – streaming " << nPoints << " points (" << allocBatches << " batches)\n";
+                  << " – streaming " << nPoints << " points (" << allocBatches << " batches), "
+                  << (mortonResort ? "two-phase (file-order → Morton resort)" : "file-order only")
+                  << (useSparse ? ", sparse VRAM" : "") << "\n";
         return pc;
     }
 
@@ -2537,7 +2719,7 @@ namespace Engine {
     // kicks off one background stream per file.  All files load concurrently, so
     // multi-tile sets fill in together instead of one-after-another.
     std::vector<PointCloud> PointCloudLoader::beginLoadLASMultipleProgressive(
-        const std::vector<std::string>& filePaths, size_t downsampleFactor) {
+        const std::vector<std::string>& filePaths, size_t downsampleFactor, bool mortonResort) {
         if (filePaths.empty()) return {};
 
         double gMinX =  DBL_MAX, gMinY =  DBL_MAX, gMinZ =  DBL_MAX;
@@ -2560,20 +2742,33 @@ namespace Engine {
         std::vector<PointCloud> out;
         out.reserve(filePaths.size());
         for (const auto& path : filePaths) {
-            PointCloud pc = beginLoadLASProgressive(path, downsampleFactor, &center);
+            PointCloud pc = beginLoadLASProgressive(path, downsampleFactor, &center, mortonResort);
             if (pc.isLoaded()) { pc.filePath = path; out.push_back(std::move(pc)); }
             else std::cerr << "[LAS-Stream-Multi] Failed to start: " << path << "\n";
         }
         return out;
     }
 
-    // Per-frame pump (GL/main thread).  Drains ready chunks from the worker and
-    // uploads them into the pre-allocated SSBOs, growing numBatches so the
-    // rasterizer draws the newly-arrived points.  No-op for non-streaming clouds.
+    // Per-frame pump (GL/main thread).  Phase 1: drain ready file-order chunks
+    // into the pre-allocated SSBOs (committing sparse pages first), growing
+    // numBatches so the rasterizer draws newly-arrived points.  Phase 2: once the
+    // worker publishes the globally Morton-sorted arrays, overwrite the SSBOs in
+    // place (visually identical re-ordering) for full render speed.  No-op for
+    // non-streaming clouds.
     void PointCloudLoader::updateStreaming(PointCloud& pc) {
         PointCloudStream* S = pc.stream.get();
         if (!S) return;
 
+        const GLsizeiptr ptBufBytes  = static_cast<GLsizeiptr>(pc.streamTargetCount) * sizeof(uint32_t);
+        const GLsizeiptr batBufBytes = static_cast<GLsizeiptr>(S->targetBatches) * sizeof(ComputeBatch);
+
+        auto put = [&](GLuint id, GLintptr off, GLsizeiptr byt, const void* data, GLsizeiptr total) {
+            glBindBuffer(GL_SHADER_STORAGE_BUFFER, id);
+            commitSparseRange(S->sparse, off, byt, total);
+            glBufferSubData(GL_SHADER_STORAGE_BUFFER, off, byt, data);
+        };
+
+        // ── Phase 1: drain ready file-order chunks ───────────────────────────
         constexpr int maxChunksPerFrame = 8; // cap upload work per frame
         int processed = 0;
         for (;;) {
@@ -2588,15 +2783,14 @@ namespace Engine {
 
             const GLintptr   pOff = static_cast<GLintptr>(ck.firstPoint) * sizeof(uint32_t);
             const GLsizeiptr pByt = static_cast<GLsizeiptr>(ck.numPoints) * sizeof(uint32_t);
-            glBindBuffer(GL_SHADER_STORAGE_BUFFER, pc.computeXyz4bSSBO);  glBufferSubData(GL_SHADER_STORAGE_BUFFER, pOff, pByt, ck.xyz4b.data());
-            glBindBuffer(GL_SHADER_STORAGE_BUFFER, pc.computeXyz8bSSBO);  glBufferSubData(GL_SHADER_STORAGE_BUFFER, pOff, pByt, ck.xyz8b.data());
-            glBindBuffer(GL_SHADER_STORAGE_BUFFER, pc.computeXyz12bSSBO); glBufferSubData(GL_SHADER_STORAGE_BUFFER, pOff, pByt, ck.xyz12b.data());
-            glBindBuffer(GL_SHADER_STORAGE_BUFFER, pc.computeRGBASSBO);   glBufferSubData(GL_SHADER_STORAGE_BUFFER, pOff, pByt, ck.rgba.data());
-            glBindBuffer(GL_SHADER_STORAGE_BUFFER, pc.computeBatchSSBO);
-            glBufferSubData(GL_SHADER_STORAGE_BUFFER,
-                            static_cast<GLintptr>(ck.firstBatch) * sizeof(ComputeBatch),
-                            static_cast<GLsizeiptr>(ck.batches.size()) * sizeof(ComputeBatch),
-                            ck.batches.data());
+            put(pc.computeXyz4bSSBO,  pOff, pByt, ck.xyz4b.data(),  ptBufBytes);
+            put(pc.computeXyz8bSSBO,  pOff, pByt, ck.xyz8b.data(),  ptBufBytes);
+            put(pc.computeXyz12bSSBO, pOff, pByt, ck.xyz12b.data(), ptBufBytes);
+            put(pc.computeRGBASSBO,   pOff, pByt, ck.rgba.data(),   ptBufBytes);
+            put(pc.computeBatchSSBO,
+                static_cast<GLintptr>(ck.firstBatch) * sizeof(ComputeBatch),
+                static_cast<GLsizeiptr>(ck.batches.size()) * sizeof(ComputeBatch),
+                ck.batches.data(), batBufBytes);
 
             pc.totalPointCount += ck.numPoints;
             pc.numBatches      += static_cast<uint32_t>(ck.batches.size());
@@ -2604,7 +2798,33 @@ namespace Engine {
         }
         glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
 
-        if (S->finished.load()) {
+        // ── Phase 2: in-place swap to the global Morton-sorted arrays ─────────
+        // Only after every phase-1 chunk is uploaded (numBatches final, pages
+        // committed). Boundaries align to kComputeBatchSize and re-ordering is
+        // visually identical, so this single overwrite is safe.
+        if (S->resortReady.load()) {
+            bool drained = false;
+            { std::lock_guard<std::mutex> lk(S->mtx); drained = S->ready.empty(); }
+            if (drained) {
+                const GLsizeiptr nBy = static_cast<GLsizeiptr>(S->r_xyz4b.size()) * sizeof(uint32_t);
+                const GLsizeiptr bBy = static_cast<GLsizeiptr>(S->r_batches.size()) * sizeof(ComputeBatch);
+                put(pc.computeXyz4bSSBO,  0, nBy, S->r_xyz4b.data(),  ptBufBytes);
+                put(pc.computeXyz8bSSBO,  0, nBy, S->r_xyz8b.data(),  ptBufBytes);
+                put(pc.computeXyz12bSSBO, 0, nBy, S->r_xyz12b.data(), ptBufBytes);
+                put(pc.computeRGBASSBO,   0, nBy, S->r_rgba.data(),   ptBufBytes);
+                put(pc.computeBatchSSBO,  0, bBy, S->r_batches.data(), batBufBytes);
+                glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+                pc.numBatches      = static_cast<uint32_t>(S->r_batches.size());
+                pc.totalPointCount = static_cast<uint32_t>(S->r_xyz4b.size());
+                std::cout << "[LAS-Stream] '" << pc.name << "' Morton resort applied ("
+                          << pc.totalPointCount << " points, " << pc.numBatches << " batches)\n";
+                pc.stream.reset(); // done (dtor joins the finished worker)
+                return;
+            }
+        }
+
+        // ── Finalize: file-order path (no resort) or a failed phase 2 ────────
+        if (S->finished.load() && !S->resortReady.load()) {
             bool drained = false;
             { std::lock_guard<std::mutex> lk(S->mtx); drained = S->ready.empty(); }
             if (drained) {
@@ -2616,10 +2836,18 @@ namespace Engine {
                     std::cerr << "[LAS-Stream] '" << pc.name << "' finished with errors ("
                               << loaded << " points loaded)\n";
                 else
-                    std::cout << "[LAS-Stream] '" << pc.name << "' complete: "
+                    std::cout << "[LAS-Stream] '" << pc.name << "' complete (file-order): "
                               << loaded << " points, " << nb << " batches\n";
             }
         }
+    }
+
+    // Set the GL extension loader (e.g. glfwGetProcAddress) so sparse buffers can
+    // be probed lazily on first use. Call once from main after the GL context and
+    // GLAD are initialised. Safe to pass nullptr (disables sparse buffers).
+    void PointCloudLoader::initGLExtensions(void* (*procLoader)(const char*)) {
+        s_glProcLoader  = procLoader;
+        s_sparseChecked = false; // re-probe on next allocation
     }
 
 } // namespace Engine

--- a/StereoVista/src/Loaders/PointCloudLoader.cpp
+++ b/StereoVista/src/Loaders/PointCloudLoader.cpp
@@ -7,6 +7,8 @@
 #include <thread>
 #include <mutex>
 #include <atomic>
+#include <queue>
+#include <condition_variable>
 #include <glad/glad.h>
 #include <cstring>
 #include <filesystem>
@@ -217,6 +219,212 @@ namespace Engine {
 
         std::cout << "[ComputePC] Built " << N << " points into " << numBatches
                   << " Morton-sorted, shuffled batches\n";
+    }
+
+    // =========================================================================
+    // Progressive (streaming) LAS/LAZ loading – Schütz "compute_loop_las" style
+    // =========================================================================
+    // Mirrors m-schuetz/compute_rasterizer's LasLoaderSparse:
+    //   • a background worker thread reads the file in chunks and produces
+    //     ready-to-upload GPU staging ("StreamChunk"s);
+    //   • the GL/main thread drains those chunks every frame in updateStreaming()
+    //     via glBufferSubData into SSBOs that were pre-allocated to the exact
+    //     header point count, growing pc.numBatches as data arrives so the
+    //     existing compute rasterizer draws the cloud while it is still loading.
+    //
+    // Unlike Schütz's pure file-order streaming, each chunk is Morton-sorted and
+    // its batches shuffled (the same transform buildComputeCloud applies, but
+    // scoped to the chunk).  This keeps per-batch bounding boxes tight regardless
+    // of the file's on-disk ordering, so frustum culling / adaptive precision /
+    // early-z stay exactly as fast as the one-shot path – at bounded CPU RAM.
+    //
+    // The LAS header is exploited up front: exact point count (precise SSBO
+    // pre-allocation + progress, no counting pass) and exact bounds (camera
+    // framing and SpaceMouse extents are valid before a single point is read).
+
+    struct StreamChunk {
+        uint32_t firstPoint = 0;   // base offset into the per-point SSBOs
+        uint32_t firstBatch = 0;   // base offset into the batch-descriptor SSBO
+        uint32_t numPoints  = 0;
+        std::vector<ComputeBatch> batches;
+        std::vector<uint32_t>     xyz4b, xyz8b, xyz12b, rgba; // chunk-local arrays
+    };
+
+    // Background-thread + producer/consumer state for one streaming cloud.
+    // Heap-allocated and owned by PointCloud via shared_ptr; the worker holds a
+    // raw pointer that stays valid because ~PointCloudStream joins the thread
+    // before the object is destroyed.  PointCloud only ever moves the shared_ptr,
+    // never this object, so the raw pointer survives vector reallocations.
+    struct PointCloudStream {
+        std::thread             worker;
+        std::mutex              mtx;
+        std::condition_variable cv;          // signals both produce and consume
+        std::queue<StreamChunk> ready;       // produced chunks awaiting upload
+        std::atomic<bool>       stop{false}; // request worker exit (cloud removed)
+        std::atomic<bool>       finished{false};
+        std::atomic<bool>       failed{false};
+        size_t                  maxInFlight = 4; // backpressure → bounds CPU RAM
+        uint32_t                targetPoints  = 0;
+        uint32_t                targetBatches = 0;
+
+        ~PointCloudStream() {
+            stop.store(true);
+            cv.notify_all();
+            if (worker.joinable()) worker.join();
+        }
+    };
+
+    // Build one StreamChunk from a run of decoded points using exactly the
+    // Morton-sort + per-batch shuffle + 10/20/30-bit quantisation of
+    // buildComputeCloud, scoped to the chunk.  globalFirstPoint/globalFirstBatch
+    // are this chunk's base offsets in the pre-allocated SSBOs; batch.firstPoint
+    // is written as a *global* index so the rasterizer indexes the SSBOs directly.
+    static void buildStreamChunk(std::vector<PointCloudPoint>& pts,
+                                 uint32_t globalFirstPoint,
+                                 uint32_t globalFirstBatch,
+                                 StreamChunk& out) {
+        const size_t N = pts.size();
+        out.firstPoint = globalFirstPoint;
+        out.firstBatch = globalFirstBatch;
+        out.numPoints  = static_cast<uint32_t>(N);
+        if (N == 0) return;
+
+        glm::vec3 gMin( FLT_MAX), gMax(-FLT_MAX);
+        for (const auto& p : pts) { gMin = glm::min(gMin, p.position); gMax = glm::max(gMax, p.position); }
+        const glm::vec3 ext = glm::max(gMax - gMin, glm::vec3(1e-9f));
+        constexpr uint32_t MAXQ = (1u << 21) - 1u;
+
+        std::vector<std::pair<uint64_t, uint32_t>> order(N);
+        for (size_t i = 0; i < N; ++i) {
+            const glm::vec3 n = glm::clamp((pts[i].position - gMin) / ext, 0.0f, 1.0f);
+            order[i] = { mortonEncode3D(static_cast<uint32_t>(n.x * static_cast<float>(MAXQ)),
+                                        static_cast<uint32_t>(n.y * static_cast<float>(MAXQ)),
+                                        static_cast<uint32_t>(n.z * static_cast<float>(MAXQ))),
+                         static_cast<uint32_t>(i) };
+        }
+        std::sort(order.begin(), order.end(),
+                  [](const std::pair<uint64_t, uint32_t>& a,
+                     const std::pair<uint64_t, uint32_t>& b) { return a.first < b.first; });
+
+        const int      B    = PointCloud::kComputeBatchSize;
+        const uint32_t numB = static_cast<uint32_t>((N + B - 1) / B);
+        std::vector<uint32_t> perm(numB);
+        for (uint32_t i = 0; i < numB; ++i) perm[i] = i;
+        std::mt19937 rng(0x5eed1234u ^ globalFirstBatch);  // per-chunk reproducible
+        std::shuffle(perm.begin(), perm.end(), rng);
+
+        std::vector<uint32_t> outFirst(numB);
+        for (uint32_t t = 0, off = 0; t < numB; ++t) {
+            const uint32_t src   = perm[t];
+            const uint32_t count = static_cast<uint32_t>(std::min<size_t>(static_cast<size_t>(B), N - static_cast<size_t>(src) * B));
+            outFirst[t] = off;
+            off += count;
+        }
+
+        out.xyz4b.resize(N); out.xyz8b.resize(N); out.xyz12b.resize(N); out.rgba.resize(N);
+        out.batches.resize(numB);
+        constexpr uint32_t STEPS_30BIT = 1u << 30;
+        constexpr uint32_t MASK_10BIT  = 1023u;
+
+        for (uint32_t t = 0; t < numB; ++t) {
+            const uint32_t src   = perm[t];
+            const size_t   s     = static_cast<size_t>(src) * B;
+            const uint32_t count = static_cast<uint32_t>(std::min<size_t>(static_cast<size_t>(B), N - s));
+            const uint32_t first = outFirst[t];
+
+            glm::vec3 bMin( FLT_MAX), bMax(-FLT_MAX);
+            for (uint32_t k = 0; k < count; ++k) {
+                const glm::vec3& p = pts[order[s + k].second].position;
+                bMin = glm::min(bMin, p); bMax = glm::max(bMax, p);
+            }
+            const glm::vec3 sz = glm::max(bMax - bMin, glm::vec3(1e-6f));
+            out.batches[t] = { bMin.x, bMin.y, bMin.z, bMax.x, bMax.y, bMax.z,
+                               static_cast<int>(count),
+                               static_cast<int>(globalFirstPoint + first) };
+
+            for (uint32_t k = 0; k < count; ++k) {
+                const PointCloudPoint& P = pts[order[s + k].second];
+                auto q = [&](float v, float lo, float ss) -> uint32_t {
+                    const float nn = glm::clamp((v - lo) / ss, 0.0f, 1.0f);
+                    return std::min(static_cast<uint32_t>(nn * static_cast<float>(STEPS_30BIT)), STEPS_30BIT - 1u);
+                };
+                const uint32_t Xb = q(P.position.x, bMin.x, sz.x);
+                const uint32_t Yb = q(P.position.y, bMin.y, sz.y);
+                const uint32_t Zb = q(P.position.z, bMin.z, sz.z);
+                const uint32_t o  = first + k;
+                out.xyz4b [o] = ((Xb>>20)&MASK_10BIT) | (((Yb>>20)&MASK_10BIT)<<10) | (((Zb>>20)&MASK_10BIT)<<20);
+                out.xyz8b [o] = ((Xb>>10)&MASK_10BIT) | (((Yb>>10)&MASK_10BIT)<<10) | (((Zb>>10)&MASK_10BIT)<<20);
+                out.xyz12b[o] = (Xb&MASK_10BIT) | ((Yb&MASK_10BIT)<<10) | ((Zb&MASK_10BIT)<<20);
+                const uint32_t r8 = static_cast<uint32_t>(glm::clamp(P.color.r,    0.f, 1.f) * 255.f + 0.5f);
+                const uint32_t g8 = static_cast<uint32_t>(glm::clamp(P.color.g,    0.f, 1.f) * 255.f + 0.5f);
+                const uint32_t b8 = static_cast<uint32_t>(glm::clamp(P.color.b,    0.f, 1.f) * 255.f + 0.5f);
+                const uint32_t a8 = static_cast<uint32_t>(glm::clamp(P.intensity, 0.f, 1.f) * 255.f + 0.5f);
+                out.rgba[o] = (a8<<24)|(b8<<16)|(g8<<8)|r8;
+            }
+        }
+    }
+
+    // Worker thread body: decode the LAS/LAZ file in chunks, build each chunk,
+    // and hand it to the consumer with backpressure (waits when too many chunks
+    // are already queued).  Pure CPU work – no GL calls happen here.
+    static void streamWorkerLAS(PointCloudStream* S, std::string filePath, size_t downsample,
+                                double sx, double sy, double sz,
+                                double ox, double oy, double oz,
+                                double cx, double cy, double cz,
+                                bool hasColor, float colorScale, int64_t nPoints) {
+        auto bail = [&]() { S->failed.store(true); S->finished.store(true); S->cv.notify_all(); };
+
+        laszip_POINTER reader = nullptr; laszip_BOOL comp = 0;
+        if (laszip_create(&reader)) { bail(); return; }
+        if (laszip_open_reader(reader, filePath.c_str(), &comp)) { laszip_destroy(reader); bail(); return; }
+        laszip_point_struct* lp = nullptr; laszip_get_point_pointer(reader, &lp);
+
+        const int    B     = PointCloud::kComputeBatchSize;
+        const size_t CHUNK = static_cast<size_t>(64) * B;   // ~655k points / chunk
+        std::vector<PointCloudPoint> buf; buf.reserve(CHUNK);
+        uint32_t outPoint = 0, outBatch = 0;
+
+        auto flush = [&]() {
+            if (buf.empty()) return;
+            StreamChunk ck;
+            buildStreamChunk(buf, outPoint, outBatch, ck);
+            outPoint += ck.numPoints;
+            outBatch += static_cast<uint32_t>(ck.batches.size());
+            std::unique_lock<std::mutex> lk(S->mtx);
+            S->cv.wait(lk, [&] { return S->stop.load() || S->ready.size() < S->maxInFlight; });
+            if (S->stop.load()) return;
+            S->ready.push(std::move(ck));
+            lk.unlock();
+            S->cv.notify_all();
+            buf.clear();
+        };
+
+        for (int64_t i = 0; i < nPoints; ++i) {
+            if (S->stop.load()) break;
+            if (laszip_read_point(reader)) break;
+            if (downsample > 1 && (static_cast<size_t>(i) % downsample) != 0) continue;
+
+            PointCloudPoint pt;
+            pt.position.x = static_cast<float>(lp->X * sx + ox - cx);
+            pt.position.y = static_cast<float>(lp->Y * sy + oy - cy);
+            pt.position.z = static_cast<float>(lp->Z * sz + oz - cz);
+            pt.intensity  = lp->intensity / 65535.0f;
+            if (hasColor) {
+                pt.color.r = lp->rgb[0] / colorScale;
+                pt.color.g = lp->rgb[1] / colorScale;
+                pt.color.b = lp->rgb[2] / colorScale;
+            } else {
+                pt.color = glm::vec3(pt.intensity);
+            }
+            buf.push_back(pt);
+            if (buf.size() >= CHUNK) flush();
+        }
+        if (!S->stop.load()) flush();
+
+        laszip_close_reader(reader);
+        laszip_destroy(reader);
+        S->finished.store(true);
+        S->cv.notify_all();
     }
 
     // Fast single-pass scan: count data lines in a text point cloud file.
@@ -2197,6 +2405,213 @@ namespace Engine {
             }
         }
         return result;
+    }
+
+    // -------------------------------------------------------------------------
+    // Progressive single-file LAS/LAZ loader
+    // Reads the header on the calling (GL) thread to learn the exact point count
+    // and bounds, pre-allocates the compute SSBOs to that size, then spawns a
+    // background worker that streams the points in.  Returns immediately with a
+    // PointCloud whose bounds are already valid and whose batches grow each frame
+    // (via updateStreaming).  globalCenter shares a centre across a multi-file
+    // load so tiles stay correctly positioned relative to each other.
+    // -------------------------------------------------------------------------
+    PointCloud PointCloudLoader::beginLoadLASProgressive(const std::string& filePath,
+                                                         size_t downsampleFactor,
+                                                         const glm::dvec3* globalCenter) {
+        PointCloud pc;
+        pc.name     = std::filesystem::path(filePath).stem().string();
+        pc.filePath = filePath;
+        pc.position  = glm::vec3(0.0f);
+        pc.rotation  = glm::vec3(-90.0f, 0.0f, 0.0f);
+        pc.scale     = glm::vec3(0.1f);
+
+        laszip_POINTER reader = nullptr; laszip_BOOL comp = 0;
+        if (laszip_create(&reader)) { std::cerr << "[LAS-Stream] laszip_create failed\n"; return pc; }
+        if (laszip_open_reader(reader, filePath.c_str(), &comp)) {
+            std::cerr << "[LAS-Stream] Cannot open '" << filePath << "'\n";
+            laszip_destroy(reader); return pc;
+        }
+        laszip_header_struct* hdr = nullptr; laszip_get_header_pointer(reader, &hdr);
+
+        const double sx = hdr->x_scale_factor, sy = hdr->y_scale_factor, sz = hdr->z_scale_factor;
+        const double ox = hdr->x_offset,       oy = hdr->y_offset,       oz = hdr->z_offset;
+        const laszip_U8 fmt = hdr->point_data_format;
+        const bool hasColor = (fmt == 2 || fmt == 3 || fmt == 5 || fmt == 7 || fmt == 8 || fmt == 10);
+        const int64_t nPoints =
+            (hdr->version_minor >= 4 && hdr->extended_number_of_point_records > 0)
+                ? static_cast<int64_t>(hdr->extended_number_of_point_records)
+                : static_cast<int64_t>(hdr->number_of_point_records);
+        const double cx = globalCenter ? globalCenter->x : (hdr->min_x + hdr->max_x) * 0.5;
+        const double cy = globalCenter ? globalCenter->y : (hdr->min_y + hdr->max_y) * 0.5;
+        const double cz = globalCenter ? globalCenter->z : (hdr->min_z + hdr->max_z) * 0.5;
+
+        // Header bounds → valid extents before any point is read (camera framing,
+        // SpaceMouse) in the cloud's local space (world − centre).
+        pc.boundsMin = glm::vec3(static_cast<float>(hdr->min_x - cx),
+                                 static_cast<float>(hdr->min_y - cy),
+                                 static_cast<float>(hdr->min_z - cz));
+        pc.boundsMax = glm::vec3(static_cast<float>(hdr->max_x - cx),
+                                 static_cast<float>(hdr->max_y - cy),
+                                 static_cast<float>(hdr->max_z - cz));
+
+        // Detect 8- vs 16-bit colour from a tiny sample (matches loadFromLAS).
+        float colorScale = 255.0f;
+        if (hasColor) {
+            laszip_point_struct* lp = nullptr; laszip_get_point_pointer(reader, &lp);
+            const int64_t lim = std::min(static_cast<int64_t>(2000), nPoints);
+            laszip_U16 mx = 0;
+            for (int64_t i = 0; i < lim; ++i) {
+                if (laszip_read_point(reader)) break;
+                mx = std::max({ mx, lp->rgb[0], lp->rgb[1], lp->rgb[2] });
+                if (mx > 255) break;
+            }
+            colorScale = (mx > 255) ? 65535.0f : 255.0f;
+        }
+        laszip_close_reader(reader);
+        laszip_destroy(reader);
+        reader = nullptr;
+
+        if (nPoints <= 0) { std::cerr << "[LAS-Stream] No points in " << filePath << "\n"; return pc; }
+
+        // Header count is exact; size the allocation for the kept points.
+        const uint32_t allocPoints = (downsampleFactor > 1)
+            ? static_cast<uint32_t>((nPoints + static_cast<int64_t>(downsampleFactor) - 1) / static_cast<int64_t>(downsampleFactor))
+            : static_cast<uint32_t>(nPoints);
+        const uint32_t allocBatches =
+            (allocPoints + PointCloud::kComputeBatchSize - 1) / PointCloud::kComputeBatchSize;
+
+        // Pre-allocate the 5 SSBOs to full size (NULL data).  VRAM use scales
+        // with the cloud (no artificial cap); allocation fails cleanly if the
+        // cloud exceeds available VRAM (Path B / out-of-core territory).
+        deleteComputeSSBOs(pc);
+        auto alloc = [&](GLuint& id, GLsizeiptr bytes) -> bool {
+            glGenBuffers(1, &id);
+            glBindBuffer(GL_SHADER_STORAGE_BUFFER, id);
+            glBufferData(GL_SHADER_STORAGE_BUFFER, bytes, nullptr, GL_STATIC_DRAW);
+            return glGetError() == GL_NO_ERROR;
+        };
+        bool ok = true;
+        ok = alloc(pc.computeBatchSSBO,  static_cast<GLsizeiptr>(allocBatches) * sizeof(ComputeBatch)) && ok;
+        ok = alloc(pc.computeXyz4bSSBO,  static_cast<GLsizeiptr>(allocPoints)  * sizeof(uint32_t)) && ok;
+        ok = alloc(pc.computeXyz8bSSBO,  static_cast<GLsizeiptr>(allocPoints)  * sizeof(uint32_t)) && ok;
+        ok = alloc(pc.computeXyz12bSSBO, static_cast<GLsizeiptr>(allocPoints)  * sizeof(uint32_t)) && ok;
+        ok = alloc(pc.computeRGBASSBO,   static_cast<GLsizeiptr>(allocPoints)  * sizeof(uint32_t)) && ok;
+        glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+        if (!ok) {
+            std::cerr << "[LAS-Stream] GPU allocation failed for " << allocPoints
+                      << " points – file likely exceeds available VRAM\n";
+            deleteComputeSSBOs(pc);
+            pc.boundsMin = glm::vec3( FLT_MAX);
+            pc.boundsMax = glm::vec3(-FLT_MAX);
+            return pc; // isLoaded() == false → caller reports failure
+        }
+
+        pc.numBatches             = 0;
+        pc.totalPointCount        = 0;
+        pc.computePointsPerThread = (PointCloud::kComputeBatchSize + 127) / 128;
+        pc.streamTargetCount      = allocPoints;
+
+        pc.stream = std::make_shared<PointCloudStream>();
+        pc.stream->targetPoints  = allocPoints;
+        pc.stream->targetBatches = allocBatches;
+        PointCloudStream* S = pc.stream.get();
+        S->worker = std::thread(streamWorkerLAS, S, filePath, downsampleFactor,
+                                sx, sy, sz, ox, oy, oz, cx, cy, cz,
+                                hasColor, colorScale, nPoints);
+
+        std::cout << "[LAS-Stream] " << (comp ? "LAZ" : "LAS") << " " << filePath
+                  << " – streaming " << nPoints << " points (" << allocBatches << " batches)\n";
+        return pc;
+    }
+
+    // Multi-file progressive loader: scans every header for a shared centre, then
+    // kicks off one background stream per file.  All files load concurrently, so
+    // multi-tile sets fill in together instead of one-after-another.
+    std::vector<PointCloud> PointCloudLoader::beginLoadLASMultipleProgressive(
+        const std::vector<std::string>& filePaths, size_t downsampleFactor) {
+        if (filePaths.empty()) return {};
+
+        double gMinX =  DBL_MAX, gMinY =  DBL_MAX, gMinZ =  DBL_MAX;
+        double gMaxX = -DBL_MAX, gMaxY = -DBL_MAX, gMaxZ = -DBL_MAX;
+        int    valid = 0;
+        for (const auto& path : filePaths) {
+            laszip_POINTER r = nullptr; laszip_BOOL c = 0;
+            if (laszip_create(&r)) continue;
+            if (laszip_open_reader(r, path.c_str(), &c)) { laszip_destroy(r); continue; }
+            laszip_header_struct* h = nullptr; laszip_get_header_pointer(r, &h);
+            gMinX = std::min(gMinX, h->min_x); gMaxX = std::max(gMaxX, h->max_x);
+            gMinY = std::min(gMinY, h->min_y); gMaxY = std::max(gMaxY, h->max_y);
+            gMinZ = std::min(gMinZ, h->min_z); gMaxZ = std::max(gMaxZ, h->max_z);
+            ++valid;
+            laszip_close_reader(r); laszip_destroy(r);
+        }
+        if (valid == 0) { std::cerr << "[LAS-Stream-Multi] No valid headers\n"; return {}; }
+
+        const glm::dvec3 center((gMinX + gMaxX) * 0.5, (gMinY + gMaxY) * 0.5, (gMinZ + gMaxZ) * 0.5);
+        std::vector<PointCloud> out;
+        out.reserve(filePaths.size());
+        for (const auto& path : filePaths) {
+            PointCloud pc = beginLoadLASProgressive(path, downsampleFactor, &center);
+            if (pc.isLoaded()) { pc.filePath = path; out.push_back(std::move(pc)); }
+            else std::cerr << "[LAS-Stream-Multi] Failed to start: " << path << "\n";
+        }
+        return out;
+    }
+
+    // Per-frame pump (GL/main thread).  Drains ready chunks from the worker and
+    // uploads them into the pre-allocated SSBOs, growing numBatches so the
+    // rasterizer draws the newly-arrived points.  No-op for non-streaming clouds.
+    void PointCloudLoader::updateStreaming(PointCloud& pc) {
+        PointCloudStream* S = pc.stream.get();
+        if (!S) return;
+
+        constexpr int maxChunksPerFrame = 8; // cap upload work per frame
+        int processed = 0;
+        for (;;) {
+            StreamChunk ck;
+            {
+                std::unique_lock<std::mutex> lk(S->mtx);
+                if (S->ready.empty()) break;
+                ck = std::move(S->ready.front());
+                S->ready.pop();
+            }
+            S->cv.notify_all(); // release backpressure for the worker
+
+            const GLintptr   pOff = static_cast<GLintptr>(ck.firstPoint) * sizeof(uint32_t);
+            const GLsizeiptr pByt = static_cast<GLsizeiptr>(ck.numPoints) * sizeof(uint32_t);
+            glBindBuffer(GL_SHADER_STORAGE_BUFFER, pc.computeXyz4bSSBO);  glBufferSubData(GL_SHADER_STORAGE_BUFFER, pOff, pByt, ck.xyz4b.data());
+            glBindBuffer(GL_SHADER_STORAGE_BUFFER, pc.computeXyz8bSSBO);  glBufferSubData(GL_SHADER_STORAGE_BUFFER, pOff, pByt, ck.xyz8b.data());
+            glBindBuffer(GL_SHADER_STORAGE_BUFFER, pc.computeXyz12bSSBO); glBufferSubData(GL_SHADER_STORAGE_BUFFER, pOff, pByt, ck.xyz12b.data());
+            glBindBuffer(GL_SHADER_STORAGE_BUFFER, pc.computeRGBASSBO);   glBufferSubData(GL_SHADER_STORAGE_BUFFER, pOff, pByt, ck.rgba.data());
+            glBindBuffer(GL_SHADER_STORAGE_BUFFER, pc.computeBatchSSBO);
+            glBufferSubData(GL_SHADER_STORAGE_BUFFER,
+                            static_cast<GLintptr>(ck.firstBatch) * sizeof(ComputeBatch),
+                            static_cast<GLsizeiptr>(ck.batches.size()) * sizeof(ComputeBatch),
+                            ck.batches.data());
+
+            pc.totalPointCount += ck.numPoints;
+            pc.numBatches      += static_cast<uint32_t>(ck.batches.size());
+            if (++processed >= maxChunksPerFrame) break;
+        }
+        glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+
+        if (S->finished.load()) {
+            bool drained = false;
+            { std::lock_guard<std::mutex> lk(S->mtx); drained = S->ready.empty(); }
+            if (drained) {
+                const bool     failed = S->failed.load();
+                const uint32_t loaded = pc.totalPointCount;
+                const uint32_t nb     = pc.numBatches;
+                pc.stream.reset(); // dtor joins the (already-finished) worker
+                if (failed)
+                    std::cerr << "[LAS-Stream] '" << pc.name << "' finished with errors ("
+                              << loaded << " points loaded)\n";
+                else
+                    std::cout << "[LAS-Stream] '" << pc.name << "' complete: "
+                              << loaded << " points, " << nb << " batches\n";
+            }
+        }
     }
 
 } // namespace Engine

--- a/StereoVista/src/Loaders/PointCloudLoader.cpp
+++ b/StereoVista/src/Loaders/PointCloudLoader.cpp
@@ -399,27 +399,35 @@ namespace Engine {
             buf.clear();
         };
 
-        for (int64_t i = 0; i < nPoints; ++i) {
-            if (S->stop.load()) break;
-            if (laszip_read_point(reader)) break;
-            if (downsample > 1 && (static_cast<size_t>(i) % downsample) != 0) continue;
+        // Decode loop is wrapped so a std::bad_alloc (or any failure building a
+        // chunk) marks the stream failed instead of std::terminate-ing the app.
+        try {
+            for (int64_t i = 0; i < nPoints; ++i) {
+                if (S->stop.load()) break;
+                if (laszip_read_point(reader)) break;
+                if (downsample > 1 && (static_cast<size_t>(i) % downsample) != 0) continue;
 
-            PointCloudPoint pt;
-            pt.position.x = static_cast<float>(lp->X * sx + ox - cx);
-            pt.position.y = static_cast<float>(lp->Y * sy + oy - cy);
-            pt.position.z = static_cast<float>(lp->Z * sz + oz - cz);
-            pt.intensity  = lp->intensity / 65535.0f;
-            if (hasColor) {
-                pt.color.r = lp->rgb[0] / colorScale;
-                pt.color.g = lp->rgb[1] / colorScale;
-                pt.color.b = lp->rgb[2] / colorScale;
-            } else {
-                pt.color = glm::vec3(pt.intensity);
+                PointCloudPoint pt;
+                pt.position.x = static_cast<float>(lp->X * sx + ox - cx);
+                pt.position.y = static_cast<float>(lp->Y * sy + oy - cy);
+                pt.position.z = static_cast<float>(lp->Z * sz + oz - cz);
+                pt.intensity  = lp->intensity / 65535.0f;
+                if (hasColor) {
+                    pt.color.r = lp->rgb[0] / colorScale;
+                    pt.color.g = lp->rgb[1] / colorScale;
+                    pt.color.b = lp->rgb[2] / colorScale;
+                } else {
+                    pt.color = glm::vec3(pt.intensity);
+                }
+                buf.push_back(pt);
+                if (buf.size() >= CHUNK) flush();
             }
-            buf.push_back(pt);
-            if (buf.size() >= CHUNK) flush();
+            if (!S->stop.load()) flush();
+        } catch (const std::exception& e) {
+            std::cerr << "[LAS-Stream] worker exception for '" << filePath << "': "
+                      << e.what() << "\n";
+            S->failed.store(true);
         }
-        if (!S->stop.load()) flush();
 
         laszip_close_reader(reader);
         laszip_destroy(reader);

--- a/StereoVista/src/Loaders/PointCloudLoader.cpp
+++ b/StereoVista/src/Loaders/PointCloudLoader.cpp
@@ -332,6 +332,7 @@ namespace Engine {
         bool                    sparse = false;  // were the SSBOs created sparse?
         uint32_t                targetPoints  = 0;
         uint32_t                targetBatches = 0;
+        std::chrono::steady_clock::time_point startTime = std::chrono::steady_clock::now();
 
         // ── Phase 2 result (built by the worker, swapped in by the GL thread) ──
         // Re-ordered, fully-quantised arrays for the whole cloud. Boundaries are
@@ -2848,6 +2849,27 @@ namespace Engine {
     void PointCloudLoader::initGLExtensions(void* (*procLoader)(const char*)) {
         s_glProcLoader  = procLoader;
         s_sparseChecked = false; // re-probe on next allocation
+    }
+
+    PointCloudLoader::StreamProgress PointCloudLoader::getStreamProgress(const PointCloud& pc) {
+        StreamProgress p;
+        PointCloudStream* S = pc.stream.get();
+        if (!S) return p;
+        p.active       = true;
+        p.pointsLoaded = pc.totalPointCount;
+        p.pointsTotal  = pc.streamTargetCount;
+        p.fraction     = (p.pointsTotal > 0)
+            ? std::min(1.0f, static_cast<float>(p.pointsLoaded) / static_cast<float>(p.pointsTotal))
+            : 0.0f;
+        // Phase 2 (background Morton sort) is running once phase 1 has finished
+        // uploading but the re-ordered arrays are not yet ready to swap in.
+        p.resorting = S->phase1Done.load() && S->resort &&
+                      !S->resortReady.load() && !S->failed.load();
+        const double el = std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - S->startTime).count();
+        p.elapsedSeconds  = el;
+        p.pointsPerSecond = (el > 1e-3) ? static_cast<double>(p.pointsLoaded) / el : 0.0;
+        return p;
     }
 
 } // namespace Engine

--- a/StereoVista/src/Loaders/PointCloudLoader.cpp
+++ b/StereoVista/src/Loaders/PointCloudLoader.cpp
@@ -2676,6 +2676,13 @@ namespace Engine {
             glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
             return ok;
         };
+        // Drain any GL error left pending by earlier rendering so the per-buffer
+        // glGetError() checks reflect ONLY our allocation calls. Without this, a
+        // stale error from the previously-loaded cloud's rendering would make the
+        // first allocation check below report a false failure on every load after
+        // the first (the reported "second load doesn't start / no progress UI").
+        while (glGetError() != GL_NO_ERROR) { /* discard */ }
+
         bool ok = allocAll();
         if (!ok && useSparse) {
             // Sparse storage was reported available but the driver rejected it;

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -4055,6 +4055,15 @@ int main() {
       continue;
     }
 
+    // ---- Pump progressive point-cloud streaming (GL thread) ----
+    // Uploads any chunks decoded by the background LAS/LAZ loaders into their
+    // pre-allocated SSBOs, growing each cloud so it renders while still loading.
+    for (auto &pointCloud : currentScene.pointClouds) {
+      if (pointCloud.isStreaming()) {
+        Engine::PointCloudLoader::updateStreaming(pointCloud);
+      }
+    }
+
     // ---- Update SpaceMouse Input ----
     if (spaceMouseInitialized) {
       bool wasSpaceMouseActive = spaceMouseActive;

--- a/StereoVista/src/main.cpp
+++ b/StereoVista/src/main.cpp
@@ -2470,6 +2470,7 @@ void savePreferences() {
   j["pointcloud"]["baseSize"] = preferences.pointCloudBaseSize;
   j["pointcloud"]["splatEnabled"] = preferences.pointSplatSettings.enabled;
   j["pointcloud"]["splatMaxRadius"] = preferences.pointSplatSettings.maxRadius;
+  j["pointcloud"]["mortonResort"] = preferences.pointCloudMortonResort;
 
   // Save sun (directional light). It is an application-global light, so it
   // belongs in preferences rather than per-scene.
@@ -3082,6 +3083,8 @@ void loadPreferences() {
           j["pointcloud"].value("splatEnabled", true);
       preferences.pointSplatSettings.maxRadius =
           j["pointcloud"].value("splatMaxRadius", 4);
+      preferences.pointCloudMortonResort =
+          j["pointcloud"].value("mortonResort", true);
     }
 
     // Sun (directional light)
@@ -3497,6 +3500,11 @@ int main() {
     glfwTerminate();
     return -1;
   }
+
+  // Let the progressive point-cloud loader probe optional GL_ARB_sparse_buffer
+  // support (not exposed by our vendored GLAD) through the same proc loader.
+  Engine::PointCloudLoader::initGLExtensions(
+      reinterpret_cast<void* (*)(const char*)>(glfwGetProcAddress));
 
   glEnable(GL_MULTISAMPLE);
 


### PR DESCRIPTION
Large LAS/LAZ files previously froze the UI for ~10s and spiked RAM to
~9GB: the loader buffered the whole cloud in a vector, did one global
Morton sort, then bulk-uploaded — all synchronously on the render thread,
one file at a time.

This adds an on-the-fly progressive path mirroring m-schuetz/
compute_rasterizer's LasLoaderSparse, feeding the existing compute
rasterizer unchanged (bindings 40-44), so render speed/quality is
untouched:

- A background worker decodes the file in ~655k-point chunks. Each chunk
  is Morton-sorted + batch-shuffled + quantised (the same transform as
  buildComputeCloud, scoped to the chunk) so per-batch AABBs stay tight
  and frustum cull / adaptive precision / early-z stay as fast as the
  one-shot path, at bounded CPU RAM (backpressure caps in-flight chunks).
- The GL thread drains ready chunks each frame in updateStreaming() via
  glBufferSubData into SSBOs pre-allocated to the exact header point
  count, growing numBatches so the cloud renders while still loading.
- LAS header is exploited: exact count (precise pre-alloc, no counting
  pass) and exact bounds (camera/SpaceMouse extents valid before any
  point is read).
- Multi-file loads now run all files concurrently and share a global
  centre, so tiles fill in together instead of one-after-another.
- VRAM use scales with the cloud (no artificial cap); allocation fails
  cleanly when a cloud exceeds VRAM (out-of-core / Path B territory).

PointCloud carries the stream via shared_ptr<PointCloudStream> (pImpl)
so it stays movable; the worker is joined when the last owner is
destroyed. The synchronous loadFromLAS path is retained (scene loading).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q1JCsugirZT6craj9yMXV7