### PR TITLE
Add Vulkan migration plan (docs/VULKAN_MIGRATION.md)

### DIFF
--- a/.github/workflows/ci-vulkan-migration.yml
+++ b/.github/workflows/ci-vulkan-migration.yml
@@ -1,0 +1,88 @@
+name: CI Build (Vulkan migration)
+
+# Compile-check for the Vulkan migration branch so every push shows whether the
+# project still builds and, if not, exactly which errors occurred.
+#
+# This is intentionally SEPARATE from msbuild.yml (which only runs on `main` and
+# publishes GitHub Releases). This workflow never creates a release — it just
+# builds Debug + Release x64 and surfaces compiler errors:
+#   * inline annotations on the changed lines (MSVC problem matcher), and
+#   * full MSBuild text + binary logs uploaded as artifacts (even on failure).
+#
+# The Vulkan SDK is installed up front so that once the migration starts adding
+# Vulkan code (VMA, vulkan.h, SPIR-V, etc.) it compiles here too. Until then it
+# is simply unused. The migration agent may pin/bump the SDK version below.
+
+on:
+  push:
+    branches: [ "claude/opengl-vulkan-migration-yqc277" ]
+  pull_request:
+    branches: [ "claude/opengl-vulkan-migration-yqc277", "main" ]
+  workflow_dispatch:
+
+# A newer push to the same branch cancels the in-flight run.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  SOLUTION_FILE_PATH: StereoVista.sln
+  BUILD_PLATFORM: x64
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.configuration }} x64
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false            # report BOTH configs even if one fails
+      matrix:
+        configuration: [ Debug, Release ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v2
+
+      # Install the Vulkan SDK (sets the VULKAN_SDK env var for later steps).
+      # Cached between runs; stripped down to keep it small. `latest` tracks the
+      # newest SDK — pin `vulkan_version:` here if a specific version is needed.
+      - name: Install Vulkan SDK
+        uses: jakoch/install-vulkan-sdk-action@v1
+        with:
+          vulkan_version: latest
+          optional_components: com.lunarg.vulkan.vma
+          install_runtime: true
+          cache: true
+          stripdown: true
+
+      # Turns raw MSVC "error C....:" lines into inline PR/commit annotations.
+      - name: Enable MSVC problem matcher
+        uses: ammaraskar/msvc-problem-matcher@master
+
+      - name: Build (${{ matrix.configuration }} | x64)
+        shell: pwsh
+        run: |
+          msbuild /m /nologo `
+            /p:Configuration=${{ matrix.configuration }} `
+            /p:Platform=${{ env.BUILD_PLATFORM }} `
+            /consoleLoggerParameters:Summary `
+            /fileLogger "/fileLoggerParameters:LogFile=build-${{ matrix.configuration }}.log;Verbosity=normal" `
+            "/binaryLogger:build-${{ matrix.configuration }}.binlog" `
+            "${{ env.SOLUTION_FILE_PATH }}"
+
+      # Upload logs even when the build fails so the errors are downloadable.
+      # The .binlog opens in the MSBuild Structured Log Viewer for deep debugging.
+      - name: Upload build logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs-${{ matrix.configuration }}
+          path: |
+            build-${{ matrix.configuration }}.log
+            build-${{ matrix.configuration }}.binlog
+          if-no-files-found: ignore

--- a/docs/VULKAN_MIGRATION.md
+++ b/docs/VULKAN_MIGRATION.md
@@ -25,6 +25,19 @@
   never touch raw Vulkan, keeping the door open for later backends and for the
   advanced features we defer.
 
+### Guiding principles (apply to every phase)
+- **Rewrite better, don't translate.** This is a chance to modernize. Produce
+  **deeply optimized, idiomatic, native Vulkan** — single‑pass multiview stereo,
+  bindless/descriptor‑indexed materials, dynamic rendering, timeline semaphores,
+  proper sync2 barriers, VMA suballocation, GPU‑driven / indirect draws where
+  they help. The OpenGL code is the reference for **behaviour**, not for **how**.
+  **No stale copy‑paste.** A large rewrite or a change of planned direction is
+  acceptable — expected, even — when it yields a better Vulkan design.
+- **When unsure, dig deeper — don't guess.** Read more of the source, and use the
+  **Internet** (Khronos Vulkan spec/registry, Vulkan‑Samples, vendor docs) to
+  confirm API/extension behaviour and best practice. If a decision is the user's
+  to make (scope/priorities/trade‑offs), **ask the user** a concrete question.
+
 ### Non‑Goals (deferred — will be re‑implemented natively in Vulkan later)
 These are **removed from the first Vulkan build** and re‑added afterwards using
 native Vulkan capabilities (compute / ray‑tracing pipelines):
@@ -148,7 +161,7 @@ logic.
 | 4 | Descriptors | **Descriptor indexing / partially‑bound** (bindless‑lite) for textures; per‑frame descriptor pools | Scales for many models/textures; simplifies material binding |
 | 5 | 64‑bit point‑cloud atomics | `VK_KHR_shader_atomic_int64` + `shaderBufferInt64Atomics` (core 1.2), SPIR‑V `Int64Atomics`, GLSL `GL_EXT_shader_atomic_int64` | Direct 1:1 map of the existing rasterizer; verify device support at startup, feature‑gate |
 | 6 | Frames in flight | **2**, timeline semaphores, per‑frame command pool + descriptor pool | Standard double‑buffering |
-| 7 | Quad‑buffer stereo | **Hardest problem.** Use `VK_KHR_display` stereo present *or* NVIDIA `VK_KHR_swapchain` `imageArrayLayers=2` where supported; fall back to two swapchains / side‑by‑side. Abstract behind a `StereoTarget` so callers stay unaware | Desktop quad‑buffer stereo is vendor‑specific; must be isolated early as a spike |
+| 7 | Quad‑buffer stereo | **Native in Vulkan.** Create the swapchain with `imageArrayLayers = 2` (when `VkSurfaceCapabilitiesKHR.maxImageArrayLayers >= 2`); the presentation engine maps layer 0/1 → left/right eye. Render **both eyes in a single pass** with `VK_KHR_multiview`. Abstract behind a `StereoTarget`; fall back to two swapchains / side‑by‑side only if a surface caps stereo out | Cleaner *and faster* than GL (no `GL_BACK_LEFT/RIGHT`, no twice‑per‑frame `renderEye`). Just validate surface caps in a small spike |
 | 8 | XR | OpenXR with `XR_USE_GRAPHICS_API_VULKAN`, Vulkan swapchain images as `VkImage` | Required; rework `XRSession` |
 | 9 | ImGui | `imgui_impl_vulkan` (+ existing glfw backend) | Official, supports multi‑viewport |
 | 10 | Windowing | Keep **GLFW** (no GL context: `GLFW_NO_API`), create `VkSurfaceKHR` | Minimal disruption to input/callbacks |
@@ -223,8 +236,10 @@ ordering front‑loads the risky spikes (bootstrap, stereo, int64 atomics).
 - **Spike A:** headless device‑capability probe — confirm on the target GPU:
   `shaderBufferInt64Atomics`, descriptor indexing, dynamic rendering, timeline
   semaphores, and the **stereo present** path. Record results here.
-- **Spike B:** quad‑buffer stereo present proof‑of‑concept (clear left eye red /
-  right eye blue on the stereo display). This de‑risks the single scariest item.
+- **Spike B:** quad‑buffer stereo validation — confirm the surface reports
+  `maxImageArrayLayers >= 2`, create a stereo swapchain (`imageArrayLayers = 2`)
+  and clear left eye red / right eye blue on the stereo display. Native path, so
+  this just confirms the target GPU/driver caps; plan single‑pass multiview.
 - Deliverable: `docs/VULKAN_MIGRATION.md` (this file) + capability report.
 
 ### Phase 1 — Core bootstrap + new App skeleton
@@ -319,8 +334,9 @@ ordering front‑loads the risky spikes (bootstrap, stereo, int64 atomics).
 ---
 
 ## 7. Risks & Mitigations
-- **Quad‑buffer stereo in Vulkan is vendor‑specific.** → Spike B in Phase 0;
-  isolate behind `StereoTarget`; keep side‑by‑side fallback.
+- **Quad‑buffer stereo** — supported natively (stereo swapchain +
+  `VK_KHR_multiview`), so low risk. → Spike B just validates surface caps on the
+  target GPU; isolate behind `StereoTarget`; keep side‑by‑side fallback.
 - **int64 atomics availability.** → Spike A gate; document fallback (e.g. 32‑bit
   depth + separate index, or split‑atomic) before committing the rewrite.
 - **Scope creep from GI systems.** → Explicitly deferred; feature‑gate the

--- a/docs/VULKAN_MIGRATION.md
+++ b/docs/VULKAN_MIGRATION.md
@@ -1,0 +1,350 @@
+# StereoVista — OpenGL → Vulkan Migration Plan
+
+> Status: **planning**. Branch: `claude/opengl-vulkan-migration-yqc277`.
+> This document is the source of truth for the migration. It is intentionally
+> detailed so the work can be picked up in independent phases.
+
+---
+
+## 1. Goals & Non‑Goals
+
+### Goals
+- Replace the OpenGL 4.6 backend with **Vulkan 1.3** while preserving the
+  application's behaviour and feature set for everything *except* the advanced GI
+  systems (see non‑goals).
+- Port, in order: **rendering core → mesh/model rendering → loading system →
+  compute point‑cloud pipeline (streaming + rasterizer + HQS) → camera → 3D
+  cursors → tools → plugins → stereo/XR**.
+- Use the migration as an opportunity to **decompose `main.cpp` (~9,800 lines)**
+  and `GUI.cpp` (~8,800 lines) into a clean, layered, expandable architecture.
+- Introduce a thin **Render Hardware Interface (RHI)** so high‑level systems
+  never touch raw Vulkan, keeping the door open for later backends and for the
+  advanced features we defer.
+
+### Non‑Goals (deferred — will be re‑implemented natively in Vulkan later)
+These are **removed from the first Vulkan build** and re‑added afterwards using
+native Vulkan capabilities (compute / ray‑tracing pipelines):
+- **Voxel Cone Tracing** (`Voxalizer`, `voxelization/*`, VCT shaders).
+- **DDGI** (`DDGIVolume`, `ddgi*` shaders).
+- **BVH ray‑traced Radiance** lighting + `BVHDebug` (will use `VK_KHR_ray_query` /
+  ray‑tracing pipelines instead of the SSBO software BVH).
+- **Heavy post FX**: Bloom/HDR bloom, SSAO. (A minimal HDR target + tonemap is
+  kept so the image pipeline is correct; SSAO/Bloom come back as Vulkan compute
+  passes.)
+
+> The lighting mode enum stays, but only **Shadow Mapping** (direct light +
+> shadow maps) ships in the first Vulkan milestone. VCT/Radiance are greyed out
+> until re‑ported.
+
+---
+
+## 2. Current Architecture Inventory (what exists today)
+
+Everything below is OpenGL‑bound unless noted. Line counts indicate effort.
+
+### 2.1 Platform / context
+- **`Engine::Window`** (`Window.cpp`) — GLFW init, **OpenGL 4.6 core** context,
+  GLAD load, callbacks. Quad‑buffer stereo requested via `glfwWindowHint(GLFW_STEREO)`
+  in `main.cpp:3500`.
+- **`Engine::Input`** (`Input.cpp`) — GLFW callback fan‑out. Portable (no GL).
+
+### 2.2 Rendering core (in `main.cpp`)
+- **`renderEye()`** — the heart of the frame; called twice per frame for stereo
+  (`GL_BACK_LEFT` / `GL_BACK_RIGHT`), once per XR eye (into an XR FBO), or once
+  mono. Drives: shadow/DDGI shared passes (guarded by `g_sharedPassesDone`),
+  SSAO geometry pass, skybox, model draw, point‑cloud composite, overlays,
+  post‑chain.
+- **HDR offscreen FBO** + tonemap/FXAA resolve, **shadow map FBO** (directional)
+  and **depth cubemap FBO** (point lights).
+- **`Engine::Shader`** (`Shader.cpp`) — GLSL program wrapper, `use()` +
+  `setX()` uniform setters with a location cache. Compute‑shader constructor.
+- **`Engine::Buffers`** — thin VAO/VBO/EBO helpers.
+- **`Engine::BloomRenderer`, `Engine::SSAORenderer`** — FBO‑based post passes
+  *(deferred)*.
+
+### 2.3 Mesh / model system
+- **`Engine::Model` / `Mesh` / `Texture`** (`ModelLoader.cpp`, 1,155 lines) —
+  Assimp import (OBJ/FBX/GLTF…), PBR material fields, per‑mesh VAO/VBO/EBO,
+  `Draw(Shader&)`. Procedural factories (cube/sphere/cylinder/plane/torus).
+  **CPU import logic is portable; only GPU upload + `Draw` change.**
+
+### 2.4 Point‑cloud pipeline (the crown jewel — mostly rewrite)
+- **`Engine::ComputePointCloudRenderer`** (`ComputePointCloudRenderer.cpp`, 650
+  lines + 222‑line header) — Schütz *compute software rasterizer*:
+  - `uint64_t` framebuffer SSBO, `atomicMin` depth sort (needs
+    `GL_ARB_gpu_shader_int64` + `GL_EXT/NV_shader_atomic_int64`).
+  - Per‑batch frustum cull, 10/20/30‑bit packed coordinates (5 SSBOs per cloud).
+  - **HQS** 3‑pass (depth → colour‑accumulate → resolve) for anti‑aliased dense
+    clouds.
+  - Clip‑plane support, per‑cloud colour lookup, fullscreen resolve writing
+    `gl_FragDepth`.
+  - Shaders: `pointcloud_rasterize.comp`, `pointcloud_hqs_depth.comp`,
+    `pointcloud_hqs_color.comp`, `pointcloud_color_lookup.comp`,
+    `pointcloud_resolve.*`, `pointcloud_hqs_resolve.frag`.
+- **`OctreePointCloudManager`** (995 lines) — LOD/streaming octree (GL_POINTS
+  fallback path + disk cache). CPU/octree logic portable; GL VBO bits change.
+- **`PointCloudLoader`** (3,005 lines) — LAS/LAZ (LASzip), binary/ASCII PLY,
+  HDF5 (HighFive), XYZ/TXT, native `.pcb`. **Progressive streaming**: worker
+  thread fills pre‑allocated SSBOs via `glBufferSubData` / sparse
+  `glBufferStorage` each frame (`updateStreaming()`). **Parsers are portable;
+  the GPU staging/upload path is rewritten for Vulkan.**
+
+### 2.5 Camera
+- **`Camera`** (`Camera.h`, 792 lines) — almost pure `glm` math (orbit, pan,
+  smooth scroll, animation, quaternion orientation). **Only GL touch points:**
+  `glReadPixels` for centre‑depth and `glfwGetTime`. Trivial to abstract.
+
+### 2.6 3D cursors
+- **`CursorManager`** + `SphereCursor` / `PlaneCursor` / `FragmentCursor`
+  (`Cursors/**`) — each owns GL programs + VAOs and draws an overlay; ray‑pick
+  against scene depth. **`CursorPreview3D`** renders a cursor to an FBO for the
+  GUI thumbnail.
+
+### 2.7 Tools & plugins
+- **Tools**: `BrushTool`, `ClipPlaneTool`, `MeasurementTool`, `TransformGizmo`
+  — all do **immediate‑style overlay drawing** (dynamic line/tri VBOs + small
+  shaders). Must become proper vertex‑buffer + pipeline draws in Vulkan.
+- **Plugin system** (`Plugins/**`, `docs/PLUGINS.md`) — `Plugin` subclasses with
+  `onRenderViewport(eye)`, `onRenderUI`, input hooks; `PluginContext` exposes a
+  `compileOverlayProgram` GL helper. **`PluginContext` is the seam** — reshape
+  it to expose an RHI overlay API instead of GL program handles.
+
+### 2.8 GUI
+- **ImGui docking + multi‑viewport**, `imgui_impl_opengl3` + `imgui_impl_glfw`.
+  Swap the render backend to **`imgui_impl_vulkan`**; keep `imgui_impl_glfw`.
+  Project‑local `imgui_style*.cpp/h`, `imgui_incl.h`, `IconsFontAwesome5.h`
+  must be preserved.
+
+### 2.9 Stereo & XR
+- **Quad‑buffer stereo** via GLFW `GL_STEREO` + `GL_BACK_LEFT/RIGHT`.
+- **`XRSession`** (`XRSession.cpp`, 687 lines) — OpenXR bound to the **GL**
+  context (`XR_USE_GRAPHICS_API_OPENGL`), per‑eye GL swapchain textures. Must be
+  reworked to `XR_USE_GRAPHICS_API_VULKAN`.
+
+### 2.10 Support systems (mostly CPU / portable)
+- `SceneManager` (JSON scene I/O), `UndoManager`, `SnapshotManager`,
+  `ShortcutManager`, `SpaceMouseInput` / `ThreeDConnexionSync` (SpaceMouse),
+  `CursorSynchronizer`, `Screenshot` (`glReadPixels` → rewrite the readback),
+  `StbImageImpl`.
+
+### 2.11 GL footprint
+Raw GL calls appear in **~33 files**. The vast majority collapse into the RHI;
+only the point‑cloud renderer, post passes, and overlays carry real per‑backend
+logic.
+
+---
+
+## 3. Key Vulkan Decisions (resolve these before coding)
+
+| # | Topic | Recommendation | Why |
+|---|-------|----------------|-----|
+| 1 | Vulkan version | **1.3** (dynamic rendering, sync2, timeline semaphores core) | Removes render‑pass/framebuffer boilerplate; cleaner code |
+| 2 | Memory management | **VMA** (AMD Vulkan Memory Allocator) | Do not hand‑roll allocation; industry standard |
+| 3 | Shaders | Keep **GLSL**, compile to **SPIR‑V** with **shaderc**/glslang; runtime + offline | Reuse existing GLSL with minimal edits (explicit `layout(set,binding)`, push constants) |
+| 4 | Descriptors | **Descriptor indexing / partially‑bound** (bindless‑lite) for textures; per‑frame descriptor pools | Scales for many models/textures; simplifies material binding |
+| 5 | 64‑bit point‑cloud atomics | `VK_KHR_shader_atomic_int64` + `shaderBufferInt64Atomics` (core 1.2), SPIR‑V `Int64Atomics`, GLSL `GL_EXT_shader_atomic_int64` | Direct 1:1 map of the existing rasterizer; verify device support at startup, feature‑gate |
+| 6 | Frames in flight | **2**, timeline semaphores, per‑frame command pool + descriptor pool | Standard double‑buffering |
+| 7 | Quad‑buffer stereo | **Hardest problem.** Use `VK_KHR_display` stereo present *or* NVIDIA `VK_KHR_swapchain` `imageArrayLayers=2` where supported; fall back to two swapchains / side‑by‑side. Abstract behind a `StereoTarget` so callers stay unaware | Desktop quad‑buffer stereo is vendor‑specific; must be isolated early as a spike |
+| 8 | XR | OpenXR with `XR_USE_GRAPHICS_API_VULKAN`, Vulkan swapchain images as `VkImage` | Required; rework `XRSession` |
+| 9 | ImGui | `imgui_impl_vulkan` (+ existing glfw backend) | Official, supports multi‑viewport |
+| 10 | Windowing | Keep **GLFW** (no GL context: `GLFW_NO_API`), create `VkSurfaceKHR` | Minimal disruption to input/callbacks |
+| 11 | Build | Add Vulkan SDK, VMA, shaderc to `dependencies/`; wire into `.vcxproj`; SPIR‑V build step | Windows/MSVC only, matches project |
+| 12 | Validation | Validation layers + `VK_EXT_debug_utils` in Debug builds | Non‑negotiable for a port of this size |
+
+---
+
+## 4. Target Architecture
+
+### 4.1 Layering (new)
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Application            App lifecycle, main loop, wiring        │  <- replaces main.cpp
+├──────────────────────────────────────────────────────────────┤
+│ Systems         SceneRenderer · PointCloudSystem · CursorSys   │
+│                 · ToolSystem · PluginHost · GuiSystem · XR      │
+├──────────────────────────────────────────────────────────────┤
+│ Renderer        FrameGraph‑lite · passes (shadow, forward,     │
+│                 pointcloud, overlay, tonemap) · StereoTarget    │
+├──────────────────────────────────────────────────────────────┤
+│ RHI (Vulkan)    Device · Swapchain · Buffer · Image · Pipeline │  <- ONLY layer that
+│                 · DescriptorSet · CommandContext · Shader(SPIR‑V)│     touches Vulkan
+├──────────────────────────────────────────────────────────────┤
+│ Platform        Window (GLFW, no API) · Input · Clock          │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Rule: **nothing above the RHI includes `<vulkan.h>`.** Systems speak in RHI
+handles (`rhi::Buffer`, `rhi::Texture`, `rhi::Pipeline`, `rhi::CommandContext`).
+
+### 4.2 Proposed source layout
+```
+src/
+  App/            Application.cpp, main.cpp (thin: build App, run)
+  Platform/       Window, Input, Clock            (moved from Engine)
+  RHI/            Device, Swapchain, Buffer, Image, Pipeline,
+                  DescriptorAllocator, ShaderModule, CommandContext, Upload,
+                  vk_mem_alloc glue, debug utils
+  Renderer/       Renderer, FrameContext, StereoTarget, passes/*, MaterialSystem
+  Scene/          (existing Core/SceneManager, Undo, Snapshot — unchanged CPU)
+  PointCloud/     ComputePointCloudRenderer (Vulkan), streaming upload
+  Loaders/        Model + PointCloud parsers (unchanged) + Vulkan upload adapters
+  Cursors/ Tools/ Plugins/   (logic reused; draw paths reworked onto RHI overlay)
+  Gui/            GuiSystem (imgui_impl_vulkan), panels split out of GUI.cpp
+```
+`main.cpp` shrinks to a few dozen lines. The current global soup in `main.cpp`
+(sun, lights, shadow FBOs, BVH/DDGI buffers, plugin context…) is redistributed
+into owning systems.
+
+### 4.3 RHI surface (minimum viable)
+- `Device` (instance, physical/logical device, queues, VMA, feature detection).
+- `Swapchain` / `StereoTarget` (present, resize, per‑eye targets).
+- `Buffer`, `Image`/`Texture` (VMA‑backed; usage flags; staged uploads).
+- `Pipeline` (graphics + compute; created from SPIR‑V + a small descriptor
+  layout spec; dynamic rendering formats).
+- `DescriptorAllocator` (growable pools, per‑frame reset).
+- `CommandContext` (records a frame; `bindPipeline/bindDescriptors/draw/dispatch/
+  barrier/beginRendering`).
+- `ShaderCompiler` (GLSL→SPIR‑V via shaderc, with disk cache + hot reload in Debug).
+
+---
+
+## 5. Phased Migration Plan (ordered)
+
+Each phase should compile, run, and be visually verifiable before the next. The
+ordering front‑loads the risky spikes (bootstrap, stereo, int64 atomics).
+
+### Phase 0 — Setup & spikes (foundation)
+- New branch (this one). Add Vulkan SDK, **VMA**, **shaderc/glslang** to
+  `dependencies/`; update `.vcxproj`/`.filters`; add a SPIR‑V build step.
+- **Spike A:** headless device‑capability probe — confirm on the target GPU:
+  `shaderBufferInt64Atomics`, descriptor indexing, dynamic rendering, timeline
+  semaphores, and the **stereo present** path. Record results here.
+- **Spike B:** quad‑buffer stereo present proof‑of‑concept (clear left eye red /
+  right eye blue on the stereo display). This de‑risks the single scariest item.
+- Deliverable: `docs/VULKAN_MIGRATION.md` (this file) + capability report.
+
+### Phase 1 — Core bootstrap + new App skeleton
+- `Platform::Window` with `GLFW_NO_API` + `VkSurfaceKHR`; keep input callbacks.
+- RHI `Device` + `Swapchain`; frames‑in‑flight; command/descriptor pools.
+- `Application` class owning the loop (poll → update → render → present).
+- **Hello‑triangle** through the RHI + `ShaderCompiler`.
+- **ImGui on Vulkan** (`imgui_impl_vulkan`), docking + multi‑viewport, existing
+  style files preserved. GUI renders even before the scene does.
+- Exit criterion: window opens, ImGui panels dock/undock, triangle draws.
+
+### Phase 2 — RHI hardening
+- Finalise `Buffer`/`Texture` with staged uploads, `Pipeline` cache,
+  `DescriptorAllocator`, barriers/sync2, dynamic‑rendering render targets, HDR
+  offscreen color target + depth, and a **tonemap** resolve pass.
+- Port `Screenshot` readback (Vulkan copy‑to‑buffer instead of `glReadPixels`).
+
+### Phase 3 — Mesh/model forward rendering (Shadow‑Mapping mode only)
+- Vulkan upload for `Mesh` (vertex/index buffers) — reuse Assimp import as‑is.
+- Camera UBO; per‑object push constants / dynamic UBO; material via descriptor
+  indexing (albedo/normal/…); **forward PBR** pipeline (port
+  `fragmentShader.glsl` / `shadowMapping*` to Vulkan GLSL).
+- **Directional shadow map** + **point‑light depth cubemap** passes.
+- Skybox pass (equirect→cubemap or sample equirect directly).
+- Exit criterion: `office.scene` models render lit + shadowed, mono, matching GL.
+
+### Phase 4 — Loading system integration
+- Route all loaders (`ModelLoader`, `PointCloudLoader`) through RHI upload.
+- Keep parsers untouched; replace only `glGen*/glBufferData/glBufferSubData`
+  with `rhi::Buffer` + staging. Preserve the **progressive streaming** contract
+  (`PointCloudStream`, `updateStreaming()`), now filling `VkBuffer`s.
+
+### Phase 5 — Compute point‑cloud pipeline (largest rewrite)
+- Port the Schütz rasterizer to a **Vulkan compute pipeline**:
+  - `uint64_t` framebuffer SSBO via `VK_KHR_shader_atomic_int64` (gate on Spike A;
+    provide a documented fallback if a target GPU lacks it).
+  - Port `pointcloud_rasterize.comp` (explicit `set/binding`, push constants for
+    MVP/imageSize/cloudID/splat), the **HQS** depth/colour/resolve passes, the
+    per‑cloud colour‑lookup pass, and the fullscreen **resolve** writing depth.
+  - Barriers replace `glMemoryBarrier(GL_ALL_BARRIER_BITS)`; clear‑buffer via
+    `vkCmdFillBuffer`.
+  - Clip planes as push‑constant/UBO array.
+- Wire streaming buffers (Phase 4) into per‑batch SSBO bindings.
+- Exit criterion: dense LAS/LAZ cloud renders (standard + HQS) with clipping,
+  composited correctly against mesh depth.
+
+### Phase 6 — Camera, cursors, tools, plugins (overlays)
+- Camera: abstract the depth read (RHI) + clock; otherwise reuse verbatim.
+- Add an **overlay renderer** (dynamic vertex buffer + line/tri pipelines) to the
+  RHI‑backed `PluginContext` (replace `compileOverlayProgram`).
+- Port `SphereCursor`/`PlaneCursor`/`FragmentCursor` + `CursorPreview3D`
+  (render‑to‑texture for the GUI thumbnail).
+- Port `TransformGizmo`, `MeasurementTool`, `ClipPlaneTool`, `BrushTool`,
+  `CrosshairPlugin`, `MeasurementPlugin` onto the overlay renderer.
+- Exit criterion: cursors + all tools + gizmo behave as today.
+
+### Phase 7 — Stereo & XR
+- Implement `StereoTarget` for quad‑buffer stereo (from Spike B) and mono; make
+  `renderEye`'s successor a per‑view loop over the stereo target.
+- Rework `XRSession` to `XR_USE_GRAPHICS_API_VULKAN` (Vulkan swapchain images).
+- Exit criterion: quad‑buffer stereo display + OpenXR HMD both render.
+
+### Phase 8 — main.cpp decomposition & cleanup
+- Retire the last globals; move state into owning systems; delete GL scaffolding.
+- Split `GUI.cpp` panels into files under `Gui/panels/` (can start earlier,
+  finishes here).
+- Update `CLAUDE.md`, `README.md`, `docs/PLUGINS.md` for the Vulkan architecture.
+
+### Phase 9 (later, out of scope now) — re‑add deferred features natively
+- SSAO + Bloom as Vulkan compute passes.
+- Voxel Cone Tracing, DDGI, and Radiance via `VK_KHR_ray_query` / RT pipelines.
+
+---
+
+## 6. Reuse vs Rewrite (quick reference)
+
+| System | Verdict | Notes |
+|--------|---------|-------|
+| SceneManager / Undo / Snapshot / Shortcuts / SpaceMouse | **Reuse as‑is** | CPU/JSON only |
+| Model/PointCloud **parsers** | **Reuse** | Swap GPU upload only |
+| Camera | **Reuse** | Abstract 2 GL calls |
+| Cursors / Tools / Plugins **logic** | **Reuse logic, rewrite draw** | Onto overlay RHI |
+| `Engine::Shader` / `Buffers` | **Replace** | Become RHI `ShaderModule` / `Buffer` |
+| ComputePointCloudRenderer | **Rewrite** | Vulkan compute + int64 atomics |
+| BloomRenderer / SSAORenderer | **Defer**, then rewrite | Vulkan compute later |
+| Voxelizer / DDGIVolume / BVH / BVHDebug | **Defer**, then native Vulkan | RT/compute later |
+| Window / Input | **Rework** | GLFW no‑API + surface |
+| XRSession | **Rework** | Vulkan graphics binding |
+| GUI backend | **Replace** | imgui_impl_vulkan |
+| main.cpp | **Rewrite/decompose** | Into App + systems |
+
+---
+
+## 7. Risks & Mitigations
+- **Quad‑buffer stereo in Vulkan is vendor‑specific.** → Spike B in Phase 0;
+  isolate behind `StereoTarget`; keep side‑by‑side fallback.
+- **int64 atomics availability.** → Spike A gate; document fallback (e.g. 32‑bit
+  depth + separate index, or split‑atomic) before committing the rewrite.
+- **Scope creep from GI systems.** → Explicitly deferred; feature‑gate the
+  lighting‑mode UI so only Shadow Mapping is selectable in the first Vulkan build.
+- **Two huge files (`main.cpp`, `GUI.cpp`).** → Decompose incrementally, not in
+  one commit; land the new `Application` skeleton early (Phase 1) and migrate
+  behaviour into it phase by phase.
+- **Regression risk (no test suite).** → Keep a manual verification checklist per
+  phase (screenshots of `office.scene`, a reference LAS cloud, each tool).
+
+---
+
+## 8. Tooling / dependencies to add
+- Vulkan SDK (headers, `vulkan-1.lib`, validation layers).
+- **VMA** (`vk_mem_alloc.h`) — vendored in `headers/libs/`.
+- **shaderc** (or glslang) for GLSL→SPIR‑V, plus an offline SPIR‑V build step.
+- OpenXR already vendored (`dependencies/include/openxr`) — reuse loader,
+  switch graphics binding.
+- `.vcxproj` / `.filters`: add new folders, SPIR‑V custom build, link changes
+  (`vulkan-1.lib`, shaderc); drop `opengl32.lib`/GLAD once GL is fully removed.
+
+---
+
+## 9. Immediate next steps
+1. Land this plan (done).
+2. Phase 0 Spike A (capability probe) + Spike B (stereo present PoC) — these two
+   decide items #5 and #7 above and unblock everything else.
+3. Stand up the `Application` + RHI `Device`/`Swapchain` + ImGui‑Vulkan
+   hello‑triangle (Phase 1).
+</content>
+</invoke>

--- a/docs/VULKAN_MIGRATION.md
+++ b/docs/VULKAN_MIGRATION.md
@@ -1,8 +1,12 @@
-# StereoVista — OpenGL → Vulkan Migration Plan
+# StereoVista — OpenGL → Vulkan Migration Plan (design & rationale)
 
 > Status: **planning**. Branch: `claude/opengl-vulkan-migration-yqc277`.
-> This document is the source of truth for the migration. It is intentionally
-> detailed so the work can be picked up in independent phases.
+> This document holds the **design rationale** (RHI layering, decisions,
+> per-system reuse/rewrite table). For **live progress** — what's done, what's
+> next, and the session log — see **`docs/VULKAN_MIGRATION_STATUS.md`**, which is
+> the file every new session should read first. This plan is intentionally
+> detailed but **not binding**: if a better approach emerges, take it and record
+> the change in the status file.
 
 ---
 

--- a/docs/VULKAN_MIGRATION.md
+++ b/docs/VULKAN_MIGRATION.md
@@ -151,6 +151,32 @@ logic.
 
 ---
 
+## 2.12 Dependency / library disposition (OpenGL‑specific vs. keep)
+
+Not every dependency is OpenGL‑specific. Some are **removed**, some are **kept**,
+some are **kept but reconfigured**. Verify against `StereoVista.vcxproj` before
+touching — current state confirmed 2026‑07‑02.
+
+| Dependency | Role | Disposition |
+|---|---|---|
+| **GLAD** (`headers/libs/glad.c`, `dependencies/include/glad`, `KHR/khrplatform.h`) | GL function loader | **REMOVE.** Replace with a Vulkan loader — **volk** (recommended) or the SDK static loader. Delete glad.c + glad/KHR headers and the `<ClCompile Include="…glad.c">`. |
+| **`opengl32.lib`** | GL lib | **REMOVE** from `<AdditionalDependencies>` (both Debug+Release). |
+| **ImGui GL3 backend** (`imgui_impl_opengl3.*`) | GUI render backend | **REMOVE.** Replace with `imgui_impl_vulkan`. **Keep** `imgui_impl_glfw`. |
+| **`Engine::Shader`** (runtime `glCompileShader` of GLSL) | shader compile | **REPLACE.** Compile GLSL→SPIR‑V (shaderc) into an RHI `ShaderModule`; GLSL sources gain explicit `layout(set,binding)` + push constants. |
+| **GLFW** (`glfw3.lib` / `glfw3_mt.lib`) | windowing + input | **KEEP** — API‑agnostic. Init with `GLFW_NO_API`, create the surface via `glfwCreateWindowSurface`. **Drop** the ~24 GL‑context calls: `GLFW_CONTEXT_VERSION_*`, `GLFW_OPENGL_PROFILE`, **`GLFW_STEREO`** (Vulkan stereo is a swapchain property, not a pixel format), `glfwMakeContextCurrent`, `glfwSwapBuffers` (→ `vkQueuePresentKHR`), `glfwSwapInterval` (→ present mode), `glfwGetProcAddress` for GL. |
+| **GLM** | math | **KEEP but reconfigure.** Vulkan clip space differs from GL: **define `GLM_FORCE_DEPTH_ZERO_TO_ONE`** (Vulkan depth is `[0,1]`, not `[-1,1]`) and handle the **inverted Y** (negate `proj[1][1]` or flip the viewport). Audit *every* projection matrix (main, shadow, point‑cloud, cursors, XR). **Not currently set — this is a real correctness item, not cosmetic.** |
+| **OpenXR loader** (`openxr_loader.lib`) | VR | **KEEP loader; SWAP graphics binding.** GL → Vulkan: `XR_USE_GRAPHICS_API_VULKAN`, `XR_KHR_vulkan_enable2`, swapchain images as `VkImage`. |
+| Assimp, LASzip, HDF5+HighFive, stb_image, TDxNavLib, nlohmann/json, portable‑file‑dialogs | loaders / input / util | **KEEP** — all graphics‑API‑agnostic. Only the *GPU upload* side of the loaders changes (Phase 4). |
+
+**New dependencies to add** (self‑integrate per §7b): Vulkan SDK, **VMA**,
+**shaderc/glslang**, and optionally **volk**, **vk‑bootstrap**, **SPIRV‑Reflect**.
+
+**Sequencing caveat:** the moment the window is created with `GLFW_NO_API` there
+is **no GL context**, so any still‑live GL call crashes. GL‑dependent systems must
+be **ported or temporarily stubbed** as the context switches — you can't run the
+old `renderEye` GL path and the new Vulkan path against the same window. Keep old
+GL files compiling only until their system is ported, then delete them.
+
 ## 3. Key Vulkan Decisions (resolve these before coding)
 
 | # | Topic | Recommendation | Why |
@@ -167,6 +193,8 @@ logic.
 | 10 | Windowing | Keep **GLFW** (no GL context: `GLFW_NO_API`), create `VkSurfaceKHR` | Minimal disruption to input/callbacks |
 | 11 | Build | Add Vulkan SDK, VMA, shaderc to `dependencies/`; wire into `.vcxproj`; SPIR‑V build step | Windows/MSVC only, matches project |
 | 12 | Validation | Validation layers + `VK_EXT_debug_utils` in Debug builds | Non‑negotiable for a port of this size |
+| 13 | GLM clip space | `GLM_FORCE_DEPTH_ZERO_TO_ONE` globally + handle inverted‑Y (flip `proj[1][1]` or viewport) | Vulkan NDC ≠ GL NDC; without this, depth test + culling are wrong everywhere. Not currently set |
+| 14 | Vulkan loader | **volk** (or SDK static loader) replacing GLAD | Faster dispatch, per‑device function pointers; removes the last GL loader |
 
 ---
 

--- a/docs/VULKAN_MIGRATION.md
+++ b/docs/VULKAN_MIGRATION.md
@@ -349,6 +349,32 @@ ordering front‑loads the risky spikes (bootstrap, stereo, int64 atomics).
 
 ---
 
+## 7b. Using & integrating third‑party libraries
+Prefer a well‑maintained library over reinventing it whenever it **greatly
+simplifies or optimizes** the work. Strong candidates for this migration:
+- **VMA** (`vk_mem_alloc.h`) — memory allocation. *(planned)*
+- **shaderc** / **glslang** — GLSL→SPIR‑V. *(planned)*
+- **volk** — dynamic Vulkan function loader (fast, avoids linking the static
+  loader for everything). *(consider)*
+- **vk‑bootstrap** — instance/physical‑device/device/swapchain boilerplate.
+  *(consider — but keep the RHI thin; don't leak it above the RHI)*
+- **SPIRV‑Reflect** — reflect descriptor/push‑constant layouts from SPIR‑V so
+  pipeline layouts aren't hand‑maintained. *(consider)*
+
+**Integration is the agent's job — do it completely, no manual steps left for the
+user:**
+1. Download **all** required files (headers, `.lib`, `.dll`, LICENSE) into the
+   repo under the existing vendoring layout — third‑party headers in
+   `headers/libs/<name>/`, prebuilt binaries in `dependencies/include|lib|bin`.
+2. Wire into `StereoVista.vcxproj`(+`.filters`): additional include dirs, library
+   dirs, additional dependencies (per‑config Debug/Release), and a **post‑build
+   copy** for any runtime `.dll` (mirror the existing `assimp-vc143-mt.dll` /
+   `LASzip64.dll` copy steps).
+3. A fresh `git clone` must build **green on CI** with no external install beyond
+   the CI‑provided Vulkan SDK. Prefer header‑only libs where practical.
+4. Keep each library's LICENSE; avoid copyleft (GPL/LGPL) that would encumber the
+   app. Record every added library (name, version, why) in the status file §4.
+
 ## 8. Tooling / dependencies to add
 - Vulkan SDK (headers, `vulkan-1.lib`, validation layers).
 - **VMA** (`vk_mem_alloc.h`) — vendored in `headers/libs/`.

--- a/docs/VULKAN_MIGRATION_STATUS.md
+++ b/docs/VULKAN_MIGRATION_STATUS.md
@@ -11,10 +11,24 @@
 > 2. **Do NOT trust this file as ground truth about the code.** Before you touch
 >    a system, **read the actual source yourself** (files change; this file lags).
 >    Use it only for orientation and history.
-> 3. **Update this file when you finish work.** Move tasks between sections, note
+> 3. **This is a rewrite, not a translation. Make it BETTER — deeply optimized,
+>    idiomatic, native Vulkan.** Do **not** stale-copy-paste the OpenGL logic
+>    into Vulkan. If something can be done better the Vulkan way (single-pass
+>    multiview stereo, GPU-driven rendering, bindless descriptors, timeline
+>    semaphores, async compute, `vkCmdDrawIndirect`, dynamic rendering, proper
+>    barriers, VMA suballocation, etc.), **do it that way** — even if it means a
+>    large rewrite or changing the planned direction. The OpenGL code is the
+>    reference for *behaviour*, not for *how*.
+> 4. **If you are unsure about anything — Vulkan APIs, extension support, the best
+>    pattern, how the existing system behaves — DIG DEEPER: read more source, and
+>    use the Internet (official Vulkan spec/registry, Khronos samples, vendor
+>    docs).** Do not guess. If it is a product/architecture decision only the user
+>    can make (scope, trade-offs, priorities), **ask the user** with a concrete
+>    question rather than assuming.
+> 5. **Update this file when you finish work.** Move tasks between sections, note
 >    what you actually did, what changed vs. the plan, and what's next. Append a
 >    dated entry to the **Session Log**.
-> 4. The deep design rationale (RHI layering, decisions, per-system reuse/rewrite
+> 6. The deep design rationale (RHI layering, decisions, per-system reuse/rewrite
 >    table) lives in **`docs/VULKAN_MIGRATION.md`** — read it once for context.
 >
 > **Branch:** `claude/opengl-vulkan-migration-yqc277` — this *is* the Vulkan
@@ -69,13 +83,20 @@ Legend: ☐ not started · ◐ in progress · ☑ done · ✎ changed from origi
     `ComputePointCloudRenderer::init` which already checks the GL equivalents),
     descriptor indexing, dynamic rendering, timeline semaphores, and the stereo
     present path. Write results into §4 below.
-  - **Spike B (stereo):** clear left eye red / right eye blue on the real
-    quad-buffer stereo display via Vulkan. This is the single biggest unknown —
-    quad-buffer stereo is vendor-specific in Vulkan (no `GL_BACK_LEFT/RIGHT`).
-- **Exit:** both spikes pass or a documented fallback is chosen; SDK builds.
+  - **Spike B (stereo — validation, not a blocker):** confirm the target GPU's
+    Vulkan surface reports `maxImageArrayLayers >= 2`, then clear left eye red /
+    right eye blue on the real quad-buffer stereo display. Vulkan supports
+    quad-buffered stereo **natively**: create the swapchain with
+    `imageArrayLayers = 2` and the presentation engine maps layer 0/1 to
+    left/right eyes (no `GL_BACK_LEFT/RIGHT` hacks). Plan to render both eyes in
+    a **single pass** with `VK_KHR_multiview` — this is strictly better than the
+    OpenGL path, which runs `renderEye()` twice per frame. If the surface caps
+    stereo out, fall back to two swapchains / side-by-side.
+- **Exit:** both spikes pass (or a documented fallback chosen); SDK builds.
 - **Read:** `src/Engine/ComputePointCloudRenderer.cpp` (int64 check + shader ext
   lines), `src/main.cpp:3485-3535` (GLFW_STEREO creation + mono fallback),
-  `docs/VULKAN_MIGRATION.md §3`.
+  `docs/VULKAN_MIGRATION.md §3`. Vulkan stereo refs: spec `VkSwapchainCreateInfoKHR`
+  (`imageArrayLayers`) + `VK_KHR_multiview`.
 
 ### Phase 1 — Core bootstrap + `Application`  ☐
 - **Goal:** a window with Vulkan + ImGui drawing, and the new app skeleton.
@@ -157,11 +178,14 @@ Legend: ☐ not started · ◐ in progress · ☑ done · ✎ changed from origi
 
 ### Phase 7 — Stereo + XR  ☐
 - **Goal:** quad-buffer stereo display and OpenXR HMD both render.
-- **How:** implement `StereoTarget` (from Spike B) for quad-buffer + mono; the
-  per-view loop replaces `renderEye`'s twice-per-frame stereo calls (keep the
-  `g_sharedPassesDone` "view-independent passes once per frame" idea). Rework
+- **How:** implement `StereoTarget` (native Vulkan stereo swapchain,
+  `imageArrayLayers = 2`, from Spike B) plus mono. **Render both eyes in a single
+  pass with `VK_KHR_multiview`** (view index selects per-eye projection/view via
+  a UBO array) instead of porting `renderEye`'s twice-per-frame calls — the
+  "view-independent passes once per frame" idea (`g_sharedPassesDone`) becomes
+  unnecessary for the main pass since both views are drawn together. Rework
   `XRSession` to `XR_USE_GRAPHICS_API_VULKAN` (Vulkan swapchain `VkImage`s
-  instead of GL textures).
+  instead of GL textures); multiview also fits HMD stereo cleanly.
 - **Exit:** stereo display + HMD both correct.
 - **Read:** `src/Engine/XRSession.cpp`, `headers/Engine/XRSession.h`,
   `src/main.cpp:4680-5180` (eye-dispatch loop).
@@ -196,7 +220,9 @@ index buffer) **before** starting Phase 5.
 - Memory: **VMA**. — _confirm_
 - Shaders: GLSL → SPIR-V via **shaderc**, runtime + offline. — _confirm_
 - int64 atomics available on target GPU? **UNKNOWN — Spike A**
-- Quad-buffer stereo present path in Vulkan? **UNKNOWN — Spike B**
+- Quad-buffer stereo: **native in Vulkan** — swapchain `imageArrayLayers = 2`
+  (needs `maxImageArrayLayers >= 2`); render both eyes single-pass via
+  `VK_KHR_multiview`. Confirm surface caps on the target GPU in **Spike B**.
 - _(add device/driver names, extension support, benchmark notes here)_
 
 ---
@@ -216,6 +242,13 @@ Re-check after each phase; capture before/after screenshots:
 ---
 
 ## 6. Session log (append newest at top; keep entries short)
+- **2026-07-02 — planning (feedback pass).** Corrected the stereo approach:
+  Vulkan supports quad-buffered stereo **natively** (swapchain
+  `imageArrayLayers = 2` + single-pass `VK_KHR_multiview`) — better than GL's
+  twice-per-frame `renderEye`; downgraded Spike B from "biggest unknown" to a
+  caps validation (confirmed via Vulkan spec). Added the core philosophy to both
+  docs: **native/optimized rewrite, no stale copy-paste, dig deeper / use the
+  Internet when unsure, ask the user for product decisions.**
 - **2026-07-02 — planning.** Deep-read the OpenGL codebase; authored
   `docs/VULKAN_MIGRATION.md` (design/rationale) and this living status file.
   Confirmed: `renderEye()` (main.cpp:5335) is a ~600-line monolith to decompose

--- a/docs/VULKAN_MIGRATION_STATUS.md
+++ b/docs/VULKAN_MIGRATION_STATUS.md
@@ -227,6 +227,21 @@ index buffer) **before** starting Phase 5.
 
 ---
 
+## 4b. Continuous Integration
+- Workflow: `.github/workflows/ci-vulkan-migration.yml` runs on every push to this
+  branch (and PRs). It builds **Debug + Release x64** on `windows-latest` with the
+  **Vulkan SDK** pre-installed (`VULKAN_SDK` set; VMA component included), and does
+  **not** publish releases (that's `msbuild.yml`, main-only).
+- Compiler errors appear as **inline annotations** (MSVC problem matcher) and the
+  full MSBuild **text + `.binlog`** are uploaded as artifacts (even on failure) —
+  download them to see every error, or open the `.binlog` in the MSBuild
+  Structured Log Viewer.
+- **After pushing, check the CI result** — this repo has no local Windows build in
+  the agent environment, so CI is the primary signal that the code compiles.
+  Wire new Vulkan sources into `StereoVista.vcxproj` (+ include dir
+  `$(VULKAN_SDK)\Include`, lib `$(VULKAN_SDK)\Lib\vulkan-1.lib`) so CI exercises
+  them.
+
 ## 5. Verification checklist (no automated tests exist — verify manually)
 Re-check after each phase; capture before/after screenshots:
 - [ ] App launches, ImGui docks/undocks/drags-out
@@ -242,6 +257,11 @@ Re-check after each phase; capture before/after screenshots:
 ---
 
 ## 6. Session log (append newest at top; keep entries short)
+- **2026-07-02 — CI setup.** Added `.github/workflows/ci-vulkan-migration.yml`:
+  Debug+Release x64 compile-check on `windows-latest` with the Vulkan SDK
+  pre-installed, inline MSVC error annotations, and build logs (`.log`+`.binlog`)
+  uploaded as artifacts. No release publishing. CI is the primary build signal
+  since the agent environment can't compile the Windows/MSVC project.
 - **2026-07-02 — planning (feedback pass).** Corrected the stereo approach:
   Vulkan supports quad-buffered stereo **natively** (swapchain
   `imageArrayLayers = 2` + single-pass `VK_KHR_multiview`) — better than GL's

--- a/docs/VULKAN_MIGRATION_STATUS.md
+++ b/docs/VULKAN_MIGRATION_STATUS.md
@@ -1,0 +1,226 @@
+# StereoVista → Vulkan — LIVING MIGRATION STATUS
+
+> ## 🚦 READ ME FIRST (every new Claude session)
+> This file is the **shared memory** for the OpenGL→Vulkan migration, which runs
+> across many separate Claude Code sessions. Read it to understand *where we are*.
+>
+> **Golden rules:**
+> 1. **This file is a helper, not a contract.** The plan below is a best guess.
+>    If you find a better approach while working, **take it** — then record the
+>    change here.
+> 2. **Do NOT trust this file as ground truth about the code.** Before you touch
+>    a system, **read the actual source yourself** (files change; this file lags).
+>    Use it only for orientation and history.
+> 3. **Update this file when you finish work.** Move tasks between sections, note
+>    what you actually did, what changed vs. the plan, and what's next. Append a
+>    dated entry to the **Session Log**.
+> 4. The deep design rationale (RHI layering, decisions, per-system reuse/rewrite
+>    table) lives in **`docs/VULKAN_MIGRATION.md`** — read it once for context.
+>
+> **Branch:** `claude/opengl-vulkan-migration-yqc277` — this *is* the Vulkan
+> branch. All migration work lands here.
+
+---
+
+## 0. Current status at a glance
+
+| | |
+|---|---|
+| **Current phase** | Phase 0 — Setup & spikes (**not started**) |
+| **What builds** | Original OpenGL app (unchanged; MSVC/`StereoVista.sln`) |
+| **Vulkan code present** | None yet |
+| **Last updated** | 2026-07-02 — planning session |
+
+Legend: ☐ not started · ◐ in progress · ☑ done · ✎ changed from original plan
+
+---
+
+## 1. Phase board (suggested order — reorder if you have a better idea)
+
+- ☐ **Phase 0 — Setup & spikes** (de-risk the two scary unknowns)
+- ☐ **Phase 1 — Core Vulkan bootstrap + `Application` skeleton** (hello triangle + ImGui)
+- ☐ **Phase 2 — RHI hardening** (buffers/images/pipelines/descriptors, HDR target + tonemap)
+- ☐ **Phase 3 — Mesh forward PBR + shadow mapping** (Shadow-Mapping lighting only)
+- ☐ **Phase 4 — Loading system → RHI upload** (parsers reused; streaming preserved)
+- ☐ **Phase 5 — Compute point-cloud pipeline** (Schütz rasterizer + HQS; biggest rewrite)
+- ☐ **Phase 6 — Camera, cursors, tools, plugins** (overlay renderer)
+- ☐ **Phase 7 — Stereo (`StereoTarget`) + Vulkan OpenXR**
+- ☐ **Phase 8 — Decompose `main.cpp`/`GUI.cpp`, delete GL scaffolding, update docs**
+- ☐ **Phase 9 (later, out of current scope) — re-add deferred features natively**
+
+> **Deferred on purpose** (do NOT port yet — re-implemented later in native Vulkan):
+> Voxel Cone Tracing (`Voxalizer`, `voxelization/*`), DDGI (`DDGIVolume`, `ddgi*`),
+> BVH ray-traced Radiance + `BVHDebug`, and heavy post-FX (Bloom, SSAO). Keep the
+> `LightingMode` enum but ship only **Shadow Mapping** in the first Vulkan build;
+> grey out VCT/Radiance in the UI.
+
+---
+
+## 2. Per-phase detail (goal · how it could be done · exit · what to read)
+
+### Phase 0 — Setup & spikes  ☐
+- **Goal:** add tooling and settle the two decisions that gate everything.
+- **How:**
+  - Add to `dependencies/`: **Vulkan SDK**, **VMA** (`vk_mem_alloc.h`),
+    **shaderc/glslang**. Wire into `StereoVista.vcxproj`(+`.filters`), add a
+    SPIR-V build step, enable validation layers in Debug.
+  - **Spike A (capabilities):** probe the target GPU for
+    `shaderBufferInt64Atomics` (point-cloud rasterizer depends on it — see
+    `ComputePointCloudRenderer::init` which already checks the GL equivalents),
+    descriptor indexing, dynamic rendering, timeline semaphores, and the stereo
+    present path. Write results into §4 below.
+  - **Spike B (stereo):** clear left eye red / right eye blue on the real
+    quad-buffer stereo display via Vulkan. This is the single biggest unknown —
+    quad-buffer stereo is vendor-specific in Vulkan (no `GL_BACK_LEFT/RIGHT`).
+- **Exit:** both spikes pass or a documented fallback is chosen; SDK builds.
+- **Read:** `src/Engine/ComputePointCloudRenderer.cpp` (int64 check + shader ext
+  lines), `src/main.cpp:3485-3535` (GLFW_STEREO creation + mono fallback),
+  `docs/VULKAN_MIGRATION.md §3`.
+
+### Phase 1 — Core bootstrap + `Application`  ☐
+- **Goal:** a window with Vulkan + ImGui drawing, and the new app skeleton.
+- **How:** `Platform::Window` on GLFW with `GLFW_NO_API` + `VkSurfaceKHR` (keep
+  existing input callbacks). RHI `Device`+`Swapchain`, 2 frames-in-flight,
+  command/descriptor pools. `Application` class owns the loop
+  (poll→update→render→present). Hello-triangle through RHI + `ShaderCompiler`.
+  Swap ImGui backend to **`imgui_impl_vulkan`** (keep `imgui_impl_glfw`);
+  preserve project-local `imgui_style*.*`, `imgui_incl.h`, `IconsFontAwesome5.h`,
+  docking + multi-viewport.
+- **Exit:** window opens, ImGui panels dock/undock/drag-out, triangle renders.
+- **Read:** `src/Engine/Window.cpp`, `src/main.cpp:3485-3900` (init order),
+  `headers/libs/imgui/backends/*`, `headers/Gui/*`.
+
+### Phase 2 — RHI hardening  ☐
+- **Goal:** the abstraction the rest of the port builds on.
+- **How:** finalize `Buffer`/`Texture` (VMA + staged uploads), `Pipeline` (gfx +
+  compute from SPIR-V + descriptor-layout spec + dynamic-rendering formats),
+  growable `DescriptorAllocator`, sync2 barriers, HDR offscreen color+depth
+  target, minimal **tonemap** resolve. Port `Screenshot` readback to a Vulkan
+  copy-to-buffer (replaces `glReadPixels`).
+- **Exit:** clear→draw→tonemap→present works; screenshot saves.
+- **Read:** `src/Engine/Screenshot.cpp`, `src/Engine/Shader.cpp`,
+  `headers/Engine/Buffers.h`.
+
+### Phase 3 — Mesh forward PBR + shadow mapping  ☐
+- **Goal:** `office.scene` meshes render lit + shadowed (mono), matching GL.
+- **How:** Vulkan vertex/index upload for `Mesh` (reuse Assimp import as-is);
+  camera UBO; per-object push constants / dynamic UBO; materials via descriptor
+  indexing; port `core/fragmentShader.glsl` + `shadowMapping*` +
+  `simpleDepth*` + point-shadow (cubemap/`pointShadow*`) + skybox to Vulkan
+  GLSL. `renderEye()` (`main.cpp:5335`, a ~600-line monolith) becomes a
+  **pass-based renderer** (shadow pass → forward pass → skybox), not a straight
+  port.
+- **Exit:** lit + shadow-mapped models on screen, mono.
+- **Read:** `src/Loaders/ModelLoader.cpp`, `headers/Loaders/ModelLoader.h`,
+  `src/main.cpp:5335-5950` (renderEye body), `assets/shaders/core/*`.
+
+### Phase 4 — Loading system → RHI upload  ☐
+- **Goal:** all loaders push data through the RHI; nothing GL remains in loaders.
+- **How:** keep every parser (Assimp, LASzip, HDF5/HighFive, PLY, XYZ, `.pcb`)
+  untouched. Replace only `glGen*`/`glBufferData`/`glBufferSubData`/sparse
+  `glBufferStorage` with `rhi::Buffer` + staging. **Preserve the progressive
+  streaming contract**: `PointCloudStream` worker thread + `updateStreaming()`
+  filling pre-allocated buffers per frame (now `VkBuffer`s).
+- **Exit:** models + streamed clouds upload correctly (verified in Phase 5 draw).
+- **Read:** `src/Loaders/PointCloudLoader.cpp` (streaming ~L200-240, ~L2770-2910),
+  `headers/Engine/Data.h` (`PointCloud`, `ComputeBatch`),
+  `src/Engine/OctreePointCloudManager.cpp`.
+
+### Phase 5 — Compute point-cloud pipeline  ☐  ← **biggest rewrite**
+- **Goal:** dense LAS/LAZ clouds render (standard + HQS) with clipping,
+  composited against mesh depth.
+- **How:** port the Schütz software rasterizer to Vulkan compute:
+  `uint64_t` framebuffer SSBO + `atomicMin` via `VK_KHR_shader_atomic_int64`
+  (gate on Spike A); port `pointcloud_rasterize.comp`, HQS depth/colour/resolve,
+  `pointcloud_color_lookup.comp`, and the fullscreen resolve writing depth —
+  adding explicit `layout(set,binding)` + push constants. Replace
+  `glMemoryBarrier(GL_ALL_BARRIER_BITS)` with sync2 barriers and the SSBO clear
+  with `vkCmdFillBuffer`. Clip planes as a push-constant/UBO array.
+- **Exit:** standard + HQS render, clipping works, depth-correct vs meshes.
+- **Read:** `headers/Engine/ComputePointCloudRenderer.h` (full design in header),
+  `src/Engine/ComputePointCloudRenderer.cpp`, `assets/shaders/core/pointcloud_*`.
+
+### Phase 6 — Camera, cursors, tools, plugins  ☐
+- **Goal:** interaction parity (cursors, gizmo, all tools) on Vulkan overlays.
+- **How:** Camera reused almost verbatim — only abstract its 2 GL touch points
+  (`glReadPixels` depth read + `glfwGetTime`). Add an **overlay renderer**
+  (dynamic vertex buffer + line/tri pipelines) and expose it through
+  `PluginContext` (replace `compileOverlayProgram`). Note **two** current overlay
+  patterns to unify: cursors load GLSL files via `Engine::loadShader`; tools/
+  gizmo/plugins compile inline GLSL via `compileOverlayProgram`. Port
+  `SphereCursor`/`PlaneCursor`/`FragmentCursor` + `CursorPreview3D` (render-to-
+  texture thumbnail), then `TransformGizmo`, `MeasurementTool`, `ClipPlaneTool`,
+  `BrushTool`, `CrosshairPlugin`, `MeasurementPlugin`.
+- **Exit:** cursors + tools + gizmo behave as today.
+- **Read:** `headers/Core/Camera.h`, `src/Cursors/**`, `src/Tools/**`,
+  `headers/Plugins/PluginContext.h`, `docs/PLUGINS.md`.
+
+### Phase 7 — Stereo + XR  ☐
+- **Goal:** quad-buffer stereo display and OpenXR HMD both render.
+- **How:** implement `StereoTarget` (from Spike B) for quad-buffer + mono; the
+  per-view loop replaces `renderEye`'s twice-per-frame stereo calls (keep the
+  `g_sharedPassesDone` "view-independent passes once per frame" idea). Rework
+  `XRSession` to `XR_USE_GRAPHICS_API_VULKAN` (Vulkan swapchain `VkImage`s
+  instead of GL textures).
+- **Exit:** stereo display + HMD both correct.
+- **Read:** `src/Engine/XRSession.cpp`, `headers/Engine/XRSession.h`,
+  `src/main.cpp:4680-5180` (eye-dispatch loop).
+
+### Phase 8 — Decompose & cleanup  ☐
+- **Goal:** professional, expandable structure; no GL left.
+- **How:** retire globals in `main.cpp` into owning systems; split `GUI.cpp`
+  panels into `Gui/panels/*`; delete GL scaffolding, GLAD, `opengl32.lib`;
+  update `CLAUDE.md`, `README.md`, `docs/PLUGINS.md`. See target layout in
+  `docs/VULKAN_MIGRATION.md §4.2`.
+
+### Phase 9 — Re-add deferred features (LATER)  ☐
+SSAO + Bloom as Vulkan compute; VCT, DDGI, Radiance via `VK_KHR_ray_query` / RT
+pipelines. Out of scope until Phases 0–8 are solid.
+
+---
+
+## 3. Next up (start here)
+1. **Phase 0 / Spike A** — Vulkan device capability probe (esp. int64 atomics +
+   stereo present). Record findings in §4.
+2. **Phase 0 / Spike B** — quad-buffer stereo present proof-of-concept.
+3. Then **Phase 1** bootstrap.
+
+If Spike A shows the target GPU lacks `shaderBufferInt64Atomics`, decide and
+document a fallback for the point-cloud framebuffer (e.g. 32-bit depth + separate
+index buffer) **before** starting Phase 5.
+
+---
+
+## 4. Decisions & spike results (fill in as you learn)
+- Vulkan version: **1.3** (proposed). — _confirm_
+- Memory: **VMA**. — _confirm_
+- Shaders: GLSL → SPIR-V via **shaderc**, runtime + offline. — _confirm_
+- int64 atomics available on target GPU? **UNKNOWN — Spike A**
+- Quad-buffer stereo present path in Vulkan? **UNKNOWN — Spike B**
+- _(add device/driver names, extension support, benchmark notes here)_
+
+---
+
+## 5. Verification checklist (no automated tests exist — verify manually)
+Re-check after each phase; capture before/after screenshots:
+- [ ] App launches, ImGui docks/undocks/drags-out
+- [ ] `office.scene` models render lit + shadow-mapped
+- [ ] A reference LAS/LAZ cloud renders (standard **and** HQS), streams in
+- [ ] Clip planes affect meshes + clouds
+- [ ] 3D cursors + `CursorPreview3D` thumbnail
+- [ ] TransformGizmo, Measurement, ClipPlane, Brush tools + a plugin overlay
+- [ ] Camera orbit/pan/zoom-to-cursor, standard views
+- [ ] Quad-buffer stereo output; OpenXR HMD
+- [ ] Screenshot + scene save/load + undo
+
+---
+
+## 6. Session log (append newest at top; keep entries short)
+- **2026-07-02 — planning.** Deep-read the OpenGL codebase; authored
+  `docs/VULKAN_MIGRATION.md` (design/rationale) and this living status file.
+  Confirmed: `renderEye()` (main.cpp:5335) is a ~600-line monolith to decompose
+  into passes; overlays use two GLSL patterns (file-loaded cursors vs inline-
+  compiled tools/plugins); XR is bound to the GL/WGL context; int64-atomics
+  check already present in the compute PC renderer; GLFW quad-buffer stereo with
+  a mono fallback. No Vulkan code written yet. **Next:** Phase 0 spikes.
+</content>

--- a/docs/VULKAN_MIGRATION_STATUS.md
+++ b/docs/VULKAN_MIGRATION_STATUS.md
@@ -105,6 +105,8 @@ Legend: ☐ not started · ◐ in progress · ☑ done · ✎ changed from origi
     a **single pass** with `VK_KHR_multiview` — this is strictly better than the
     OpenGL path, which runs `renderEye()` twice per frame. If the surface caps
     stereo out, fall back to two swapchains / side-by-side.
+- **Spikes are throwaway/reference** — prove the approach, then fold the *lessons*
+  (not necessarily the code) into Phase 1. Don't over-build them.
 - **Exit:** both spikes pass (or a documented fallback chosen); SDK builds.
 - **Read:** `src/Engine/ComputePointCloudRenderer.cpp` (int64 check + shader ext
   lines), `src/main.cpp:3485-3535` (GLFW_STEREO creation + mono fallback),
@@ -144,7 +146,13 @@ Legend: ☐ not started · ◐ in progress · ☑ done · ✎ changed from origi
   GLSL. `renderEye()` (`main.cpp:5335`, a ~600-line monolith) becomes a
   **pass-based renderer** (shadow pass → forward pass → skybox), not a straight
   port.
-- **Exit:** lit + shadow-mapped models on screen, mono.
+- **⚠ Design for multiview NOW (so Phase 7 stereo is additive, not a rewrite):**
+  make the color/depth target a **layered** image and the camera UBO a
+  **per-view array** indexed by `gl_ViewIndex` (`VK_KHR_multiview`). Mono = 1
+  view/layer today; stereo just enables the 2nd view + a stereo swapchain later.
+  Don't bake a single view/projection into shaders or the pass. Also set
+  `GLM_FORCE_DEPTH_ZERO_TO_ONE` + fix inverted-Y on all projections here.
+- **Exit:** lit + shadow-mapped models on screen, mono (1-view).
 - **Read:** `src/Loaders/ModelLoader.cpp`, `headers/Loaders/ModelLoader.h`,
   `src/main.cpp:5335-5950` (renderEye body), `assets/shaders/core/*`.
 
@@ -288,6 +296,12 @@ Re-check after each phase; capture before/after screenshots:
 ---
 
 ## 6. Session log (append newest at top; keep entries short)
+- **2026-07-02 — order refinement (final planning pass).** Kept the phase order
+  (it's dependency-sound) but made the renderer **multiview-aware from Phase 3**
+  (layered target + per-view camera UBO array via `gl_ViewIndex`) so Phase 7
+  stereo is additive, not a rewrite; folded the GLM clip-space fix into Phase 3;
+  noted Phase 0 spikes are throwaway. Planning is considered complete — next
+  session starts Phase 0 implementation.
 - **2026-07-02 — dependency disposition.** Added an explicit GL-specific
   library swap/remove/keep matrix (new §2c here + `MIGRATION.md §2.12`). Verified
   against the .vcxproj: `opengl32.lib` linked (remove), GLAD vendored (remove →

--- a/docs/VULKAN_MIGRATION_STATUS.md
+++ b/docs/VULKAN_MIGRATION_STATUS.md
@@ -216,6 +216,24 @@ pipelines. Out of scope until Phases 0–8 are solid.
 
 ---
 
+## 2c. OpenGL-specific dependencies — swap / remove / keep
+The project links some **GL-specific** libraries that must go, keeps others, and
+keeps one that needs **reconfiguration**. Full matrix + rationale in
+`docs/VULKAN_MIGRATION.md §2.12`; the essentials:
+- **REMOVE:** GLAD (`headers/libs/glad.c` + glad/`KHR` headers), `opengl32.lib`,
+  ImGui `imgui_impl_opengl3.*`, and the runtime-GLSL `Engine::Shader`.
+- **REPLACE loader:** add **volk** (or SDK loader) in GLAD's place; shaders → SPIR-V (shaderc).
+- **KEEP (API-agnostic):** GLFW (init `GLFW_NO_API` + surface; drop the ~24
+  GL-context calls incl. `GLFW_STEREO`/`glfwSwapBuffers`), Assimp, LASzip,
+  HDF5/HighFive, stb_image, TDxNavLib, json, portable-file-dialogs.
+- **KEEP + RECONFIGURE:** **GLM** — Vulkan clip space differs from GL. Define
+  **`GLM_FORCE_DEPTH_ZERO_TO_ONE`** and fix the inverted Y on **every** projection
+  matrix. **Currently NOT set — real correctness bug if missed.**
+- **KEEP loader, SWAP binding:** OpenXR loader → `XR_USE_GRAPHICS_API_VULKAN`.
+- ⚠️ **Sequencing:** once the window is `GLFW_NO_API` there is no GL context —
+  any live GL call crashes. Port or stub GL systems as the context switches; don't
+  run old-GL and new-Vulkan paths on the same window.
+
 ## 3. Next up (start here)
 1. **Phase 0 / Spike A** — Vulkan device capability probe (esp. int64 atomics +
    stereo present). Record findings in §4.
@@ -270,6 +288,12 @@ Re-check after each phase; capture before/after screenshots:
 ---
 
 ## 6. Session log (append newest at top; keep entries short)
+- **2026-07-02 — dependency disposition.** Added an explicit GL-specific
+  library swap/remove/keep matrix (new §2c here + `MIGRATION.md §2.12`). Verified
+  against the .vcxproj: `opengl32.lib` linked (remove), GLAD vendored (remove →
+  volk), ImGui GL3 backend (→ vulkan), ~24 GL-context GLFW calls to drop. Flagged
+  the **GLM clip-space** issue: `GLM_FORCE_DEPTH_ZERO_TO_ONE` is NOT set and must
+  be, plus inverted-Y on all projections. Noted the no-GL-context sequencing trap.
 - **2026-07-02 — library policy.** Added guidance: prefer good libraries that
   greatly simplify/optimize (VMA, shaderc/glslang, volk, vk-bootstrap,
   SPIRV-Reflect); the agent must fully self-integrate them (download all headers/

--- a/docs/VULKAN_MIGRATION_STATUS.md
+++ b/docs/VULKAN_MIGRATION_STATUS.md
@@ -25,10 +25,23 @@
 >    docs).** Do not guess. If it is a product/architecture decision only the user
 >    can make (scope, trade-offs, priorities), **ask the user** with a concrete
 >    question rather than assuming.
-> 5. **Update this file when you finish work.** Move tasks between sections, note
+> 5. **Prefer good libraries over reinventing.** If a well-maintained library
+>    greatly simplifies or optimizes the work (e.g. **VMA** for allocation,
+>    **shaderc/glslang** for GLSL→SPIR-V, **volk** for a Vulkan loader,
+>    **vk-bootstrap** for instance/device setup, **SPIRV-Reflect** for descriptor
+>    reflection), **use it** instead of hand-rolling. When you do, **fully
+>    integrate it yourself**: download *every* required file (headers, `.lib`,
+>    `.dll`, license) into the repo under the existing vendoring layout
+>    (`headers/libs/…`, `dependencies/include|lib|bin`), wire it into
+>    `StereoVista.vcxproj`(+`.filters`) — include dirs, lib dirs, additional
+>    dependencies, and a post-build copy for any runtime `.dll` (mirror how
+>    `assimp-vc143-mt.dll` / `LASzip64.dll` are handled) — and confirm it builds
+>    **green on CI**. No "install this SDK manually" hand-waving: the checkout must
+>    build as-is. Keep licenses; avoid GPL. Note each added library in §4.
+> 6. **Update this file when you finish work.** Move tasks between sections, note
 >    what you actually did, what changed vs. the plan, and what's next. Append a
 >    dated entry to the **Session Log**.
-> 6. The deep design rationale (RHI layering, decisions, per-system reuse/rewrite
+> 7. The deep design rationale (RHI layering, decisions, per-system reuse/rewrite
 >    table) lives in **`docs/VULKAN_MIGRATION.md`** — read it once for context.
 >
 > **Branch:** `claude/opengl-vulkan-migration-yqc277` — this *is* the Vulkan
@@ -257,6 +270,11 @@ Re-check after each phase; capture before/after screenshots:
 ---
 
 ## 6. Session log (append newest at top; keep entries short)
+- **2026-07-02 — library policy.** Added guidance: prefer good libraries that
+  greatly simplify/optimize (VMA, shaderc/glslang, volk, vk-bootstrap,
+  SPIRV-Reflect); the agent must fully self-integrate them (download all headers/
+  .lib/.dll/license into the vendoring layout, wire into the .vcxproj incl.
+  post-build DLL copy, build green on CI — no manual install steps).
 - **2026-07-02 — CI setup.** Added `.github/workflows/ci-vulkan-migration.yml`:
   Debug+Release x64 compile-check on `windows-latest` with the Vulkan SDK
   pre-installed, inline MSVC error annotations, and build logs (`.log`+`.binlog`)


### PR DESCRIPTION
Deep inventory of existing OpenGL systems, per-system reuse/rewrite
verdict, a layered target architecture (RHI + systems, decomposed
main.cpp), and a phased migration order that front-loads the risky
spikes (Vulkan bootstrap, quad-buffer stereo, int64 point-cloud
atomics). GI/voxelization/heavy post-FX/ray tracing are explicitly
deferred for later native-Vulkan re-implementation.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Gdd8eHLSE7wdaWy3yaK9Ua